### PR TITLE
fix(ci): resolve PR #56 CI failures and review feedback

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,10 +41,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+
+    env:
+      DATABASE_URL: postgresql://app:chifoumi_dev@localhost:5432/chifoumi
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Build database package
+        run: pnpm --filter @chifoumi/db build
 
       - name: Test with coverage
         run: pnpm -r run --if-present test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,8 +33,8 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - name: Generate Prisma Client
-        run: pnpm --filter @chifoumi/db generate
+      - name: Build database package
+        run: pnpm --filter @chifoumi/db build
 
       - name: Typecheck
         run: pnpm -r typecheck

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
 
       - name: Test with coverage
-        run: pnpm -r run --if-present test -- --coverage
+        run: pnpm -r run --if-present test
 
       - name: Upload coverage artifact
         if: always()

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@chifoumi/db": "workspace:*",
-    "@chifoumi/db": "workspace:*",
     "@nestjs/common": "^11.1.21",
     "@nestjs/core": "^11.1.21",
     "@nestjs/jwt": "11.0.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "test:e2e": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./jest-e2e.config.cjs"
   },
   "dependencies": {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -21,7 +21,8 @@ export class AuthService {
     password: string;
     displayName: string;
   }): Promise<AuthResult> {
-    const existing = await this.usersService.findByEmail(input.email);
+    const email = input.email.toLowerCase();
+    const existing = await this.usersService.findByEmail(email);
     if (existing) {
       throw new ConflictException("Unable to complete registration");
     }
@@ -30,7 +31,7 @@ export class AuthService {
 
     try {
       const user = await this.usersService.createUser({
-        email: input.email.toLowerCase(),
+        email,
         passwordHash,
         displayName: input.displayName,
       });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,10 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "paths": {
-      "@chifoumi/db": ["../../packages/db/src/index.ts"]
-    }
+    "moduleResolution": "NodeNext"
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
     "generate": "prisma generate",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@nestjs/common':
         specifier: ^11.1.21
         version: 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/config':
-        specifier: 4.0.0
-        version: 4.0.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(@nestjs/websockets@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -782,12 +779,6 @@ packages:
         optional: true
       class-validator:
         optional: true
-
-  '@nestjs/config@4.0.0':
-    resolution: {integrity: sha512-hyhUMtVwlT+tavtPNyekl8iP0QTU1U6awKrgdOSxhMhp3TQMltx7hz2yqGTcARp+19zWPfgJudyxthuD3lPp/Q==}
-    peerDependencies:
-      '@nestjs/common': ^10.0.0 || ^11.0.0
-      rxjs: ^7.1.0
 
   '@nestjs/core@11.1.21':
     resolution: {integrity: sha512-fqo0BHgny3MOuAL8GSfG3ZUKFVVBaBQD/0iyibnwTONT5vPexjQxJzu+945iloVvBDmrnAaRWxC1gqCDEs/AXQ==}
@@ -1599,14 +1590,6 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  dotenv-expand@12.0.1:
-    resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
-    engines: {node: '>=12'}
-
-  dotenv@16.4.7:
-    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
-    engines: {node: '>=12'}
-
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
@@ -2322,9 +2305,6 @@ packages:
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -3745,14 +3725,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/config@4.0.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
-    dependencies:
-      '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      dotenv: 16.4.7
-      dotenv-expand: 12.0.1
-      lodash: 4.17.21
-      rxjs: 7.8.2
-
   '@nestjs/core@11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(@nestjs/websockets@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -4570,12 +4542,6 @@ snapshots:
       wrappy: 1.0.2
 
   diff-sequences@29.6.3: {}
-
-  dotenv-expand@12.0.1:
-    dependencies:
-      dotenv: 16.4.7
-
-  dotenv@16.4.7: {}
 
   dotenv@17.4.2: {}
 
@@ -5493,8 +5459,6 @@ snapshots:
   lodash.memoize@4.1.2: {}
 
   lodash.once@4.1.1: {}
-
-  lodash@4.17.21: {}
 
   long@5.3.2: {}
 


### PR DESCRIPTION
## Summary
- Sync \pnpm-lock.yaml\ after removing unused \@nestjs/config\ and duplicate \@chifoumi/db\ entry (fixes frozen-lockfile install failure blocking all CI jobs)
- Point \@chifoumi/db\ package types to \dist/index.d.ts\ and build the db package before workspace typecheck in CI
- Remove broken \	sconfig\ path alias that pulled db source outside \pps/api\ rootDir
- Normalize email once in \AuthService.register()\ before lookup and insert (Copilot review on PR #56)

## Context
PR #56 merged with failing CI (lint, typecheck, test, build) due to an outdated lockfile. This follow-up PR addresses the merge-blocking issues and remaining valid review feedback.

## Test plan
- [x] \pnpm install --frozen-lockfile\
- [x] \pnpm --filter @chifoumi/db build && pnpm -r typecheck\
- [x] \pnpm --filter @chifoumi/api test -- --coverage\ (unit tests)
- [x] \pnpm -r run --if-present build\
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)