### PR TITLE
US-16 - Document Swagger API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ JWT_PRIVATE_KEY_PATH=infra/keys/jwt-private.pem
 JWT_PUBLIC_KEY_PATH=infra/keys/jwt-public.pem
 JWT_ACCESS_TTL_SECONDS=900
 JWT_REFRESH_TTL_SECONDS=604800
+
+# Swagger UI protection in production. Without both values in production, docs are disabled.
+SWAGGER_USER=docs
+SWAGGER_PASSWORD=change-me

--- a/README.md
+++ b/README.md
@@ -100,9 +100,13 @@ pnpm --filter @chifoumi/front dev
 | Front | `http://localhost:5173` | disponible |
 | API health | `http://localhost:3000/health` | disponible |
 | Game service health | `http://localhost:3001/health` | disponible |
-| Swagger | `http://localhost:3000/api/docs` | prevu par US-008 |
+| Swagger | `http://localhost:3000/api/docs` | disponible |
+| OpenAPI JSON | `http://localhost:3000/api/docs-json` | disponible |
 | MailHog | `http://localhost:8025` | disponible apres `docker compose up -d` |
 | Grafana | `http://localhost:3002` | prevu avec la stack observabilite |
+
+En production, la documentation Swagger est protegee par Basic Auth via `SWAGGER_USER` et `SWAGGER_PASSWORD`.
+Sans ces deux variables en production, les routes `/api/docs` et `/api/docs-json` ne sont pas exposees.
 
 ## Contributing
 

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@n
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiBody,
   ApiConflictResponse,
   ApiCreatedResponse,
   ApiNoContentResponse,
@@ -34,20 +35,83 @@ export class AuthController {
 
   @Post("register")
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: "Register a new player account" })
-  @ApiCreatedResponse({ description: "Account created", type: AuthResponseDto })
-  @ApiBadRequestResponse({ description: "Validation error" })
-  @ApiConflictResponse({ description: "Unable to complete registration" })
+  @ApiOperation({
+    summary: "Register a new player account",
+    description: "Creates a player account, initializes its default ELO rating and returns tokens.",
+  })
+  @ApiBody({
+    type: RegisterDto,
+    examples: {
+      player: {
+        summary: "New player",
+        value: { email: "player@example.com", password: "password1234", displayName: "player1" },
+      },
+    },
+  })
+  @ApiCreatedResponse({
+    description: "Account created",
+    type: AuthResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: "Validation error",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["email must be an email"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: "Unable to complete registration",
+    schema: {
+      example: {
+        statusCode: 409,
+        message: "Unable to complete registration",
+        error: "Conflict",
+      },
+    },
+  })
   async register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);
   }
 
   @Post("login")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Login with email and password" })
+  @ApiOperation({
+    summary: "Login with email and password",
+    description:
+      "Authenticates an existing player and returns a JWT access token plus refresh token.",
+  })
+  @ApiBody({
+    type: LoginDto,
+    examples: {
+      player: {
+        summary: "Player credentials",
+        value: { email: "player@example.com", password: "password1234" },
+      },
+    },
+  })
   @ApiOkResponse({ description: "Authenticated", type: AuthResponseDto })
-  @ApiBadRequestResponse({ description: "Validation error" })
-  @ApiUnauthorizedResponse({ description: "Invalid credentials" })
+  @ApiBadRequestResponse({
+    description: "Validation error",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["email must be an email"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: "Invalid credentials",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
+  })
   async login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
   }
@@ -56,9 +120,21 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth(SWAGGER_BEARER_AUTH)
-  @ApiOperation({ summary: "Logout and revoke the current access token" })
+  @ApiOperation({
+    summary: "Logout and revoke the current access token",
+    description:
+      "Adds the current JWT jti to the Redis blacklist until token expiry and revokes active refresh tokens for the user.",
+  })
   @ApiNoContentResponse({ description: "Access token blacklisted and refresh tokens revoked" })
