### PR TITLE
feat(api): implement US-010 GET /me profile endpoint

### DIFF
--- a/apps/api/jest-e2e.config.cjs
+++ b/apps/api/jest-e2e.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
   extensionsToTreatAsEsm: [".ts"],
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
-    "^@chifoumi/db$": "<rootDir>/../../packages/db/src/index.ts",
+    "^@chifoumi/db$": "@prisma/client",
   },
   testEnvironment: "node",
   rootDir: ".",
@@ -14,7 +14,7 @@ module.exports = {
       "ts-jest",
       {
         useESM: true,
-        tsconfig: "tsconfig.json",
+        tsconfig: "tsconfig.e2e.json",
       },
     ],
   },

--- a/apps/api/jest.config.cjs
+++ b/apps/api/jest.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
       "ts-jest",
       {
         useESM: true,
-        tsconfig: "tsconfig.json",
+        tsconfig: "tsconfig.spec.json",
       },
     ],
   },

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { config as dotenvConfig } from "dotenv";
 import "reflect-metadata";
@@ -8,7 +8,7 @@ import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module.js";
 import { resolveCorsOrigins } from "./cors.js";
 
-const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "../../..");
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 dotenvConfig({ path: resolve(repoRoot, ".env") });
 
 process.env.JWT_PRIVATE_KEY_PATH = resolve(

--- a/apps/api/src/me/me.controller.ts
+++ b/apps/api/src/me/me.controller.ts
@@ -1,14 +1,17 @@
 import { Controller, Get, Req, UseGuards } from "@nestjs/common";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
 import type { SafeUser } from "../users/users.service.js";
+import { type MeProfile, MeService } from "./me.service.js";
 
 type AuthenticatedRequest = { user: SafeUser };
 
 @Controller("me")
 export class MeController {
+  constructor(private readonly meService: MeService) {}
+
   @UseGuards(JwtAuthGuard)
   @Get()
-  getMe(@Req() req: AuthenticatedRequest): { user: SafeUser } {
-    return { user: req.user };
+  getMe(@Req() req: AuthenticatedRequest): Promise<MeProfile> {
+    return this.meService.getProfile(req.user.id);
   }
 }

--- a/apps/api/src/me/me.module.ts
+++ b/apps/api/src/me/me.module.ts
@@ -1,9 +1,12 @@
 import { Module } from "@nestjs/common";
 import { AuthModule } from "../auth/auth.module.js";
+import { PrismaModule } from "../prisma/prisma.module.js";
 import { MeController } from "./me.controller.js";
+import { MeService } from "./me.service.js";
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, PrismaModule],
   controllers: [MeController],
+  providers: [MeService],
 })
 export class MeModule {}

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { PrismaService } from "../prisma/prisma.service.js";
+
+export type MeProfile = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "player" | "admin";
+  rating: number;
+  gamesPlayed: number;
+  createdAt: Date;
+};
+
+@Injectable()
+export class MeService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getProfile(userId: string): Promise<MeProfile> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: { eloRating: true },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      role: user.role === "admin" ? "admin" : "player",
+      rating: user.eloRating?.rating ?? 1000,
+      gamesPlayed: user.eloRating?.gamesPlayed ?? 0,
+      createdAt: user.createdAt,
+    };
+  }
+}

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -1,4 +1,5 @@
-import { resolve } from "node:path";
+import { generateKeyPairSync } from "node:crypto";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { type INestApplication, ValidationPipe } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
@@ -7,9 +8,18 @@ import request from "supertest";
 import { AppModule } from "../src/app.module.js";
 import { PrismaService } from "../src/prisma/prisma.service.js";
 
-const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "../../..");
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 config({ path: resolve(repoRoot, ".env") });
 
+const jwtKeys = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+process.env.JWT_PRIVATE_KEY = jwtKeys.privateKey;
+process.env.JWT_PUBLIC_KEY = jwtKeys.publicKey;
+process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
 process.env.JWT_PRIVATE_KEY_PATH = resolve(
   repoRoot,
   process.env.JWT_PRIVATE_KEY_PATH ?? "infra/keys/jwt-private.pem",
@@ -77,10 +87,20 @@ describe("Auth (e2e)", () => {
 
     await request(app.getHttpServer()).get("/me").expect(401);
 
-    await request(app.getHttpServer())
+    const meRes = await request(app.getHttpServer())
       .get("/me")
       .set("Authorization", `Bearer ${access}`)
       .expect(200);
+
+    expect(meRes.body).toEqual({
+      id: expect.any(String),
+      email,
+      displayName: "player1",
+      role: "player",
+      rating: 1000,
+      gamesPlayed: 0,
+      createdAt: expect.any(String),
+    });
   });
 
   it("duplicate register → 409 with generic message", async () => {

--- a/apps/api/tsconfig.e2e.json
+++ b/apps/api/tsconfig.e2e.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../../packages/db/src/**/*.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,10 +3,11 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
+    "baseUrl": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "paths": {
-      "@chifoumi/db": ["../../packages/db/src/index.ts"]
+      "@chifoumi/db": ["../../node_modules/@prisma/client"]
     }
   },
   "include": ["src/**/*.ts"]

--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
+  "include": ["src/**/*.ts", "../../packages/db/src/**/*.ts"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@chifoumi/db",
   "version": "1.0.0",
+  "type": "module",
   "description": "",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary
- implement `MeService.getProfile(userId)` to return the authenticated user's full profile with ELO data
- update `GET /me` to return `{ id, email, displayName, role, rating, gamesPlayed, createdAt }`
- make API Jest/e2e TypeScript config compatible with the workspace db package
- make auth e2e tests self-contained for JWT keys and cover the `/me` response contract

## Validation
- `npx pnpm@9.15.9 -r typecheck`
- `npx pnpm@9.15.9 -r run --if-present test`
- `npx pnpm@9.15.9 -r run --if-present test:e2e`
- pre-commit hook: Biome + typecheck

Closes #10