### PR TITLE
feat(game-service): Socket.io JWT auth with Redis blacklist (US-017)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.cjs text eol=lf
+*.mjs text eol=lf
+*.json text eol=lf
+*.jsonc text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     env:
       DATABASE_URL: postgresql://app:chifoumi_dev@localhost:5432/chifoumi
+      REDIS_URL: redis://localhost:6379
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -52,6 +64,9 @@ jobs:
 
       - name: Test with coverage
         run: pnpm -r run --if-present test
+
+      - name: Game service WebSocket e2e tests
+        run: pnpm --filter @chifoumi/game-service test:e2e
 
       - name: Upload coverage artifact
         if: always()

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -130,6 +130,7 @@ export class AuthService {
       const { accessToken } = await this.tokenService.issueAccessToken({
         userId: stored.userId,
         role: safeUser.role,
+        displayName: safeUser.displayName,
       });
       const tokens = { access: accessToken, refresh: newRefreshToken };
       await this.cacheRotation(cacheKey, tokens);
@@ -208,6 +209,7 @@ export class AuthService {
     const { accessToken } = await this.tokenService.issueAccessToken({
       userId,
       role: safeUser.role,
+      displayName: safeUser.displayName,
     });
     const { refreshToken, refreshTokenHash } = this.tokenService.issueRefreshToken();
     await this.prisma.refreshToken.create({

--- a/apps/api/src/auth/token.service.spec.ts
+++ b/apps/api/src/auth/token.service.spec.ts
@@ -39,6 +39,7 @@ describe("TokenService", () => {
     const { accessToken } = await tokenService.issueAccessToken({
       userId: "11111111-1111-1111-1111-111111111111",
       role: "player",
+      displayName: "player1",
     });
     const parts = accessToken.split(".");
     expect(parts).toHaveLength(3);
@@ -46,11 +47,13 @@ describe("TokenService", () => {
       sub: string;
       role: string;
       jti: string;
+      displayName: string;
       exp: number;
       iat: number;
     };
     expect(payload.sub).toBe("11111111-1111-1111-1111-111111111111");
     expect(payload.role).toBe("player");
+    expect(payload.displayName).toBe("player1");
     expect(payload.jti).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
     );

--- a/apps/api/src/auth/token.service.ts
+++ b/apps/api/src/auth/token.service.ts
@@ -8,6 +8,7 @@ export type AccessTokenPayload = {
   sub: string;
   role: string;
   jti: string;
+  displayName: string;
 };
 
 @Injectable()
@@ -20,10 +21,11 @@ export class TokenService {
   async issueAccessToken(input: {
     userId: string;
     role: string;
+    displayName: string;
   }): Promise<{ accessToken: string }> {
     const jti = uuidv4();
     const accessToken = await this.jwtService.signAsync(
-      { sub: input.userId, role: input.role, jti },
+      { sub: input.userId, role: input.role, jti, displayName: input.displayName },
       {
         algorithm: "RS256",
         expiresIn: this.jwtConfig.accessTtlSeconds,

--- a/apps/game-service/biome.json
+++ b/apps/game-service/biome.json
@@ -1,3 +1,15 @@
 {
-  "extends": "//"
+  "extends": "//",
+  "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    }
+  },
+  "linter": {
+    "rules": {
+      "style": {
+        "useImportType": "off"
+      }
+    }
+  }
 }

--- a/apps/game-service/jest-e2e.config.cjs
+++ b/apps/game-service/jest-e2e.config.cjs
@@ -1,0 +1,20 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testEnvironment: "node",
+  roots: ["<rootDir>/test"],
+  testRegex: ".*\\.e2e-spec\\.ts$",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.e2e.json",
+      },
+    ],
+  },
+};

--- a/apps/game-service/jest-e2e.config.cjs
+++ b/apps/game-service/jest-e2e.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
   testEnvironment: "node",
+  testTimeout: 15_000,
   roots: ["<rootDir>/test"],
   testRegex: ".*\\.e2e-spec\\.ts$",
   transform: {

--- a/apps/game-service/jest.config.cjs
+++ b/apps/game-service/jest.config.cjs
@@ -1,0 +1,20 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testRegex: ".*\\.spec\\.ts$",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.spec.json",
+      },
+    ],
+  },
+};

--- a/apps/game-service/package.json
+++ b/apps/game-service/package.json
@@ -14,8 +14,10 @@
   "devDependencies": {
     "@jest/globals": "29.7.0",
     "@nestjs/testing": "11.1.21",
+    "@types/ioredis-mock": "^8.2.7",
     "@types/jest": "29.5.14",
     "@types/node": "^24.12.4",
+    "ioredis-mock": "^8.13.1",
     "jest": "29.7.0",
     "socket.io-client": "^4.8.3",
     "ts-jest": "29.2.5",

--- a/apps/game-service/package.json
+++ b/apps/game-service/package.json
@@ -7,21 +7,35 @@
     "dev": "tsx watch src/main.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/main.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:e2e": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./jest-e2e.config.cjs"
   },
   "devDependencies": {
+    "@jest/globals": "29.7.0",
+    "@nestjs/testing": "11.1.21",
+    "@types/jest": "29.5.14",
     "@types/node": "^24.12.4",
+    "jest": "29.7.0",
+    "socket.io-client": "^4.8.3",
+    "ts-jest": "29.2.5",
     "tsx": "^4.22.2",
     "typescript": "~5.7.3"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.21",
     "@nestjs/core": "^11.1.21",
+    "@nestjs/jwt": "11.0.0",
     "@nestjs/platform-express": "^11.1.21",
     "@nestjs/platform-socket.io": "^11.1.21",
     "@nestjs/websockets": "^11.1.21",
+    "dotenv": "^17.2.3",
+    "ioredis": "^5.11.1",
+    "nestjs-pino": "4.2.0",
+    "pino-http": "10.4.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "socket.io": "^4.8.3"
+    "socket.io": "^4.8.3",
+    "uuid": "11.0.5"
   }
 }

--- a/apps/game-service/src/app.module.ts
+++ b/apps/game-service/src/app.module.ts
@@ -1,9 +1,23 @@
 import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { AuthModule } from "./auth/auth.module.js";
+import { AppConfigModule } from "./config/config.module.js";
 import { GameGateway } from "./game.gateway.js";
 import { HealthModule } from "./health/health.module.js";
+import { RedisModule } from "./redis/redis.module.js";
 
 @Module({
-  imports: [HealthModule],
+  imports: [
+    LoggerModule.forRoot({
+      pinoHttp: {
+        redact: ["req.url", "req.query.token", "req.headers.authorization"],
+      },
+    }),
+    AppConfigModule,
+    RedisModule,
+    AuthModule,
+    HealthModule,
+  ],
   providers: [GameGateway],
 })
 export class AppModule {}

--- a/apps/game-service/src/auth/auth.module.ts
+++ b/apps/game-service/src/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { JWT_CONFIG, type JwtConfig } from "../config/jwt.config.js";
+import { WsAuthService } from "./ws-auth.service.js";
+
+@Module({
+  imports: [
+    JwtModule.registerAsync({
+      inject: [JWT_CONFIG],
+      useFactory: (jwtConfig: JwtConfig) => ({
+        publicKey: jwtConfig.publicKey,
+        verifyOptions: { algorithms: ["RS256"] },
+      }),
+    }),
+  ],
+  providers: [WsAuthService],
+  exports: [WsAuthService],
+})
+export class AuthModule {}

--- a/apps/game-service/src/auth/ws-auth.error.ts
+++ b/apps/game-service/src/auth/ws-auth.error.ts
@@ -1,0 +1,12 @@
+export const WS_AUTH_INVALID_TOKEN_CODE = 4001;
+export const WS_AUTH_TOKEN_REVOKED_CODE = 4003;
+
+export class WsAuthError extends Error {
+  constructor(
+    message: string,
+    readonly code: number,
+  ) {
+    super(message);
+    this.name = "WsAuthError";
+  }
+}

--- a/apps/game-service/src/auth/ws-auth.service.spec.ts
+++ b/apps/game-service/src/auth/ws-auth.service.spec.ts
@@ -1,0 +1,103 @@
+import { generateKeyPairSync } from "node:crypto";
+import { jest } from "@jest/globals";
+import { JwtModule, JwtService } from "@nestjs/jwt";
+import { Test } from "@nestjs/testing";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  WS_AUTH_INVALID_TOKEN_CODE,
+  WS_AUTH_TOKEN_REVOKED_CODE,
+  WsAuthError,
+} from "./ws-auth.error.js";
+import { WsAuthService } from "./ws-auth.service.js";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+describe("WsAuthService", () => {
+  let wsAuthService: WsAuthService;
+  let jwtService: JwtService;
+  const redisService = {
+    isAccessTokenRevoked: jest.fn<RedisService["isAccessTokenRevoked"]>(),
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        JwtModule.register({
+          privateKey,
+          publicKey,
+          signOptions: { algorithm: "RS256", expiresIn: 60 },
+        }),
+      ],
+      providers: [WsAuthService, { provide: RedisService, useValue: redisService }],
+    }).compile();
+
+    wsAuthService = moduleRef.get(WsAuthService);
+    jwtService = moduleRef.get(JwtService);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redisService.isAccessTokenRevoked.mockResolvedValue(false);
+  });
+
+  async function signToken(overrides?: {
+    sub?: string;
+    displayName?: string;
+    jti?: string;
+    expiresIn?: number;
+  }): Promise<string> {
+    return jwtService.signAsync(
+      {
+        sub: overrides?.sub ?? "user-1",
+        role: "player",
+        jti: overrides?.jti ?? "jti-1",
+        displayName: overrides?.displayName ?? "player1",
+      },
+      {
+        algorithm: "RS256",
+        expiresIn: overrides?.expiresIn ?? 60,
+      },
+    );
+  }
+
+  it("accepts a valid non-revoked token", async () => {
+    const token = await signToken();
+    await expect(wsAuthService.verifyToken(token)).resolves.toEqual({
+      userId: "user-1",
+      displayName: "player1",
+      jti: "jti-1",
+    });
+  });
+
+  it("rejects missing tokens", async () => {
+    await expect(wsAuthService.verifyToken(undefined)).rejects.toMatchObject({
+      message: "INVALID_TOKEN",
+      code: WS_AUTH_INVALID_TOKEN_CODE,
+    });
+  });
+
+  it("rejects malformed tokens", async () => {
+    await expect(wsAuthService.verifyToken("not-a-jwt")).rejects.toBeInstanceOf(WsAuthError);
+  });
+
+  it("rejects expired tokens", async () => {
+    const token = await signToken({ expiresIn: -1 });
+    await expect(wsAuthService.verifyToken(token)).rejects.toMatchObject({
+      message: "INVALID_TOKEN",
+      code: WS_AUTH_INVALID_TOKEN_CODE,
+    });
+  });
+
+  it("rejects blacklisted tokens", async () => {
+    redisService.isAccessTokenRevoked.mockResolvedValue(true);
+    const token = await signToken();
+    await expect(wsAuthService.verifyToken(token)).rejects.toMatchObject({
+      message: "TOKEN_REVOKED",
+      code: WS_AUTH_TOKEN_REVOKED_CODE,
+    });
+  });
+});