-  @ApiUnauthorizedResponse({ description: "Missing, invalid, expired or revoked access token" })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid, expired or revoked access token",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
+  })
   async logout(@Req() req: AuthenticatedRequest): Promise<void> {
     await this.authService.logout({
       userId: req.user.id,

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -120,11 +120,39 @@ export class AuthController {
 
   @Post("refresh")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "Rotate refresh token and issue a new access token" })
+  @ApiOperation({
+    summary: "Rotate refresh token and issue a new access token",
+    description:
+      "Exchanges a valid opaque refresh token for a new access/refresh token pair and revokes the previous refresh token.",
+  })
+  @ApiBody({
+    type: RefreshDto,
+    examples: {
+      refresh: {
+        summary: "Refresh token rotation",
+        value: { refreshToken: "dGhpcyBpcyBhbiBvcGFxdWUgcmVmcmVzaCB0b2tlbg" },
+      },
+    },
+  })
   @ApiOkResponse({ description: "New token pair issued", type: RefreshResponseDto })
-  @ApiBadRequestResponse({ description: "Validation error" })
+  @ApiBadRequestResponse({
+    description: "Validation error",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["refreshToken must be longer than or equal to 20 characters"],
+        error: "Bad Request",
+      },
+    },
+  })
   @ApiUnauthorizedResponse({
     description: "Invalid, expired, revoked or unknown refresh token",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
   })
   async refresh(@Body() dto: RefreshDto) {
     return this.authService.refresh(dto.refreshToken);

--- a/apps/api/src/auth/dto/tokens.dto.ts
+++ b/apps/api/src/auth/dto/tokens.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class TokensDto {
-  @ApiProperty({ description: "RS256 JWT access token (15 min TTL)" })
+  @ApiProperty({
+    description: "RS256 JWT access token (15 min TTL)",
+    example: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  })
   access!: string;
 
-  @ApiProperty({ description: "Opaque refresh token (7 day TTL)" })
+  @ApiProperty({
+    description: "Opaque refresh token (7 day TTL)",
+    example: "vJ6E3j6bU5Wc3cS8mQf9Rk5H2q3T4p1N",
+  })
   refresh!: string;
 }

--- a/apps/api/src/leaderboard/dto/leaderboard-query.dto.ts
+++ b/apps/api/src/leaderboard/dto/leaderboard-query.dto.ts
@@ -3,7 +3,7 @@ import { Type } from "class-transformer";
 import { IsInt, IsOptional, Max, Min } from "class-validator";
 
 export class LeaderboardQueryDto {
-  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 50 })
+  @ApiPropertyOptional({ type: Number, minimum: 1, maximum: 100, default: 50, example: 50 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/apps/api/src/leaderboard/dto/leaderboard-response.dto.ts
+++ b/apps/api/src/leaderboard/dto/leaderboard-response.dto.ts
@@ -1,19 +1,19 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class LeaderboardEntryDto {
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   rank!: number;
 
-  @ApiProperty({ format: "uuid" })
+  @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   userId!: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: "player1" })
   displayName!: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1600 })
   rating!: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 42 })
   gamesPlayed!: number;
 }
 

--- a/apps/api/src/leaderboard/leaderboard.controller.ts
+++ b/apps/api/src/leaderboard/leaderboard.controller.ts
@@ -1,5 +1,11 @@
 import { Controller, Get, Query, Res, UseGuards } from "@nestjs/common";
