### PR TITLE
ci(pr): add parallel typecheck test build and readme badge (#5)

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,24 @@
+name: Setup Node and PNPM
+description: Install PNPM, Node 20 with cache, and workspace dependencies
+
+inputs:
+  pnpm-version:
+    description: PNPM version to install
+    required: false
+    default: "9.15.9"
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: 20
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,10 +67,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test with coverage
-        run: pnpm -r test -- --coverage
+        run: pnpm -r run --if-present test -- --coverage
 
       - name: Upload coverage artifact
-        if: success() || failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-reports
@@ -97,4 +97,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm -r build
+        run: pnpm -r run --if-present build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,19 +12,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Biome (CI mode)
         run: pnpm exec biome ci .
@@ -32,19 +22,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Typecheck
         run: pnpm -r typecheck
@@ -52,26 +32,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Test with coverage
         run: pnpm -r run --if-present test -- --coverage
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-reports
           path: |
@@ -82,19 +52,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Build
         run: pnpm -r run --if-present build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,3 +28,73 @@ jobs:
 
       - name: Biome (CI mode)
         run: pnpm exec biome ci .
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm -r typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Test with coverage
+        run: pnpm -r test -- --coverage
+
+      - name: Upload coverage artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            **/coverage/**
+            !**/coverage/**/node_modules/**
+          if-no-files-found: warn
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm -r build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Chifoumi Ranked
 
-[![PR workflow](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml/badge.svg)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml)
+[![PR workflow (develop)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml/badge.svg?branch=develop)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml?query=branch%3Adevelop)
+[![PR workflow (main)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml?query=branch%3Amain)
 
 Monorepo for the YNOV Chifoumi Ranked platform (setup sprint).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Chifoumi Ranked
+
+[![PR workflow](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml/badge.svg)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml)
+
+Monorepo for the YNOV Chifoumi Ranked platform (setup sprint).


### PR DESCRIPTION
Closes #5

## Summary

- Extend `.github/workflows/pr.yml` with parallel jobs `typecheck`, `test` (coverage + artifact), and `build`, alongside existing Biome `lint`.
- Pin third-party Actions to commit SHAs; factor PNPM/Node install into `.github/actions/setup-node-pnpm`.
- Add root `README.md` with CI badges for `develop` and `main`.

## Test plan

- [x] CI green on PR: `lint`, `typecheck`, `test`, `build`
- [x] `pnpm -r run --if-present test -- --coverage` and `pnpm -r run --if-present build` locally
- [ ] After merge: enable branch protection on `develop` / `main` requiring the four checks (US-005 AC2)

## Review feedback addressed

| Copilot comment | Fix |
|----------------|-----|
| `pnpm -r test` / `build` without scripts | `pnpm -r run --if-present` |
| Coverage upload `if: success() \|\| failure()` | `if: always()` |
| README badge default branch | Badges with `?branch=develop` and `?branch=main` |
| Floating action tags | Pinned SHAs + composite action |
| Duplicated setup steps | `.github/actions/setup-node-pnpm` |