--- a/apps/game-service/src/auth/ws-auth.service.ts
+++ b/apps/game-service/src/auth/ws-auth.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  WS_AUTH_INVALID_TOKEN_CODE,
+  WS_AUTH_TOKEN_REVOKED_CODE,
+  WsAuthError,
+} from "./ws-auth.error.js";
+
+export type WsAuthPayload = {
+  sub: string;
+  role: string;
+  jti: string;
+  displayName: string;
+  exp: number;
+};
+
+export type WsAuthResult = {
+  userId: string;
+  displayName: string;
+  jti: string;
+};
+
+@Injectable()
+export class WsAuthService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async verifyToken(token: string | undefined): Promise<WsAuthResult> {
+    if (!token || token.trim().length === 0) {
+      throw new WsAuthError("INVALID_TOKEN", WS_AUTH_INVALID_TOKEN_CODE);
+    }
+
+    let payload: WsAuthPayload;
+    try {
+      payload = await this.jwtService.verifyAsync<WsAuthPayload>(token);
+    } catch {
+      throw new WsAuthError("INVALID_TOKEN", WS_AUTH_INVALID_TOKEN_CODE);
+    }
+
+    if (!payload.sub || !payload.jti || !payload.displayName) {
+      throw new WsAuthError("INVALID_TOKEN", WS_AUTH_INVALID_TOKEN_CODE);
+    }
+
+    let revoked: boolean;
+    try {
+      revoked = await this.redisService.isAccessTokenRevoked(payload.jti);
+    } catch {
+      throw new WsAuthError("INVALID_TOKEN", WS_AUTH_INVALID_TOKEN_CODE);
+    }
+
+    if (revoked) {
+      throw new WsAuthError("TOKEN_REVOKED", WS_AUTH_TOKEN_REVOKED_CODE);
+    }
+
+    return {
+      userId: payload.sub,
+      displayName: payload.displayName,
+      jti: payload.jti,
+    };
+  }
+}