-import { ApiBadRequestResponse, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from "@nestjs/swagger";
 import { SkipThrottle } from "@nestjs/throttler";
 import { Public } from "../auth/decorators/public.decorator.js";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
@@ -16,9 +22,33 @@ export class LeaderboardController {
 
   @Public()
   @Get()
-  @ApiOperation({ summary: "Get global top players by rating" })
-  @ApiOkResponse({ description: "Leaderboard page", type: LeaderboardResponseDto })
-  @ApiBadRequestResponse({ description: "Invalid query parameters" })
+  @ApiOperation({
+    summary: "Get global top players by rating",
+    description:
+      "Public leaderboard sorted by `rating DESC, gamesPlayed DESC`. Results are cached in Redis for 30 seconds.",
+  })
+  @ApiQuery({ name: "limit", required: false, type: Number, example: 50, minimum: 1, maximum: 100 })
+  @ApiOkResponse({
+    description: "Leaderboard page",
+    type: LeaderboardResponseDto,
+    headers: {
+      "X-Cache": {
+        description:
+          "Cache status returned by the API: HIT when Redis served the response, MISS otherwise.",
+        schema: { type: "string", enum: ["HIT", "MISS"] },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "Invalid query parameters",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["limit must be ≤ 100"],
+        error: "Bad Request",
+      },
+    },
+  })
   async getLeaderboard(
     @Query() query: LeaderboardQueryDto,
     @Res({ passthrough: true }) res: { setHeader(name: string, value: string): void },

--- a/apps/api/src/me/dto/me-history-query.dto.ts
+++ b/apps/api/src/me/dto/me-history-query.dto.ts
@@ -3,7 +3,7 @@ import { Type } from "class-transformer";
 import { IsInt, IsOptional, IsString, Max, Min } from "class-validator";
 
 export class MeHistoryQueryDto {
-  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 20 })
+  @ApiPropertyOptional({ type: Number, minimum: 1, maximum: 100, default: 20, example: 20 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -11,7 +11,10 @@ export class MeHistoryQueryDto {
   @Max(100, { message: "limit must be ≤ 100" })
   limit = 20;
 
-  @ApiPropertyOptional({ description: "Opaque cursor from a previous page" })
+  @ApiPropertyOptional({
+    description: "Opaque cursor returned by the previous page",
+    example: "eyJ0cyI6IjIwMjYtMDEtMDFUMDA6MDA6MzEuMDAwWiIsImlkIjoiIn0",
+  })
   @IsOptional()
   @IsString()
   cursor?: string;

--- a/apps/api/src/me/dto/me-history-response.dto.ts
+++ b/apps/api/src/me/dto/me-history-response.dto.ts
@@ -1,33 +1,33 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class MeHistoryOpponentDto {
-  @ApiProperty()
+  @ApiProperty({ example: "opponent42" })
   displayName!: string;
 
-  @ApiProperty({ description: "Opponent rating at match time" })
+  @ApiProperty({ description: "Opponent rating at match time", example: 1040 })
   ratingAtMatch!: number;
 }
 
 export class MeHistoryItemDto {
-  @ApiProperty({ format: "uuid" })
+  @ApiProperty({ format: "uuid", example: "499abac5-30b8-4a28-bf95-4ef0b3df6098" })
   matchId!: string;
 
   @ApiProperty({ type: MeHistoryOpponentDto })
   opponent!: MeHistoryOpponentDto;
 
-  @ApiProperty()
+  @ApiProperty({ example: 2 })
   scoreA!: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   scoreB!: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: true })
   isWinner!: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ example: 16 })
   eloDelta!: number;
 
-  @ApiProperty({ format: "date-time" })
+  @ApiProperty({ format: "date-time", example: "2026-06-08T12:00:00.000Z" })
   endedAt!: Date;
 }
 

--- a/apps/api/src/me/dto/me-profile.dto.ts
+++ b/apps/api/src/me/dto/me-profile.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { TokensDto } from "./tokens.dto.js";
 
-export class SafeUserDto {
+export class MeProfileDto {
   @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   id!: string;
 
@@ -13,12 +12,13 @@ export class SafeUserDto {
 
   @ApiProperty({ enum: ["player", "admin"], example: "player" })
   role!: "player" | "admin";
-}
 
-export class AuthResponseDto {
-  @ApiProperty({ type: SafeUserDto })
-  user!: SafeUserDto;
+  @ApiProperty({ example: 1000 })
+  rating!: number;
 
-  @ApiProperty({ type: TokensDto })
-  tokens!: TokensDto;
+  @ApiProperty({ example: 0 })
+  gamesPlayed!: number;
+
+  @ApiProperty({ format: "date-time", example: "2026-06-08T12:00:00.000Z" })
+  createdAt!: Date;
 }

--- a/apps/api/src/me/me.controller.ts
+++ b/apps/api/src/me/me.controller.ts
@@ -4,6 +4,7 @@ import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
@@ -12,6 +13,7 @@ import { SWAGGER_BEARER_AUTH } from "../swagger.js";
 import type { SafeUser } from "../users/users.service.js";
 import { MeHistoryQueryDto } from "./dto/me-history-query.dto.js";
 import { MeHistoryResponseDto } from "./dto/me-history-response.dto.js";
+import { MeProfileDto } from "./dto/me-profile.dto.js";
 import { type MeProfile, MeService } from "./me.service.js";
 import { MeHistoryService } from "./me-history.service.js";
 
@@ -28,19 +30,58 @@ export class MeController {
 
   @UseGuards(JwtAuthGuard)
   @Get()
-  @ApiOperation({ summary: "Get authenticated user profile" })
-  @ApiOkResponse({ description: "Current user" })
-  @ApiUnauthorizedResponse({ description: "Missing or invalid JWT" })
+  @ApiOperation({
+    summary: "Get authenticated user profile",
+    description:
+      "Returns private profile data for the current player, including email and ELO stats.",
+  })
+  @ApiOkResponse({ description: "Current user", type: MeProfileDto })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked JWT",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
+  })
   getMe(@Req() req: AuthenticatedRequest): Promise<MeProfile> {
     return this.meService.getProfile(req.user.id);
   }
 
   @UseGuards(JwtAuthGuard)
   @Get("history")
-  @ApiOperation({ summary: "Paginated match history for the authenticated user" })
+  @ApiOperation({
+    summary: "Paginated match history for the authenticated user",
+    description: "Returns ended matches sorted by `endedAt DESC` using an opaque cursor.",
+  })
+  @ApiQuery({ name: "limit", required: false, type: Number, example: 20, minimum: 1, maximum: 100 })
+  @ApiQuery({
+    name: "cursor",
+    required: false,
+    type: String,
+    description: "Opaque cursor returned by a previous page",
+  })
   @ApiOkResponse({ description: "Match history page", type: MeHistoryResponseDto })
-  @ApiBadRequestResponse({ description: "Invalid query parameters" })
-  @ApiUnauthorizedResponse({ description: "Missing or invalid JWT" })
+  @ApiBadRequestResponse({
+    description: "Invalid query parameters",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["limit must be ≤ 100"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked JWT",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
+  })
   getHistory(
     @Req() req: AuthenticatedRequest,
     @Query() query: MeHistoryQueryDto,

--- a/apps/api/src/swagger.spec.ts
+++ b/apps/api/src/swagger.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { createSwaggerBasicAuthMiddleware, isSwaggerEnabled } from "./swagger.js";
+
+describe("swagger", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("is disabled in production when basic auth credentials are missing", () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      SWAGGER_USER: "",
+      SWAGGER_PASSWORD: "",
+    };
+
+    expect(isSwaggerEnabled()).toBe(false);
+  });
+
+  it("allows Swagger in production with valid basic auth credentials", () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      SWAGGER_USER: "docs",
+      SWAGGER_PASSWORD: "secret",
+    };
+    const middleware = createSwaggerBasicAuthMiddleware();
+    const next = jest.fn();
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ send: jest.fn() })),
+    };
+
+    middleware(
+      {
+        headers: {
+          authorization: `Basic ${Buffer.from("docs:secret").toString("base64")}`,
+        },
+      },
+      res,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("rejects Swagger in production with invalid basic auth credentials", () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      SWAGGER_USER: "docs",
+      SWAGGER_PASSWORD: "secret",
+    };
+    const middleware = createSwaggerBasicAuthMiddleware();
+    const next = jest.fn();
+    const send = jest.fn();
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn(() => ({ send })),
+    };
+
+    middleware({ headers: { authorization: "Basic wrong" } }, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "WWW-Authenticate",
+      'Basic realm="Chifoumi Swagger"',
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(send).toHaveBeenCalledWith("Authentication required");
+  });
+});

