### PR TITLE
US-14 - Logout avec blacklist JWT

### DIFF
--- a/apps/api/jest-e2e.config.cjs
+++ b/apps/api/jest-e2e.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
     "^@chifoumi/db$": "@prisma/client",
   },
   testEnvironment: "node",
+  maxWorkers: 1,
   rootDir: ".",
   testRegex: "test/.*\\.e2e-spec\\.ts$",
   transform: {

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,18 +1,30 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from "@nestjs/common";
+import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@nestjs/common";
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
+import { SWAGGER_BEARER_AUTH } from "../swagger.js";
+import type { SafeUser } from "../users/users.service.js";
 import { AuthService } from "./auth.service.js";
 import { AuthResponseDto } from "./dto/auth-response.dto.js";
 import { LoginDto } from "./dto/login.dto.js";
 import { RegisterDto } from "./dto/register.dto.js";
+import { JwtAuthGuard } from "./guards/jwt-auth.guard.js";
+
+type AuthenticatedRequest = {
+  user: SafeUser & {
+    tokenJti: string;
+    tokenExpiresAt: Date;
+  };
+};
 
 @ApiTags("auth")
 @Throttle({ auth: { limit: 5, ttl: 60_000 } })
@@ -38,5 +50,20 @@ export class AuthController {
   @ApiUnauthorizedResponse({ description: "Invalid credentials" })
   async login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
+  }
+
+  @Post("logout")
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth(SWAGGER_BEARER_AUTH)
+  @ApiOperation({ summary: "Logout and revoke the current access token" })
+  @ApiNoContentResponse({ description: "Access token blacklisted and refresh tokens revoked" })
+  @ApiUnauthorizedResponse({ description: "Missing, invalid, expired or revoked access token" })
+  async logout(@Req() req: AuthenticatedRequest): Promise<void> {
+    await this.authService.logout({
+      userId: req.user.id,
+      jti: req.user.tokenJti,
+      expiresAt: req.user.tokenExpiresAt,
+    });
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { JWT_CONFIG, type JwtConfig } from "../config/jwt.config.js";
+import { RedisModule } from "../redis/redis.module.js";
 import { UsersModule } from "../users/users.module.js";
 import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
@@ -13,6 +14,7 @@ import { TokenService } from "./token.service.js";
 @Module({
   imports: [
     UsersModule,
+    RedisModule,
     PassportModule.register({ defaultStrategy: "jwt" }),
     JwtModule.registerAsync({
       inject: [JWT_CONFIG],

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -2,13 +2,19 @@ import { jest } from "@jest/globals";
 import { ConflictException, UnauthorizedException } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { PrismaService } from "../prisma/prisma.service.js";
+import { RedisService } from "../redis/redis.service.js";
 import { UsersService } from "../users/users.service.js";
 import { AuthService } from "./auth.service.js";
 import { PasswordService } from "./password.service.js";
 import { TokenService } from "./token.service.js";
 
 describe("AuthService", () => {
-  const prisma = { refreshToken: { create: jest.fn<PrismaService["refreshToken"]["create"]>() } };
+  const prisma = {
+    refreshToken: {
+      create: jest.fn<PrismaService["refreshToken"]["create"]>(),
+      updateMany: jest.fn<PrismaService["refreshToken"]["updateMany"]>(),
+    },
+  };
   const usersService = {
     findByEmail: jest.fn<UsersService["findByEmail"]>(),
     createUser: jest.fn<UsersService["createUser"]>(),
@@ -24,6 +30,9 @@ describe("AuthService", () => {
     issueRefreshToken: jest.fn<TokenService["issueRefreshToken"]>(),
     getRefreshExpiresAt: jest.fn<TokenService["getRefreshExpiresAt"]>(),
   };
+  const redisService = {
+    revokeAccessToken: jest.fn<RedisService["revokeAccessToken"]>(),
+  };
   let authService: AuthService;
 
   beforeEach(async () => {
@@ -36,6 +45,7 @@ describe("AuthService", () => {
         { provide: UsersService, useValue: usersService },
         { provide: PasswordService, useValue: passwordService },
         { provide: TokenService, useValue: tokenService },
+        { provide: RedisService, useValue: redisService },
       ],
     }).compile();
     authService = moduleRef.get(AuthService);
@@ -114,5 +124,42 @@ describe("AuthService", () => {
     await expect(authService.login({ email: "a@b.com", password: "wrong" })).rejects.toBeInstanceOf(
       UnauthorizedException,
     );
+  });
+
+  it("logout blacklists access token and revokes active refresh tokens", async () => {
+    redisService.revokeAccessToken.mockResolvedValue();
+    prisma.refreshToken.updateMany.mockResolvedValue({
+      count: 1,
+    } as Awaited<ReturnType<PrismaService["refreshToken"]["updateMany"]>>);
+
+    await authService.logout({
+      userId: "u1",
+      jti: "jti-1",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    expect(redisService.revokeAccessToken).toHaveBeenCalledWith("jti-1", expect.any(Number));
+    expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: "u1",
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("logout rejects already expired access tokens", async () => {
+    await expect(
+      authService.logout({
+        userId: "u1",
+        jti: "jti-1",
+        expiresAt: new Date(Date.now() - 1_000),
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+
+    expect(redisService.revokeAccessToken).not.toHaveBeenCalled();
+    expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
+import { RedisService } from "../redis/redis.service.js";
 import { type SafeUser, UsersService } from "../users/users.service.js";
 import { PasswordService } from "./password.service.js";
 import { TokenService } from "./token.service.js";
@@ -14,6 +15,7 @@ export class AuthService {
     private readonly passwordService: PasswordService,
     private readonly tokenService: TokenService,
     private readonly prisma: PrismaService,
+    private readonly redisService: RedisService,
   ) {}
 
   async register(input: {
@@ -54,6 +56,24 @@ export class AuthService {
       throw new UnauthorizedException("Invalid credentials");
     }
     return this.issueTokensForUser(user.id, user);
+  }
+
+  async logout(input: { userId: string; jti: string; expiresAt: Date }): Promise<void> {
+    const ttlSeconds = Math.ceil((input.expiresAt.getTime() - Date.now()) / 1000);
+    if (ttlSeconds <= 0) {
+      throw new UnauthorizedException();
+    }
+
+    await this.redisService.revokeAccessToken(input.jti, ttlSeconds);
+    await this.prisma.refreshToken.updateMany({
+      where: {
+        userId: input.userId,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
   }
 
   private async issueTokensForUser(

--- a/apps/api/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,62 @@
+import { generateKeyPairSync } from "node:crypto";
+import { jest } from "@jest/globals";
+import { ServiceUnavailableException, UnauthorizedException } from "@nestjs/common";
+import type { RedisService } from "../../redis/redis.service.js";
+import type { UsersService } from "../../users/users.service.js";
+import { JwtStrategy } from "./jwt.strategy.js";
+
+describe("JwtStrategy", () => {
+  const { publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+
+  const usersService = {
+    findById: jest.fn<UsersService["findById"]>(),
+    toSafeUser: jest.fn<UsersService["toSafeUser"]>(),
+  };
+  const redisService = {
+    isAccessTokenRevoked: jest.fn<RedisService["isAccessTokenRevoked"]>(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns service unavailable when Redis revocation check fails", async () => {
+    redisService.isAccessTokenRevoked.mockRejectedValue(new Error("redis down"));
+    const strategy = new JwtStrategy(
+      { publicKey, privateKey: "unused", accessTtlSeconds: 900, refreshTtlSeconds: 604800 },
+      usersService as unknown as UsersService,
+      redisService as unknown as RedisService,
+    );
+
+    await expect(
+      strategy.validate({
+        sub: "user-1",
+        role: "player",
+        jti: "jti-1",
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it("rejects revoked access tokens", async () => {
+    redisService.isAccessTokenRevoked.mockResolvedValue(true);
+    const strategy = new JwtStrategy(
+      { publicKey, privateKey: "unused", accessTtlSeconds: 900, refreshTtlSeconds: 604800 },
+      usersService as unknown as UsersService,
+      redisService as unknown as RedisService,
+    );
+
+    await expect(
+      strategy.validate({
+        sub: "user-1",
+        role: "player",
+        jti: "jti-1",
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+});

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -1,13 +1,20 @@
-import { Inject, Injectable, UnauthorizedException } from "@nestjs/common";
+import {
+  Inject,
+  Injectable,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
 import { JWT_CONFIG, type JwtConfig } from "../../config/jwt.config.js";
+import { RedisService } from "../../redis/redis.service.js";
 import { UsersService } from "../../users/users.service.js";
 
 export type JwtPayload = {
   sub: string;
   role: string;
   jti: string;
+  exp: number;
 };
 
 @Injectable()
@@ -15,6 +22,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     @Inject(JWT_CONFIG) jwtConfig: JwtConfig,
     private readonly usersService: UsersService,
+    private readonly redisService: RedisService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -25,10 +33,25 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
+    let revoked: boolean;
+    try {
+      revoked = await this.redisService.isAccessTokenRevoked(payload.jti);
+    } catch {
+      throw new ServiceUnavailableException("Authentication revocation store unavailable");
+    }
+
+    if (revoked) {
+      throw new UnauthorizedException();
+    }
+
     const user = await this.usersService.findById(payload.sub);
     if (!user) {
       throw new UnauthorizedException();
     }
-    return this.usersService.toSafeUser(user);
+    return {
+      ...this.usersService.toSafeUser(user),
+      tokenJti: payload.jti,
+      tokenExpiresAt: new Date(payload.exp * 1000),
+    };
   }
 }

--- a/apps/api/src/redis/redis.service.spec.ts
+++ b/apps/api/src/redis/redis.service.spec.ts
@@ -23,4 +23,11 @@ describe("RedisService", () => {
     expect(await client.get(`${LEADERBOARD_CACHE_KEY_PREFIX}20`)).toBeNull();
     expect(await client.get("other:key")).toBe("keep-me");
   });
+
+  it("blacklists and checks access tokens by jti", async () => {
+    await service.revokeAccessToken("jti-1", 60);
+
+    expect(await service.isAccessTokenRevoked("jti-1")).toBe(true);
+    expect(await service.isAccessTokenRevoked("jti-2")).toBe(false);
+  });
 });

--- a/apps/api/src/redis/redis.service.ts
+++ b/apps/api/src/redis/redis.service.ts
@@ -40,6 +40,15 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     await this.requireClient().setex(key, ttlSeconds, value);
   }
 
+  async revokeAccessToken(jti: string, ttlSeconds: number): Promise<void> {
+    await this.requireClient().set(`blacklist:jwt:${jti}`, "1", "EX", ttlSeconds);
+  }
+
+  async isAccessTokenRevoked(jti: string): Promise<boolean> {
+    const value = await this.requireClient().get(`blacklist:jwt:${jti}`);
+    return value === "1";
+  }
+
   async invalidateLeaderboardCache(): Promise<void> {
     const client = this.requireClient();
     const keys = await client.keys(`${LEADERBOARD_CACHE_KEY_PREFIX}*`);

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -20,6 +20,7 @@ const jwtKeys = generateKeyPairSync("rsa", {
 process.env.JWT_PRIVATE_KEY = jwtKeys.privateKey;
 process.env.JWT_PUBLIC_KEY = jwtKeys.publicKey;
 process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.JWT_PRIVATE_KEY_PATH = resolve(
   repoRoot,
   process.env.JWT_PRIVATE_KEY_PATH ?? "infra/keys/jwt-private.pem",
@@ -48,6 +49,9 @@ describe("Auth (e2e)", () => {
     );
     await app.init();
     prisma = app.get(PrismaService);
+    await prisma.eloHistory.deleteMany();
+    await prisma.round.deleteMany();
+    await prisma.match.deleteMany();
     await prisma.refreshToken.deleteMany();
     await prisma.eloRating.deleteMany();
     await prisma.user.deleteMany();
@@ -127,6 +131,29 @@ describe("Auth (e2e)", () => {
       .expect(404);
 
     expect(missingProfileRes.body).toEqual({ error: "USER_NOT_FOUND" });
+
+    await request(app.getHttpServer())
+      .post("/auth/logout")
+      .set("Authorization", `Bearer ${access}`)
+      .expect(204);
+
+    await request(app.getHttpServer())
+      .post("/auth/logout")
+      .set("Authorization", `Bearer ${access}`)
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .get("/me")
+      .set("Authorization", `Bearer ${access}`)
+      .expect(401);
+
+    const activeRefreshTokens = await prisma.refreshToken.count({
+      where: {
+        userId: registerRes.body.user.id,
+        revokedAt: null,
+      },
+    });
+    expect(activeRefreshTokens).toBe(0);
   });
 
   it("duplicate register → 409 with generic message", async () => {

--- a/apps/api/test/me-history.e2e-spec.ts
+++ b/apps/api/test/me-history.e2e-spec.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from "node:crypto";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, URL } from "node:url";
 import { MatchStatus } from "@chifoumi/db";
 import { type INestApplication, ValidationPipe } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
@@ -12,6 +12,16 @@ import { PrismaService } from "../src/prisma/prisma.service.js";
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "../../..");
 config({ path: resolve(repoRoot, ".env") });
 
+const jwtKeys = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+process.env.JWT_PRIVATE_KEY = jwtKeys.privateKey;
+process.env.JWT_PUBLIC_KEY = jwtKeys.publicKey;
+process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.JWT_PRIVATE_KEY_PATH = resolve(
   repoRoot,
   process.env.JWT_PRIVATE_KEY_PATH ?? "infra/keys/jwt-private.pem",
@@ -25,7 +35,7 @@ describe("GET /me/history (e2e)", () => {
   let app: INestApplication;
   let prisma: PrismaService;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -40,9 +50,7 @@ describe("GET /me/history (e2e)", () => {
     );
     await app.init();
     prisma = app.get(PrismaService);
-  });
 
-  beforeEach(async () => {
     await prisma.eloHistory.deleteMany();
     await prisma.round.deleteMany();
     await prisma.match.deleteMany();
@@ -51,7 +59,7 @@ describe("GET /me/history (e2e)", () => {
     await prisma.user.deleteMany();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     if (app) {
       await app.close();
     }
@@ -117,6 +125,10 @@ describe("GET /me/history (e2e)", () => {
     return matchId;
   }
 
+  it("requires authentication", async () => {
+    await request(app.getHttpServer()).get("/me/history").expect(401);
+  });
+
   it("returns empty history for a user without matches", async () => {
     const { access } = await registerAndLogin("solo");
 
@@ -126,6 +138,17 @@ describe("GET /me/history (e2e)", () => {
       .expect(200);
 
     expect(res.body).toEqual({ items: [], nextCursor: null });
+  });
+
+  it("rejects limit above 100", async () => {
+    const { access } = await registerAndLogin("limit");
+
+    const res = await request(app.getHttpServer())
+      .get("/me/history?limit=101")
+      .set("Authorization", `Bearer ${access}`)
+      .expect(400);
+
+    expect(res.body.message).toContain("limit must be ≤ 100");
   });
 
   it("paginates 50 matches with stable cursor pages", async () => {
@@ -185,20 +208,5 @@ describe("GET /me/history (e2e)", () => {
 
     expect(thirdPage.body.items).toHaveLength(10);
     expect(thirdPage.body.nextCursor).toBeNull();
-  });
-
-  it("rejects limit above 100", async () => {
-    const { access } = await registerAndLogin("limit");
-
-    const res = await request(app.getHttpServer())
-      .get("/me/history?limit=101")
-      .set("Authorization", `Bearer ${access}`)
-      .expect(400);
-
-    expect(res.body.message).toContain("limit must be ≤ 100");
-  });
-
-  it("requires authentication", async () => {
-    await request(app.getHttpServer()).get("/me/history").expect(401);
   });
 });

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -125,6 +125,27 @@
         "tags": ["auth"]
       }
     },
+    "/auth/logout": {
+      "post": {
+        "operationId": "AuthController_logout",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "Access token blacklisted and refresh tokens revoked"
+          },
+          "401": {
+            "description": "Missing, invalid, expired or revoked access token"
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Logout and revoke the current access token",
+        "tags": ["auth"]
+      }
+    },
     "/me": {
       "get": {
         "operationId": "MeController_getMe",


### PR DESCRIPTION
## Résumé

- Ajoute `POST /auth/logout` côté API.
- Blacklist le JWT courant dans Redis via `blacklist:jwt:{jti}` avec le TTL restant.
- Révoque les refresh tokens actifs de l'utilisateur lors du logout.
- Refuse les access tokens déjà blacklistés dans la stratégie JWT.
- Met à jour la documentation OpenAPI et stabilise les tests e2e avec une base partagée.

## Validation

- `npx pnpm@9.15.9 exec biome check --write ...`
- `npx pnpm@9.15.9 -r typecheck`
- `npx pnpm@9.15.9 -r run --if-present test`
- `npx pnpm@9.15.9 -r run --if-present test:e2e`
- Hook pre-commit : `biome` + `typecheck`