--- a/apps/game-service/src/config/config.module.ts
+++ b/apps/game-service/src/config/config.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from "@nestjs/common";
+import { JWT_CONFIG, loadJwtConfig } from "./jwt.config.js";
+import { loadRedisConfig, REDIS_CONFIG } from "./redis.config.js";
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: JWT_CONFIG,
+      useFactory: () => loadJwtConfig(),
+    },
+    {
+      provide: REDIS_CONFIG,
+      useFactory: () => loadRedisConfig(),
+    },
+  ],
+  exports: [JWT_CONFIG, REDIS_CONFIG],
+})
+export class AppConfigModule {}

--- a/apps/game-service/src/config/jwt.config.ts
+++ b/apps/game-service/src/config/jwt.config.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type JwtConfig = {
+  publicKey: string;
+};
+
+function readPemFromEnvOrPath(envValue: string | undefined, pathEnv: string | undefined): string {
+  if (envValue?.includes("BEGIN")) {
+    return envValue.replace(/\\n/g, "\n");
+  }
+  if (!pathEnv) {
+    throw new Error("JWT key missing: set JWT_PUBLIC_KEY or JWT_PUBLIC_KEY_PATH");
+  }
+  return readFileSync(resolve(pathEnv), "utf8");
+}
+
+export function loadJwtConfig(): JwtConfig {
+  return {
+    publicKey: readPemFromEnvOrPath(process.env.JWT_PUBLIC_KEY, process.env.JWT_PUBLIC_KEY_PATH),
+  };
+}
+
+export const JWT_CONFIG = "JWT_CONFIG";