--- a/apps/api/src/swagger.ts
+++ b/apps/api/src/swagger.ts
@@ -1,18 +1,36 @@
-import type { INestApplication } from "@nestjs/common";
+import type { INestApplication, NestMiddleware } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 export const SWAGGER_BEARER_AUTH = "JWT-auth";
 
+type BasicAuthRequest = {
+  headers: {
+    authorization?: string;
+  };
+};
+
+type BasicAuthResponse = {
+  setHeader(name: string, value: string): void;
+  status(statusCode: number): {
+    send(body: string): void;
+  };
+};
+
+type NextFunction = () => void;
+
 export function buildSwaggerDocument(app: INestApplication) {
   const config = new DocumentBuilder()
     .setTitle("Chifoumi API")
-    .setVersion("0.1.0")
+    .setDescription(
+      "API REST Chifoumi Ranked pour l'authentification, le profil joueur, l'historique de matchs et le leaderboard.",
+    )
+    .setVersion("1.0.0")
     .addBearerAuth(
       {
         type: "http",
         scheme: "bearer",
         bearerFormat: "JWT",
-        description: "RS256 access token from register/login",
+        description: "RS256 access token returned by register/login. Paste only the token value.",
       },
       SWAGGER_BEARER_AUTH,
     )
@@ -21,7 +39,57 @@ export function buildSwaggerDocument(app: INestApplication) {
   return SwaggerModule.createDocument(app, config);
 }
 
+export function isSwaggerEnabled(): boolean {
+  return (
+    process.env.NODE_ENV !== "production" ||
+    Boolean(process.env.SWAGGER_USER && process.env.SWAGGER_PASSWORD)
+  );
+}
+
+export function createSwaggerBasicAuthMiddleware(): NestMiddleware["use"] {
+  return (req: BasicAuthRequest, res: BasicAuthResponse, next: NextFunction) => {
+    if (process.env.NODE_ENV !== "production") {
+      next();
+      return;
+    }
+
+    const expectedUser = process.env.SWAGGER_USER;
+    const expectedPassword = process.env.SWAGGER_PASSWORD;
+    if (!expectedUser || !expectedPassword) {
+      res.status(404).send("Swagger documentation is disabled");
+      return;
+    }
+
+    const [scheme, credentials] = req.headers.authorization?.split(" ") ?? [];
+    const decodedCredentials =
+      scheme === "Basic" && credentials ? Buffer.from(credentials, "base64").toString("utf8") : "";
+    const separatorIndex = decodedCredentials.indexOf(":");
+    const user = decodedCredentials.slice(0, separatorIndex);
+    const password = decodedCredentials.slice(separatorIndex + 1);
+
+    if (user === expectedUser && password === expectedPassword) {
+      next();
+      return;
+    }
+
+    res.setHeader("WWW-Authenticate", 'Basic realm="Chifoumi Swagger"');
+    res.status(401).send("Authentication required");
+  };
+}
+
 export function setupSwagger(app: INestApplication): void {
+  if (!isSwaggerEnabled()) {
+    return;
+  }
+
+  app.use(["/api/docs", "/api/docs-json"], createSwaggerBasicAuthMiddleware());
   const document = buildSwaggerDocument(app);
-  SwaggerModule.setup("api/docs", app, document);
+  SwaggerModule.setup("api/docs", app, document, {
+    jsonDocumentUrl: "api/docs-json",
+    swaggerOptions: {
+      persistAuthorization: true,
+      tagsSorter: "alpha",
+      operationsSorter: "alpha",
+    },
+  });
 }

--- a/apps/api/src/users/dto/public-profile.dto.ts
+++ b/apps/api/src/users/dto/public-profile.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class PublicProfileDto {
-  @ApiProperty({ format: "uuid" })
+  @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   id!: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: "player1" })
   displayName!: string;
 
   @ApiProperty({ example: 1000 })
