### PR TITLE
feat(api): implement US-012 public user profile endpoint

### DIFF
--- a/apps/api/src/users/dto/public-profile.dto.ts
+++ b/apps/api/src/users/dto/public-profile.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class PublicProfileDto {
+  @ApiProperty({ format: "uuid" })
+  id!: string;
+
+  @ApiProperty()
+  displayName!: string;
+
+  @ApiProperty({ example: 1000 })
+  rating!: number;
+
+  @ApiProperty({ example: 0 })
+  gamesPlayed!: number;
+
+  @ApiProperty({ example: 0, description: "Wins divided by games played, rounded to 2 decimals." })
+  winRate!: number;
+
+  @ApiProperty({ format: "date-time" })
+  createdAt!: Date;
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Param, ParseUUIDPipe, UseGuards } from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
+import { SWAGGER_BEARER_AUTH } from "../swagger.js";
+import { PublicProfileDto } from "./dto/public-profile.dto.js";
+import { UsersService } from "./users.service.js";
+
+@ApiTags("users")
+@ApiBearerAuth(SWAGGER_BEARER_AUTH)
+@UseGuards(JwtAuthGuard)
+@Controller("users")
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get(":id/profile")
+  @ApiOperation({ summary: "Get another player's public profile" })
+  @ApiOkResponse({ description: "Public profile", type: PublicProfileDto })
+  @ApiUnauthorizedResponse({ description: "Missing or invalid access token" })
+  @ApiNotFoundResponse({ description: "USER_NOT_FOUND" })
+  getPublicProfile(@Param("id", new ParseUUIDPipe()) userId: string): Promise<PublicProfileDto> {
+    return this.usersService.getPublicProfile(userId);
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,7 +1,9 @@
 import { Module } from "@nestjs/common";
+import { UsersController } from "./users.controller.js";
 import { UsersService } from "./users.service.js";
 
 @Module({
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,6 +1,7 @@
 import { Prisma, type User, UserRole } from "@chifoumi/db";
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
+import type { PublicProfileDto } from "./dto/public-profile.dto.js";
 
 export type SafeUser = {
   id: string;
@@ -19,6 +20,29 @@ export class UsersService {
 
   findById(id: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { id } });
+  }
+
+  async getPublicProfile(userId: string): Promise<PublicProfileDto> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: { eloRating: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException({ error: "USER_NOT_FOUND" });
+    }
+
+    const gamesPlayed = user.eloRating?.gamesPlayed ?? 0;
+    const wins = gamesPlayed === 0 ? 0 : await this.countWins(userId);
+
+    return {
+      id: user.id,
+      displayName: user.displayName,
+      rating: user.eloRating?.rating ?? 1000,
+      gamesPlayed,
+      winRate: this.calculateWinRate(wins, gamesPlayed),
+      createdAt: user.createdAt,
+    };
   }
 
   async createUser(input: {
@@ -53,5 +77,37 @@ export class UsersService {
 
   isUniqueConstraintError(error: unknown): boolean {
     return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+  }
+
+  private calculateWinRate(wins: number, gamesPlayed: number): number {
+    if (gamesPlayed === 0) {
+      return 0;
+    }
+    return Math.round((wins / gamesPlayed) * 100) / 100;
+  }
+
+  private async countWins(userId: string): Promise<number> {
+    try {
+      const rows = await this.prisma.$queryRaw<Array<{ wins: number | bigint }>>`
+        SELECT COUNT(*)::int AS wins
+        FROM matches
+        WHERE winner_id = ${userId}::uuid
+      `;
+      return Number(rows[0]?.wins ?? 0);
+    } catch (error) {
+      if (this.isUndefinedTableError(error)) {
+        return 0;
+      }
+      throw error;
+    }
+  }
+
+  private isUndefinedTableError(error: unknown): boolean {
+    return (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2010" &&
+      typeof error.meta?.code === "string" &&
+      error.meta.code === "42P01"
+    );
   }
 }

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -101,6 +101,32 @@ describe("Auth (e2e)", () => {
       gamesPlayed: 0,
       createdAt: expect.any(String),
     });
+
+    const publicProfileRes = await request(app.getHttpServer())
+      .get(`/users/${registerRes.body.user.id}/profile`)
+      .set("Authorization", `Bearer ${access}`)
+      .expect(200);
+
+    expect(publicProfileRes.body).toEqual({
+      id: registerRes.body.user.id,
+      displayName: "player1",
+      rating: 1000,
+      gamesPlayed: 0,
+      winRate: 0,
+      createdAt: expect.any(String),
+    });
+    expect(publicProfileRes.body.email).toBeUndefined();
+
+    await request(app.getHttpServer())
+      .get(`/users/${registerRes.body.user.id}/profile`)
+      .expect(401);
+
+    const missingProfileRes = await request(app.getHttpServer())
+      .get("/users/00000000-0000-4000-8000-000000000000/profile")
+      .set("Authorization", `Bearer ${access}`)
+      .expect(404);
+
+    expect(missingProfileRes.body).toEqual({ error: "USER_NOT_FOUND" });
   });
 
   it("duplicate register → 409 with generic message", async () => {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,6 +13,46 @@
         "tags": ["Health"]
       }
     },
+    "/users/{id}/profile": {
+      "get": {
+        "operationId": "UsersController_getPublicProfile",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicProfileDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid access token"
+          },
+          "404": {
+            "description": "USER_NOT_FOUND"
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Get another player's public profile",
+        "tags": ["users"]
+      }
+    },
     "/auth/register": {
       "post": {
         "operationId": "AuthController_register",
@@ -128,6 +168,36 @@
       }
     },
     "schemas": {
+      "PublicProfileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "number",
+            "example": 1000
+          },
+          "gamesPlayed": {
+            "type": "number",
+            "example": 0
+          },
+          "winRate": {
+            "type": "number",
+            "example": 0,
+            "description": "Wins divided by games played, rounded to 2 decimals."
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": ["id", "displayName", "rating", "gamesPlayed", "winRate", "createdAt"]
+      },
       "RegisterDto": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- add authenticated `GET /users/:id/profile` endpoint for public player profiles
- return explicit public payload without private fields: `{ id, displayName, rating, gamesPlayed, winRate, createdAt }`
- return `404 { error: "USER_NOT_FOUND" }` for unknown users
- add Swagger DTO/controller docs and regenerate `docs/openapi.json`
- extend e2e coverage for success, auth required, not found, and no email leak

## Validation
- `DATABASE_URL=... npx pnpm@9.15.9 -r typecheck`
- `npx pnpm@9.15.9 -r run --if-present test`
- `npx pnpm@9.15.9 -r run --if-present test:e2e`
- pre-commit hook: Biome + typecheck

Closes #12