--- a/apps/game-service/src/config/redis.config.ts
+++ b/apps/game-service/src/config/redis.config.ts
@@ -1,0 +1,13 @@
+export const REDIS_CONFIG = Symbol("REDIS_CONFIG");
+
+export type RedisConfig = {
+  url: string;
+};
+
+export function loadRedisConfig(): RedisConfig {
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    throw new Error("REDIS_URL is required");
+  }
+  return { url };
+}

--- a/apps/game-service/src/game.gateway.ts
+++ b/apps/game-service/src/game.gateway.ts
@@ -1,10 +1,28 @@
 import {
   type OnGatewayConnection,
   type OnGatewayDisconnect,
+  type OnGatewayInit,
   WebSocketGateway,
+  WebSocketServer,
 } from "@nestjs/websockets";
-import type { Socket } from "socket.io";
+import { Logger } from "nestjs-pino";
+import type { Server, Socket } from "socket.io";
+import { WS_AUTH_INVALID_TOKEN_CODE, WsAuthError } from "./auth/ws-auth.error.js";
+import { WsAuthService } from "./auth/ws-auth.service.js";
 import { resolveCorsOrigins } from "./cors.js";
+import { scrubTokenFromUrl } from "./logging/scrub-token.js";
+import { RedisService } from "./redis/redis.service.js";
+
+function extractToken(socket: Socket): string | undefined {
+  const queryToken = socket.handshake.query.token;
+  if (typeof queryToken === "string") {
+    return queryToken;
+  }
+  if (Array.isArray(queryToken) && queryToken[0]) {
+    return queryToken[0];
+  }
+  return undefined;
+}
 
 @WebSocketGateway({
   namespace: "/game",
@@ -12,12 +30,56 @@ import { resolveCorsOrigins } from "./cors.js";
     origin: resolveCorsOrigins(),
   },
 })