@@ -16,6 +16,6 @@ export class PublicProfileDto {
   @ApiProperty({ example: 0, description: "Wins divided by games played, rounded to 2 decimals." })
   winRate!: number;
 
-  @ApiProperty({ format: "date-time" })
+  @ApiProperty({ format: "date-time", example: "2026-06-08T12:00:00.000Z" })
   createdAt!: Date;
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -4,6 +4,7 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
@@ -20,10 +21,35 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get(":id/profile")
-  @ApiOperation({ summary: "Get another player's public profile" })
+  @ApiOperation({
+    summary: "Get another player's public profile",
+    description:
+      "Returns public player information only. Private fields such as email are intentionally omitted.",
+  })
+  @ApiParam({
+    name: "id",
+    format: "uuid",
+    example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1",
+    description: "User id",
+  })
   @ApiOkResponse({ description: "Public profile", type: PublicProfileDto })
-  @ApiUnauthorizedResponse({ description: "Missing or invalid access token" })
-  @ApiNotFoundResponse({ description: "USER_NOT_FOUND" })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked access token",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: "USER_NOT_FOUND",
+    schema: {
+      example: {
+        error: "USER_NOT_FOUND",
+      },
+    },
+  })
   getPublicProfile(@Param("id", new ParseUUIDPipe()) userId: string): Promise<PublicProfileDto> {
     return this.usersService.getPublicProfile(userId);
   }

--- a/apps/api/test/swagger.e2e-spec.ts
+++ b/apps/api/test/swagger.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { generateKeyPairSync } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type INestApplication, ValidationPipe } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { config } from "dotenv";
+import request from "supertest";
+import { AppModule } from "../src/app.module.js";
+import { setupSwagger } from "../src/swagger.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+const jwtKeys = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+const originalEnv = {
+  JWT_PRIVATE_KEY: process.env.JWT_PRIVATE_KEY,
+  JWT_PUBLIC_KEY: process.env.JWT_PUBLIC_KEY,
+  DATABASE_URL: process.env.DATABASE_URL,
+  REDIS_URL: process.env.REDIS_URL,
+  SKIP_DB_CONNECT: process.env.SKIP_DB_CONNECT,
+  SKIP_REDIS_CONNECT: process.env.SKIP_REDIS_CONNECT,
+};
+
+process.env.JWT_PRIVATE_KEY = jwtKeys.privateKey;
+process.env.JWT_PUBLIC_KEY = jwtKeys.publicKey;
+process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.SKIP_DB_CONNECT = "true";
+process.env.SKIP_REDIS_CONNECT = "true";
+
+describe("Swagger docs (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    setupSwagger(app);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("publishes OpenAPI JSON with tags, bearer auth and sprint-1 endpoints", async () => {
+    const res = await request(app.getHttpServer()).get("/api/docs-json").expect(200);
+
+    expect(res.body.info).toMatchObject({
+      title: "Chifoumi API",
+      version: "1.0.0",
+    });
+    expect(res.body.components.securitySchemes["JWT-auth"]).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT",
+    });
+    expect(Object.keys(res.body.paths)).toEqual(
+      expect.arrayContaining([
+        "/auth/register",
+        "/auth/login",
+        "/auth/logout",
+        "/me",
+        "/me/history",
+        "/users/{id}/profile",
+        "/leaderboard",
+      ]),
+    );
+    const tags = Object.values(res.body.paths)
+      .flatMap((pathItem) => Object.values(pathItem as Record<string, { tags?: string[] }>))
+      .flatMap((operation) => operation.tags ?? []);
+
+    expect([...new Set(tags)]).toEqual(
+      expect.arrayContaining(["auth", "me", "users", "leaderboard"]),
+    );
+  });
+});

--- a/apps/api/test/swagger.e2e-spec.ts
+++ b/apps/api/test/swagger.e2e-spec.ts
@@ -83,6 +83,7 @@ describe("Swagger docs (e2e)", () => {
       expect.arrayContaining([
         "/auth/register",
         "/auth/login",
+        "/auth/refresh",
         "/auth/logout",
         "/me",
         "/me/history",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10,18 +10,24 @@
             "description": ""
           }
         },
-        "tags": ["Health"]
+        "tags": [
+          "Health"
+        ]
       }
     },
     "/users/{id}/profile": {
       "get": {
+        "description": "Returns public player information only. Private fields such as email are intentionally omitted.",
         "operationId": "UsersController_getPublicProfile",
         "parameters": [
           {
             "name": "id",
             "required": true,
             "in": "path",
+            "description": "User id",
             "schema": {
+              "format": "uuid",
+              "example": "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1",
               "type": "string"
             }
           }
@@ -38,10 +44,29 @@
             }
           },
           "401": {
-            "description": "Missing or invalid access token"
+            "description": "Missing, invalid or revoked access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
           },
           "404": {
-            "description": "USER_NOT_FOUND"
+            "description": "USER_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "error": "USER_NOT_FOUND"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -50,11 +75,14 @@
           }
         ],
         "summary": "Get another player's public profile",
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
     "/auth/register": {
       "post": {
+        "description": "Creates a player account, initializes its default ELO rating and returns tokens.",
         "operationId": "AuthController_register",
         "parameters": [],
         "requestBody": {
@@ -63,6 +91,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RegisterDto"
+              },
+              "examples": {
+                "player": {
+                  "summary": "New player",
+                  "value": {
+                    "email": "player@example.com",
+                    "password": "password1234",
+                    "displayName": "player1"
+                  }
+                }
               }
             }
           }
@@ -79,18 +117,45 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": [
+                      "email must be an email"
+                    ],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
           },
           "409": {
-            "description": "Unable to complete registration"
+            "description": "Unable to complete registration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 409,
+                    "message": "Unable to complete registration",
+                    "error": "Conflict"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Register a new player account",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/auth/login": {
       "post": {
+        "description": "Authenticates an existing player and returns a JWT access token plus refresh token.",
         "operationId": "AuthController_login",
         "parameters": [],
         "requestBody": {
@@ -99,6 +164,15 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LoginDto"
+              },
+              "examples": {
+                "player": {
+                  "summary": "Player credentials",
+                  "value": {
+                    "email": "player@example.com",
+                    "password": "password1234"
+                  }
+                }
               }
             }
           }
@@ -115,18 +189,44 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": [
+                      "email must be an email"
+                    ],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
           },
           "401": {
-            "description": "Invalid credentials"
+            "description": "Invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Login with email and password",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/auth/logout": {
       "post": {
+        "description": "Adds the current JWT jti to the Redis blacklist until token expiry and revokes active refresh tokens for the user.",
         "operationId": "AuthController_logout",
         "parameters": [],
         "responses": {
@@ -134,7 +234,17 @@
             "description": "Access token blacklisted and refresh tokens revoked"
           },
           "401": {
-            "description": "Missing, invalid, expired or revoked access token"
+            "description": "Missing, invalid, expired or revoked access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -143,19 +253,39 @@
           }
         ],
         "summary": "Logout and revoke the current access token",
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/me": {
       "get": {
+        "description": "Returns private profile data for the current player, including email and ELO stats.",
         "operationId": "MeController_getMe",
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Current user"
+            "description": "Current user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeProfileDto"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Missing or invalid JWT"
+            "description": "Missing, invalid or revoked JWT",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -164,11 +294,14 @@
           }
         ],
         "summary": "Get authenticated user profile",
-        "tags": ["me"]
+        "tags": [
+          "me"
+        ]
       }
     },
     "/me/history": {
       "get": {
+        "description": "Returns ended matches sorted by `endedAt DESC` using an opaque cursor.",
         "operationId": "MeController_getHistory",
         "parameters": [
           {
@@ -176,15 +309,20 @@
             "required": false,
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Object"
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "example": 20,
+              "type": "number"
             }
           },
           {
             "name": "cursor",
             "required": false,
             "in": "query",
-            "description": "Opaque cursor from a previous page",
+            "description": "Opaque cursor returned by a previous page",
             "schema": {
+              "example": "eyJ0cyI6IjIwMjYtMDEtMDFUMDA6MDA6MzEuMDAwWiIsImlkIjoiIn0",
               "type": "string"
             }
           }
@@ -201,10 +339,33 @@
             }
           },
           "400": {
-            "description": "Invalid query parameters"
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": [
+                      "limit must be ≤ 100"
+                    ],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
           },
           "401": {
-            "description": "Missing or invalid JWT"
+            "description": "Missing, invalid or revoked JWT",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -213,11 +374,14 @@
           }
         ],
         "summary": "Paginated match history for the authenticated user",