-export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
-  handleConnection(client: Socket) {
-    console.log(`[game-service] socket connected ${client.id}`);
+export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server!: Server;
+
+  constructor(
+    private readonly wsAuthService: WsAuthService,
+    private readonly redisService: RedisService,
+    private readonly logger: Logger,
+  ) {}
+
+  afterInit(server: Server): void {
+    server.use(async (socket, next) => {
+      try {
+        const auth = await this.wsAuthService.verifyToken(extractToken(socket));
+        socket.data.userId = auth.userId;
+        socket.data.displayName = auth.displayName;
+        socket.data.jti = auth.jti;
+        next();
+      } catch (error) {
+        if (error instanceof WsAuthError) {
+          const err = new Error(error.message) as Error & { data: { code: number } };
+          err.data = { code: error.code };
+          return next(err);
+        }
+
+        const err = new Error("INVALID_TOKEN") as Error & { data: { code: number } };
+        err.data = { code: WS_AUTH_INVALID_TOKEN_CODE };
+        next(err);
+      }
+    });
   }
 
-  handleDisconnect(client: Socket) {
-    console.log(`[game-service] socket disconnected ${client.id}`);
+  async handleConnection(client: Socket): Promise<void> {
+    const userId = client.data.userId as string;
+    const displayName = client.data.displayName as string;
+
+    await this.redisService.setUserSocket(userId, client.id);
+    client.emit("connected", { userId, displayName });
+
+    const requestUrl = client.request.url ?? "";
+    this.logger.log(
+      { userId, socketId: client.id, url: scrubTokenFromUrl(requestUrl) },
+      "game socket connected",
+    );
+  }
+
+  async handleDisconnect(client: Socket): Promise<void> {
+    const userId = client.data.userId as string | undefined;
+    if (userId) {
+      await this.redisService.removeUserSocket(userId, client.id);
+    }
   }
 }

--- a/apps/game-service/src/logging/scrub-token.spec.ts
+++ b/apps/game-service/src/logging/scrub-token.spec.ts
@@ -1,0 +1,9 @@
+import { scrubTokenFromUrl } from "./scrub-token.js";
+
+describe("scrubTokenFromUrl", () => {
+  it("redacts token query values from websocket URLs", () => {
+    const url = "/game?token=super-secret-jwt&EIO=4";
+    expect(scrubTokenFromUrl(url)).toBe("/game?token=***&EIO=4");
+    expect(scrubTokenFromUrl(url)).not.toContain("super-secret-jwt");
+  });
+});

--- a/apps/game-service/src/logging/scrub-token.ts
+++ b/apps/game-service/src/logging/scrub-token.ts
@@ -1,0 +1,3 @@
+export function scrubTokenFromUrl(url: string): string {
+  return url.replace(/([?&]token=)[^&]*/gi, "$1***");
+}

--- a/apps/game-service/src/main.ts
+++ b/apps/game-service/src/main.ts
@@ -1,19 +1,32 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { config as dotenvConfig } from "dotenv";
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
+import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module.js";
 import { resolveCorsOrigins } from "./cors.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+dotenvConfig({ path: resolve(repoRoot, ".env") });
+
+process.env.JWT_PUBLIC_KEY_PATH = resolve(
+  repoRoot,
+  process.env.JWT_PUBLIC_KEY_PATH ?? "infra/keys/jwt-public.pem",
+);
 
 const DEFAULT_PORT = 3001;
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  // biome-ignore lint/correctness/useHookAtTopLevel: NestJS bootstrap, not React hooks
+  app.useLogger(app.get(Logger));
   app.enableCors({
     origin: resolveCorsOrigins(),
   });
 
   const port = Number(process.env.GAME_SERVICE_PORT ?? DEFAULT_PORT);
   await app.listen(port);
-  console.log(`[game-service] ready on port ${port}`);
 }
 
 void bootstrap();

--- a/apps/game-service/src/redis/redis.module.ts
+++ b/apps/game-service/src/redis/redis.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from "@nestjs/common";
+import { RedisService } from "./redis.service.js";
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/apps/game-service/src/redis/redis.service.spec.ts
+++ b/apps/game-service/src/redis/redis.service.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import Redis from "ioredis-mock";
+import { RedisService } from "./redis.service.js";
+
+describe("RedisService", () => {
+  let service: RedisService;
+  let client: InstanceType<typeof Redis>;
+
+  beforeEach(() => {
+    client = new Redis();
+    service = new RedisService({ url: "redis://localhost:6379" });
+    Object.assign(service, { client });
+  });
+
+  it("maps and reads a user socket", async () => {
+    await service.setUserSocket("user-1", "socket-a");
+
+    expect(await service.getUserSocket("user-1")).toBe("socket-a");
+  });
+
+  it("removes a user socket only when the stored socket id matches", async () => {
+    await service.setUserSocket("user-1", "socket-a");
+
+    await service.removeUserSocket("user-1", "socket-a");
+
+    expect(await service.getUserSocket("user-1")).toBeNull();
+  });
+
+  it("does not delete a newer socket mapping when an older socket disconnects", async () => {
+    await service.setUserSocket("user-1", "socket-a");
+    await service.setUserSocket("user-1", "socket-b");
+
+    await service.removeUserSocket("user-1", "socket-a");
+
+    expect(await service.getUserSocket("user-1")).toBe("socket-b");
+  });
+});