-        "tags": ["me"]
+        "tags": [
+          "me"
+        ]
       }
     },
     "/leaderboard": {
       "get": {
+        "description": "Public leaderboard sorted by `rating DESC, gamesPlayed DESC`. Results are cached in Redis for 30 seconds.",
         "operationId": "LeaderboardController_getLeaderboard",
         "parameters": [
           {
@@ -225,13 +389,29 @@
             "required": false,
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Object"
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50,
+              "example": 50,
+              "type": "number"
             }
           }
         ],
         "responses": {
           "200": {
             "description": "Leaderboard page",
+            "headers": {
+              "X-Cache": {
+                "description": "Cache status returned by the API: HIT when Redis served the response, MISS otherwise.",
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "HIT",
+                    "MISS"
+                  ]
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -241,11 +421,26 @@
             }
           },
           "400": {
-            "description": "Invalid query parameters"
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": [
+                      "limit must be ≤ 100"
+                    ],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Get global top players by rating",
-        "tags": ["leaderboard"]
+        "tags": [
+          "leaderboard"
+        ]
       }
     },
     "/.well-known/jwks.json": {
@@ -257,14 +452,16 @@
             "description": ""
           }
         },
-        "tags": ["Jwks"]
+        "tags": [
+          "Jwks"
+        ]
       }
     }
   },
   "info": {
     "title": "Chifoumi API",
-    "description": "",
-    "version": "0.1.0",
+    "description": "API REST Chifoumi Ranked pour l'authentification, le profil joueur, l'historique de matchs et le leaderboard.",
+    "version": "1.0.0",
     "contact": {}
   },
   "tags": [],
@@ -275,7 +472,7 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "type": "http",
-        "description": "RS256 access token from register/login"
+        "description": "RS256 access token returned by register/login. Paste only the token value."
       }
     },
     "schemas": {
@@ -284,10 +481,12 @@
         "properties": {
           "id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "example": "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1"
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "example": "player1"
           },
           "rating": {
             "type": "number",
@@ -304,10 +503,18 @@
           },
           "createdAt": {
             "format": "date-time",
-            "type": "string"
+            "type": "string",
+            "example": "2026-06-08T12:00:00.000Z"
           }
         },
-        "required": ["id", "displayName", "rating", "gamesPlayed", "winRate", "createdAt"]
+        "required": [
+          "id",
+          "displayName",
+          "rating",
+          "gamesPlayed",
+          "winRate",
+          "createdAt"
+        ]
       },
       "RegisterDto": {
         "type": "object",
@@ -331,42 +538,63 @@
             "example": "player1"
           }
         },
-        "required": ["email", "password", "displayName"]
+        "required": [
+          "email",
+          "password",
+          "displayName"
+        ]
       },
       "SafeUserDto": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "example": "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1"
           },
           "email": {
             "type": "string",
-            "format": "email"
+            "format": "email",
+            "example": "player@example.com"
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "example": "player1"
           },
           "role": {
             "type": "string",
-            "enum": ["player", "admin"]
+            "enum": [
+              "player",
+              "admin"
+            ],
+            "example": "player"
           }
         },
-        "required": ["id", "email", "displayName", "role"]
+        "required": [
+          "id",
+          "email",
+          "displayName",
+          "role"
+        ]
       },
       "TokensDto": {
         "type": "object",
         "properties": {
           "access": {
             "type": "string",
-            "description": "RS256 JWT access token (15 min TTL)"
+            "description": "RS256 JWT access token (15 min TTL)",
+            "example": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
           },
           "refresh": {
             "type": "string",
-            "description": "Opaque refresh token (7 day TTL)"
+            "description": "Opaque refresh token (7 day TTL)",
+            "example": "vJ6E3j6bU5Wc3cS8mQf9Rk5H2q3T4p1N"
           }
         },
-        "required": ["access", "refresh"]
+        "required": [
+          "access",
+          "refresh"
+        ]
       },
       "AuthResponseDto": {
         "type": "object",
@@ -378,7 +606,10 @@
             "$ref": "#/components/schemas/TokensDto"
           }
         },
-        "required": ["user", "tokens"]
+        "required": [
+          "user",
+          "tokens"
+        ]
       },
       "LoginDto": {
         "type": "object",
@@ -395,53 +626,120 @@
             "example": "password1234"
           }
         },
-        "required": ["email", "password"]
+        "required": [
+          "email",
+          "password"
+        ]
       },