--- a/apps/game-service/src/redis/redis.service.ts
+++ b/apps/game-service/src/redis/redis.service.ts
@@ -4,6 +4,14 @@ import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
 
 const USER_SOCKET_TTL_SECONDS = 3600;
 
+const REMOVE_USER_SOCKET_IF_MATCH_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`;
+
 @Injectable()
 export class RedisService implements OnModuleInit, OnModuleDestroy {
   private client: Redis | null = null;
@@ -42,10 +50,7 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
 
   async removeUserSocket(userId: string, socketId: string): Promise<void> {
     const key = `ws:user:${userId}:socket`;
-    const current = await this.requireClient().get(key);
-    if (current === socketId) {
-      await this.requireClient().del(key);
-    }
+    await this.requireClient().eval(REMOVE_USER_SOCKET_IF_MATCH_SCRIPT, 1, key, socketId);
   }
 
   async getUserSocket(userId: string): Promise<string | null> {

--- a/apps/game-service/src/redis/redis.service.ts
+++ b/apps/game-service/src/redis/redis.service.ts
@@ -1,0 +1,61 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Redis } from "ioredis";
+import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
+
+const USER_SOCKET_TTL_SECONDS = 3600;
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private client: Redis | null = null;
+
+  constructor(@Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.client = new Redis(this.redisConfig.url);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.client?.quit();
+  }
+
+  async isAccessTokenRevoked(jti: string): Promise<boolean> {
+    const value = await this.requireClient().get(`blacklist:jwt:${jti}`);
+    return value === "1";
+  }
+
+  async revokeAccessToken(jti: string, ttlSeconds: number): Promise<void> {
+    await this.requireClient().set(`blacklist:jwt:${jti}`, "1", "EX", ttlSeconds);
+  }
+
+  async setUserSocket(userId: string, socketId: string): Promise<void> {
+    await this.requireClient().set(
+      `ws:user:${userId}:socket`,
+      socketId,
+      "EX",
+      USER_SOCKET_TTL_SECONDS,
+    );
+  }
+
+  async removeUserSocket(userId: string, socketId: string): Promise<void> {
+    const key = `ws:user:${userId}:socket`;
+    const current = await this.requireClient().get(key);
+    if (current === socketId) {
+      await this.requireClient().del(key);
+    }
+  }
+
+  async getUserSocket(userId: string): Promise<string | null> {
+    return (await this.requireClient().get(`ws:user:${userId}:socket`)) ?? null;
+  }
+
+  private requireClient(): Redis {
+    if (!this.client) {
+      throw new Error("Redis client is not connected");
+    }
+    return this.client;
+  }
+}

--- a/apps/game-service/src/testing/issue-test-access-token.ts
+++ b/apps/game-service/src/testing/issue-test-access-token.ts
@@ -1,0 +1,35 @@
+import { generateKeyPairSync } from "node:crypto";
+import { JwtService } from "@nestjs/jwt";
+import { v4 as uuidv4 } from "uuid";
+
+export const testJwtKeys = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+export async function issueTestAccessToken(input?: {
+  userId?: string;
+  displayName?: string;
+  jti?: string;
+  expiresIn?: number;
+}): Promise<string> {
+  const jwtService = new JwtService({
+    privateKey: testJwtKeys.privateKey,
+    publicKey: testJwtKeys.publicKey,
+    signOptions: { algorithm: "RS256" },
+  });
+
+  return jwtService.signAsync(
+    {
+      sub: input?.userId ?? "11111111-1111-1111-1111-111111111111",
+      role: "player",
+      jti: input?.jti ?? uuidv4(),
+      displayName: input?.displayName ?? "player1",
+    },
+    {
+      algorithm: "RS256",
+      expiresIn: input?.expiresIn ?? 60,
+    },
+  );
+}

--- a/apps/game-service/test/game-ws.e2e-spec.ts
+++ b/apps/game-service/test/game-ws.e2e-spec.ts
@@ -42,12 +42,12 @@ function waitForConnectError(socket: Socket): Promise<Error & { data?: { code?: 
 
 function waitForConnected(socket: Socket): Promise<ConnectedPayload> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("connected timeout")), 5_000);
-    socket.on("connected", (payload: ConnectedPayload) => {
+    const timeout = setTimeout(() => reject(new Error("connected timeout")), 10_000);
+    socket.once("connected", (payload: ConnectedPayload) => {
       clearTimeout(timeout);
       resolve(payload);
     });
-    socket.on("connect_error", (error) => {
+    socket.once("connect_error", (error) => {
       clearTimeout(timeout);
       reject(error);
     });
@@ -86,13 +86,14 @@ describe("Game WS auth (e2e)", () => {
       displayName: "Ace",
     });
     const socket = connectClient(port, token);
+    const connectedPromise = waitForConnected(socket);
 
     await new Promise<void>((resolve, reject) => {
-      socket.on("connect", () => resolve());
-      socket.on("connect_error", reject);
+      socket.once("connect", () => resolve());
+      socket.once("connect_error", reject);
     });
 
-    const payload = await waitForConnected(socket);
+    const payload = await connectedPromise;
     expect(payload).toEqual({ userId: "user-valid", displayName: "Ace" });
 
     const mappedSocketId = await redisService.getUserSocket("user-valid");

--- a/apps/game-service/test/game-ws.e2e-spec.ts
+++ b/apps/game-service/test/game-ws.e2e-spec.ts
@@ -1,0 +1,132 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { config } from "dotenv";
+import { io, type Socket } from "socket.io-client";
+import { AppModule } from "../src/app.module.js";
+import { JWT_CONFIG } from "../src/config/jwt.config.js";
+import { RedisService } from "../src/redis/redis.service.js";
+import { issueTestAccessToken, testJwtKeys } from "../src/testing/issue-test-access-token.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+process.env.JWT_PUBLIC_KEY = testJwtKeys.publicKey;
+process.env.REDIS_URL ??= "redis://localhost:6379";
+
+type ConnectedPayload = { userId: string; displayName: string };
+
+function connectClient(port: number, token?: string): Socket {
+  return io(`http://127.0.0.1:${port}/game`, {
+    transports: ["websocket"],
+    forceNew: true,
+    reconnection: false,
+    query: token ? { token } : {},
+  });
+}
+
+function waitForConnectError(socket: Socket): Promise<Error & { data?: { code?: number } }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("connect_error timeout")), 5_000);
+    socket.on("connect", () => {
+      clearTimeout(timeout);
+      reject(new Error("expected connect_error but socket connected"));
+    });
+    socket.on("connect_error", (error) => {
+      clearTimeout(timeout);
+      resolve(error as Error & { data?: { code?: number } });
+    });
+  });
+}
+
+function waitForConnected(socket: Socket): Promise<ConnectedPayload> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("connected timeout")), 5_000);
+    socket.on("connected", (payload: ConnectedPayload) => {
+      clearTimeout(timeout);
+      resolve(payload);
+    });
+    socket.on("connect_error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+describe("Game WS auth (e2e)", () => {
+  let app: INestApplication;
+  let port: number;
+  let redisService: RedisService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(JWT_CONFIG)
+      .useValue({ publicKey: testJwtKeys.publicKey })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0, "127.0.0.1");
+    port = app.getHttpServer().address().port as number;
+    redisService = app.get(RedisService);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("accepts a valid JWT and emits connected", async () => {
+    const token = await issueTestAccessToken({
+      userId: "user-valid",
+      displayName: "Ace",
+    });
+    const socket = connectClient(port, token);
+
+    await new Promise<void>((resolve, reject) => {
+      socket.on("connect", () => resolve());
+      socket.on("connect_error", reject);
+    });
+
+    const payload = await waitForConnected(socket);
+    expect(payload).toEqual({ userId: "user-valid", displayName: "Ace" });
+
+    const mappedSocketId = await redisService.getUserSocket("user-valid");
+    expect(mappedSocketId).toBe(socket.id);
+
+    socket.disconnect();
+  });
+
+  it("rejects connections without a token", async () => {
+    const socket = connectClient(port);
+    const error = await waitForConnectError(socket);
+    expect(error.message).toBe("INVALID_TOKEN");
+    expect(error.data?.code).toBe(4001);
+    socket.disconnect();
+  });
+
+  it("rejects expired tokens", async () => {
+    const token = await issueTestAccessToken({ expiresIn: -1 });
+    const socket = connectClient(port, token);
+    const error = await waitForConnectError(socket);
+    expect(error.message).toBe("INVALID_TOKEN");
+    expect(error.data?.code).toBe(4001);
+    socket.disconnect();
+  });
+
+  it("rejects blacklisted tokens", async () => {
+    const jti = "revoked-jti";
+    const token = await issueTestAccessToken({ jti });
+    await redisService.revokeAccessToken(jti, 60);
+
+    const socket = connectClient(port, token);
+    const error = await waitForConnectError(socket);
+    expect(error.message).toBe("TOKEN_REVOKED");
+    expect(error.data?.code).toBe(4003);
+    socket.disconnect();
+  });
+});

--- a/apps/game-service/tsconfig.e2e.json
+++ b/apps/game-service/tsconfig.e2e.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/apps/game-service/tsconfig.spec.json
+++ b/apps/game-service/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "scripts": {
     "dev": "pnpm --parallel --filter @chifoumi/api --filter @chifoumi/game-service --filter @chifoumi/job-runner --filter @chifoumi/front dev",
-    "biome:check": "biome check .",
-    "biome:fix": "biome check --write .",
+    "biome:check": "biome check apps packages .github biome.json lefthook.yml",
+    "biome:fix": "biome check --write apps packages .github biome.json lefthook.yml",
     "typecheck": "pnpm --filter @chifoumi/db typecheck && pnpm -r typecheck",
     "docs:openapi": "pnpm --filter @chifoumi/api docs:openapi",
     "lefthook:install": "lefthook install"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,12 +212,18 @@ importers:
       '@nestjs/testing':
         specifier: 11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/platform-express@11.1.21)
+      '@types/ioredis-mock':
+        specifier: ^8.2.7
+        version: 8.2.7(ioredis@5.11.1)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      ioredis-mock:
+        specifier: ^8.13.1
+        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1)
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@24.12.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@nestjs/core':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(@nestjs/websockets@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/jwt':
+        specifier: 11.0.0
+        version: 11.0.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/platform-express':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
@@ -178,6 +181,18 @@ importers:
       '@nestjs/websockets':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/platform-socket.io@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.4.2
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
+      nestjs-pino:
+        specifier: 4.2.0
+        version: 4.2.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.4.0)
+      pino-http:
+        specifier: 10.4.0
+        version: 10.4.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -187,10 +202,31 @@ importers:
       socket.io:
         specifier: ^4.8.3
         version: 4.8.3