-      "Object": {
+      "MeProfileDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "player@example.com"
+          },
+          "displayName": {
+            "type": "string",
+            "example": "player1"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "player",
+              "admin"
+            ],
+            "example": "player"
+          },
+          "rating": {
+            "type": "number",
+            "example": 1000
+          },
+          "gamesPlayed": {
+            "type": "number",
+            "example": 0
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "example": "2026-06-08T12:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "displayName",
+          "role",
+          "rating",
+          "gamesPlayed",
+          "createdAt"
+        ]
       },
       "MeHistoryOpponentDto": {
         "type": "object",
         "properties": {
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "example": "opponent42"
           },
           "ratingAtMatch": {
             "type": "number",
-            "description": "Opponent rating at match time"
+            "description": "Opponent rating at match time",
+            "example": 1040
           }
         },
-        "required": ["displayName", "ratingAtMatch"]
+        "required": [
+          "displayName",
+          "ratingAtMatch"
+        ]
       },
       "MeHistoryItemDto": {
         "type": "object",
         "properties": {
           "matchId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "example": "499abac5-30b8-4a28-bf95-4ef0b3df6098"
           },
           "opponent": {
             "$ref": "#/components/schemas/MeHistoryOpponentDto"
           },
           "scoreA": {
-            "type": "number"
+            "type": "number",
+            "example": 2
           },
           "scoreB": {
-            "type": "number"
+            "type": "number",
+            "example": 1
           },
           "isWinner": {
-            "type": "boolean"
+            "type": "boolean",
+            "example": true
           },
           "eloDelta": {
-            "type": "number"
+            "type": "number",
+            "example": 16
           },
           "endedAt": {
             "format": "date-time",
-            "type": "string"
+            "type": "string",
+            "example": "2026-06-08T12:00:00.000Z"
           }
         },
-        "required": ["matchId", "opponent", "scoreA", "scoreB", "isWinner", "eloDelta", "endedAt"]
+        "required": [
+          "matchId",
+          "opponent",
+          "scoreA",
+          "scoreB",
+          "isWinner",
+          "eloDelta",
+          "endedAt"
+        ]
       },
       "MeHistoryResponseDto": {
         "type": "object",
@@ -458,29 +756,42 @@
             "nullable": true
           }
         },
-        "required": ["items"]
+        "required": [
+          "items"
+        ]
       },
       "LeaderboardEntryDto": {
         "type": "object",
         "properties": {
           "rank": {
-            "type": "number"
+            "type": "number",
+            "example": 1
           },
           "userId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "example": "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1"
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "example": "player1"
           },
           "rating": {
-            "type": "number"
+            "type": "number",
+            "example": 1600
           },
           "gamesPlayed": {
-            "type": "number"
+            "type": "number",
+            "example": 42
           }
         },
-        "required": ["rank", "userId", "displayName", "rating", "gamesPlayed"]
+        "required": [
+          "rank",
+          "userId",
+          "displayName",
+          "rating",
+          "gamesPlayed"
+        ]
       },
       "LeaderboardResponseDto": {
         "type": "object",
@@ -492,7 +803,9 @@
             }
           }
         },
-        "required": ["items"]
+        "required": [
+          "items"
+        ]
       }
     }
   }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -214,6 +214,7 @@
     },
     "/auth/refresh": {
       "post": {
+        "description": "Exchanges a valid opaque refresh token for a new access/refresh token pair and revokes the previous refresh token.",
         "operationId": "AuthController_refresh",
         "parameters": [],
         "requestBody": {
@@ -222,6 +223,14 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RefreshDto"
+              },
+              "examples": {
+                "refresh": {
+                  "summary": "Refresh token rotation",
+                  "value": {
+                    "refreshToken": "dGhpcyBpcyBhbiBvcGFxdWUgcmVmcmVzaCB0b2tlbg"
+                  }
+                }
               }
             }
           }
@@ -238,10 +247,31 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": ["refreshToken must be longer than or equal to 20 characters"],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
           },
           "401": {
-            "description": "Invalid, expired, revoked or unknown refresh token"
+            "description": "Invalid, expired, revoked or unknown refresh token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Rotate refresh token and issue a new access token",


### PR DESCRIPTION
## Summary

- Configure Swagger UI at `/api/docs` and raw OpenAPI JSON at `/api/docs-json`.
- Add bearer JWT authorization support and production Basic Auth protection via `SWAGGER_USER` / `SWAGGER_PASSWORD`.
- Enrich Sprint 1 API documentation for auth, me, users and leaderboard endpoints with descriptions, params, schemas and examples.
- Update README, `.env.example`, and regenerate `docs/openapi.json`.

## Validation

- `pnpm -r typecheck`
- `pnpm --filter @chifoumi/api test`
- `pnpm --filter @chifoumi/api test:e2e`
- `pnpm exec biome check` on the changed files