+      uuid:
+        specifier: 11.0.5
+        version: 11.0.5
     devDependencies:
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
+      '@nestjs/testing':
+        specifier: 11.1.21
+        version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/platform-express@11.1.21)
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@24.12.4)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
+      ts-jest:
+        specifier: 29.2.5
+        version: 29.2.5(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.12.4))(typescript@5.7.3)
       tsx:
         specifier: ^4.22.2
         version: 4.22.2
@@ -1696,6 +1732,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  engine.io-client@6.6.5:
+    resolution: {integrity: sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==}
+
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
@@ -2941,6 +2980,10 @@ packages:
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
@@ -3262,6 +3305,22 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4732,6 +4791,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  engine.io-client@6.6.5:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.20.1
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   engine.io-parser@5.2.3: {}
 
   engine.io@6.6.7:
@@ -6183,6 +6254,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.5
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -6450,6 +6532,10 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@8.18.3: {}
+
+  ws@8.20.1: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- Add WebSocket authentication on the `/game` namespace: RS256 JWT verification via shared public key, Redis blacklist check, `connected { userId, displayName }` emission, and `ws:user:{userId}:socket` Redis mapping for multi-instance push.
- Reject invalid handshakes with Socket.io error codes `4001 INVALID_TOKEN` and `4003 TOKEN_REVOKED`; scrub JWT tokens from Pino logs (`token=***`).
- Embed `displayName` in API access JWTs so the game service can stay stateless without DB access.

## Test plan
- [x] `pnpm --filter @chifoumi/game-service test` (unit: WsAuthService, scrub-token)
- [x] `pnpm --filter @chifoumi/game-service test:e2e` (valid JWT, missing token, expired, blacklisted)
- [x] `pnpm --filter @chifoumi/api test -- --testPathPattern=auth.service|token.service`
- [x] `pnpm exec biome check apps/game-service apps/api/src/auth`
- [ ] Manual: connect with `ws://localhost:3001/game?token=<access>` after login and receive `connected`