### PR TITLE
feat(game-service): matchmaking worker with progressive ELO window (US-019)

### DIFF
--- a/apps/game-service/jest-e2e.config.cjs
+++ b/apps/game-service/jest-e2e.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
   testEnvironment: "node",
+  maxWorkers: 1,
   testTimeout: 15_000,
   roots: ["<rootDir>/test"],
   testRegex: ".*\\.e2e-spec\\.ts$",

--- a/apps/game-service/package.json
+++ b/apps/game-service/package.json
@@ -35,6 +35,7 @@
     "ioredis": "^5.11.1",
     "nestjs-pino": "4.2.0",
     "pino-http": "10.4.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "socket.io": "^4.8.3",

--- a/apps/game-service/src/app.module.ts
+++ b/apps/game-service/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from "./auth/auth.module.js";
 import { AppConfigModule } from "./config/config.module.js";
 import { GameGateway } from "./game.gateway.js";
 import { HealthModule } from "./health/health.module.js";
+import { MatchmakingModule } from "./matchmaking/matchmaking.module.js";
 import { RedisModule } from "./redis/redis.module.js";
 
 @Module({
@@ -17,6 +18,7 @@ import { RedisModule } from "./redis/redis.module.js";
     RedisModule,
     AuthModule,
     HealthModule,
+    MatchmakingModule,
   ],
   providers: [GameGateway],
 })

--- a/apps/game-service/src/game.gateway.ts
+++ b/apps/game-service/src/game.gateway.ts
@@ -11,6 +11,8 @@ import { WS_AUTH_INVALID_TOKEN_CODE, WsAuthError } from "./auth/ws-auth.error.js
 import { WsAuthService } from "./auth/ws-auth.service.js";
 import { resolveCorsOrigins } from "./cors.js";
 import { scrubTokenFromUrl } from "./logging/scrub-token.js";
+import { MatchmakingService } from "./matchmaking/matchmaking.service.js";
+import { MatchmakingEventsService } from "./matchmaking/matchmaking-events.service.js";
 import { RedisService } from "./redis/redis.service.js";
 
 function extractToken(socket: Socket): string | undefined {
@@ -37,10 +39,14 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   constructor(
     private readonly wsAuthService: WsAuthService,
     private readonly redisService: RedisService,
+    private readonly matchmakingService: MatchmakingService,
+    private readonly matchmakingEventsService: MatchmakingEventsService,
     private readonly logger: Logger,
   ) {}
 
   afterInit(server: Server): void {
+    this.matchmakingEventsService.setServer(server);
+
     server.use(async (socket, next) => {
       try {
         const auth = await this.wsAuthService.verifyToken(extractToken(socket));
@@ -79,6 +85,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   async handleDisconnect(client: Socket): Promise<void> {
     const userId = client.data.userId as string | undefined;
     if (userId) {
+      await this.matchmakingService.leaveQueue(userId);
       await this.redisService.removeUserSocket(userId, client.id);
     }
   }

--- a/apps/game-service/src/matchmaking/elo-window.spec.ts
+++ b/apps/game-service/src/matchmaking/elo-window.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "@jest/globals";
+import { getEloWindow, ratingsMatch } from "./elo-window.js";
+
+describe("getEloWindow", () => {
+  it("returns ±50 before 10 seconds", () => {
+    expect(getEloWindow(0)).toBe(50);
+    expect(getEloWindow(9_999)).toBe(50);
+  });
+
+  it("returns ±100 between 10 and 30 seconds", () => {
+    expect(getEloWindow(10_000)).toBe(100);
+    expect(getEloWindow(29_999)).toBe(100);
+  });
+
+  it("returns ±200 between 30 and 60 seconds", () => {
+    expect(getEloWindow(30_000)).toBe(200);
+    expect(getEloWindow(59_999)).toBe(200);
+  });
+
+  it("returns unlimited after 60 seconds", () => {
+    expect(getEloWindow(60_000)).toBe(Number.POSITIVE_INFINITY);
+    expect(getEloWindow(120_000)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("ratingsMatch", () => {
+  it("matches players within the wider window", () => {
+    expect(ratingsMatch(1000, 1040, 50, 50)).toBe(true);
+    expect(ratingsMatch(1000, 1060, 50, 50)).toBe(false);
+  });
+
+  it("uses the wider of two player windows", () => {
+    expect(ratingsMatch(1000, 1080, 50, 100)).toBe(true);
+    expect(ratingsMatch(1000, 1101, 50, 100)).toBe(false);
+  });
+
+  it("matches any ratings when a window is unlimited", () => {
+    expect(ratingsMatch(800, 1500, 50, Number.POSITIVE_INFINITY)).toBe(true);
+  });
+});

--- a/apps/game-service/src/matchmaking/elo-window.ts
+++ b/apps/game-service/src/matchmaking/elo-window.ts
@@ -1,0 +1,30 @@
+const TEN_SECONDS_MS = 10_000;
+const THIRTY_SECONDS_MS = 30_000;
+const SIXTY_SECONDS_MS = 60_000;
+
+export function getEloWindow(elapsedMs: number): number {
+  if (elapsedMs < TEN_SECONDS_MS) {
+    return 50;
+  }
+  if (elapsedMs < THIRTY_SECONDS_MS) {
+    return 100;
+  }
+  if (elapsedMs < SIXTY_SECONDS_MS) {
+    return 200;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export function ratingsMatch(
+  ratingA: number,
+  ratingB: number,
+  windowA: number,
+  windowB: number,
+): boolean {
+  const diff = Math.abs(ratingA - ratingB);
+  const allowedWindow = Math.max(windowA, windowB);
+  if (!Number.isFinite(allowedWindow)) {
+    return true;
+  }
+  return diff <= allowedWindow;
+}

--- a/apps/game-service/src/matchmaking/match-session.service.ts
+++ b/apps/game-service/src/matchmaking/match-session.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from "@nestjs/common";
+import { v4 as uuidv4 } from "uuid";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  MATCH_BY_USER_TTL_SECONDS,
+  MATCH_STATE_TTL_SECONDS,
+  matchByUserKey,
+  matchStateKey,
+} from "./matchmaking.constants.js";
+
+export type MatchPlayer = {
+  userId: string;
+  displayName: string;
+  rating: number;
+};
+
+export type MatchState = {
+  matchId: string;
+  players: [MatchPlayer, MatchPlayer];
+  scoreA: number;
+  scoreB: number;
+  currentRound: number;
+  status: "WAITING_PLAYS";
+  startedAt: string;
+};
+
+@Injectable()
+export class MatchSessionService {
+  constructor(private readonly redisService: RedisService) {}
+
+  buildMatchState(playerA: MatchPlayer, playerB: MatchPlayer, matchId = uuidv4()): MatchState {
+    return {
+      matchId,
+      players: [playerA, playerB],
+      scoreA: 0,
+      scoreB: 0,
+      currentRound: 1,
+      status: "WAITING_PLAYS",
+      startedAt: new Date().toISOString(),
+    };
+  }
+
+  async persistMatchState(state: MatchState): Promise<void> {
+    await this.redisService.setex(
+      matchStateKey(state.matchId),
+      MATCH_STATE_TTL_SECONDS,
+      JSON.stringify(state),
+    );
+    await this.redisService.setex(
+      matchByUserKey(state.players[0].userId),
+      MATCH_BY_USER_TTL_SECONDS,
+      state.matchId,
+    );
+    await this.redisService.setex(
+      matchByUserKey(state.players[1].userId),
+      MATCH_BY_USER_TTL_SECONDS,
+      state.matchId,
+    );
+  }
+
+  async getMatchState(matchId: string): Promise<MatchState | null> {
+    const raw = await this.redisService.get(matchStateKey(matchId));
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as MatchState;
+  }
+}

--- a/apps/game-service/src/matchmaking/matchmaking-events.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-events.service.ts
@@ -20,16 +20,23 @@ export class MatchmakingEventsService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
-    this.subscriber = await this.redisService.subscribe(
-      MATCHMAKING_MATCH_FOUND_CHANNEL,
-      (message) => {
+    this.subscriber = this.redisService.createSubscriber();
+    await this.subscriber.subscribe(MATCHMAKING_MATCH_FOUND_CHANNEL);
+    this.subscriber.on("message", (channel, message) => {
+      if (channel === MATCHMAKING_MATCH_FOUND_CHANNEL) {
         this.handleMatchFoundMessage(message);
-      },
-    );
+      }
+    });
   }
 
   async onModuleDestroy(): Promise<void> {
-    await this.subscriber?.quit();
+    if (!this.subscriber) {
+      return;
+    }
+
+    const subscriber = this.subscriber;
+    this.subscriber = null;
+    await subscriber.quit().catch(() => undefined);
   }
 
   private handleMatchFoundMessage(message: string): void {

--- a/apps/game-service/src/matchmaking/matchmaking-events.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-events.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import type { Redis } from "ioredis";
+import type { Server } from "socket.io";
+import { RedisService } from "../redis/redis.service.js";
+import { MATCHMAKING_MATCH_FOUND_CHANNEL, type MatchFoundEvent } from "./matchmaking.constants.js";
+
+@Injectable()
+export class MatchmakingEventsService implements OnModuleInit, OnModuleDestroy {
+  private server: Server | null = null;
+  private subscriber: Redis | null = null;
+
+  constructor(private readonly redisService: RedisService) {}
+
+  setServer(server: Server): void {
+    this.server = server;
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.subscriber = await this.redisService.subscribe(
+      MATCHMAKING_MATCH_FOUND_CHANNEL,
+      (message) => {
+        this.handleMatchFoundMessage(message);
+      },
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.subscriber?.quit();
+  }
+
+  private handleMatchFoundMessage(message: string): void {
+    if (!this.server) {
+      return;
+    }
+
+    let event: MatchFoundEvent;
+    try {
+      event = JSON.parse(message) as MatchFoundEvent;
+    } catch {
+      return;
+    }
+
+    void this.emitMatchFound(event);
+  }
+
+  private async emitMatchFound(event: MatchFoundEvent): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    const socketId = await this.redisService.getUserSocket(event.userId);
+    if (!socketId) {
+      return;
+    }
+
+    this.server.to(socketId).emit("matchFound", event.payload);
+  }
+}

--- a/apps/game-service/src/matchmaking/matchmaking-metrics.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-metrics.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@nestjs/common";
+import { collectDefaultMetrics, Gauge, Histogram, Registry } from "prom-client";
+
+@Injectable()
+export class MatchmakingMetricsService {
+  readonly registry = new Registry();
+  readonly queueSize: Gauge<string>;
+  readonly matchDurationSeconds: Histogram<string>;
+
+  constructor() {
+    collectDefaultMetrics({ register: this.registry });
+
+    this.queueSize = new Gauge({
+      name: "matchmaking_queue_size",
+      help: "Current number of players waiting in the matchmaking queue",
+      registers: [this.registry],
+    });
+
+    this.matchDurationSeconds = new Histogram({
+      name: "matchmaking_match_duration_seconds",
+      help: "Time elapsed between joinQueue and matchFound",
+      buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+      registers: [this.registry],
+    });
+  }
+
+  setQueueSize(size: number): void {
+    this.queueSize.set(size);
+  }
+
+  observeMatchDuration(queuedAt: number, matchedAt: number): void {
+    const elapsedSeconds = (matchedAt - queuedAt) / 1000;
+    this.matchDurationSeconds.observe(elapsedSeconds);
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Logger } from "nestjs-pino";
+import { v4 as uuidv4 } from "uuid";
+import { RedisService } from "../redis/redis.service.js";
+import { getEloWindow, ratingsMatch } from "./elo-window.js";
+import { MatchSessionService } from "./match-session.service.js";
+import {
+  BEST_OF,
+  MATCHMAKING_MATCH_FOUND_CHANNEL,
+  MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
+  MATCHMAKING_QUEUE_KEY,
+  MATCHMAKING_WORKER_INTERVAL_MS,
+  type MatchFoundEvent,
+  matchmakingPairLockKey,
+  type QueueMemberMeta,
+} from "./matchmaking.constants.js";
+import { MatchmakingService } from "./matchmaking.service.js";
+import { MatchmakingMetricsService } from "./matchmaking-metrics.service.js";
+
+const PAIR_PLAYERS_SCRIPT = `
+local queueKey = KEYS[1]
+local metaPrefix = ARGV[1]
+local pairLockKey = ARGV[2]
+local matchId = ARGV[3]
+local userA = ARGV[4]
+local userB = ARGV[5]
+local matchByUserPrefix = ARGV[6]
+local matchStateKey = ARGV[7]
+local matchStateJson = ARGV[8]
+local matchTtl = tonumber(ARGV[9])
+
+if redis.call("EXISTS", pairLockKey) == 0 then
+  return 0
+end
+
+if redis.call("ZSCORE", queueKey, userA) == false or redis.call("ZSCORE", queueKey, userB) == false then
+  redis.call("DEL", pairLockKey)
+  return 0
+end
+
+redis.call("ZREM", queueKey, userA, userB)
+redis.call("DEL", metaPrefix .. userA, metaPrefix .. userB)
+redis.call("SETEX", matchByUserPrefix .. userA, matchTtl, matchId)
+redis.call("SETEX", matchByUserPrefix .. userB, matchTtl, matchId)
+redis.call("SETEX", matchStateKey, matchTtl, matchStateJson)
+redis.call("DEL", pairLockKey)
+
+return 1
+`;
+
+@Injectable()
+export class MatchmakingWorkerService implements OnModuleInit, OnModuleDestroy {
+  private interval: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly matchmakingService: MatchmakingService,
+    private readonly matchSessionService: MatchSessionService,
+    private readonly metricsService: MatchmakingMetricsService,
+    private readonly logger: Logger,
+  ) {}
+
+  onModuleInit(): void {
+    if (process.env.MATCHMAKING_WORKER_ENABLED === "false") {
+      return;
+    }
+
+    this.interval = setInterval(() => {
+      void this.tick();
+    }, MATCHMAKING_WORKER_INTERVAL_MS);
+    this.interval.unref();
+  }
+
+  onModuleDestroy(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+
+  async tick(now = Date.now()): Promise<number> {
+    if (this.running) {
+      return 0;
+    }
+
+    this.running = true;
+    try {
+      const queueSize = await this.matchmakingService.getQueueSize();
+      this.metricsService.setQueueSize(queueSize);
+
+      if (queueSize < 2) {
+        return 0;
+      }
+
+      const members = await this.matchmakingService.listQueueMembers();
+      let matchesCreated = 0;
+
+      for (const candidate of members) {
+        const opponent = this.findOpponent(candidate, members, now);
+        if (!opponent) {
+          continue;
+        }
+
+        const paired = await this.tryPairPlayers(candidate, opponent, now);
+        if (paired) {
+          matchesCreated += 1;
+        }
+      }
+
+      return matchesCreated;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  findOpponent(
+    player: QueueMemberMeta,
+    members: QueueMemberMeta[],
+    now: number,
+  ): QueueMemberMeta | null {
+    const playerWindow = getEloWindow(now - player.queuedAt);
+
+    for (const candidate of members) {
+      if (candidate.userId === player.userId) {
+        continue;
+      }
+
+      const candidateWindow = getEloWindow(now - candidate.queuedAt);
+      if (ratingsMatch(player.rating, candidate.rating, playerWindow, candidateWindow)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  private async tryPairPlayers(
+    playerA: QueueMemberMeta,
+    playerB: QueueMemberMeta,
+    now: number,
+  ): Promise<boolean> {
+    const pairLockKey = matchmakingPairLockKey(playerA.userId, playerB.userId);
+    const lockAcquired = await this.redisService.setnx(
+      pairLockKey,
+      MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
+    );
+    if (!lockAcquired) {
+      return false;
+    }
+
+    const matchId = uuidv4();
+    const matchState = this.matchSessionService.buildMatchState(
+      {
+        userId: playerA.userId,
+        displayName: playerA.displayName,
+        rating: playerA.rating,
+      },
+      {
+        userId: playerB.userId,
+        displayName: playerB.displayName,
+        rating: playerB.rating,
+      },
+      matchId,
+    );
+
+    const committed = await this.redisService.evalScript<number>(
+      PAIR_PLAYERS_SCRIPT,
+      [MATCHMAKING_QUEUE_KEY],
+      [
+        "matchmaking:meta:",
+        pairLockKey,
+        matchId,
+        playerA.userId,
+        playerB.userId,
+        "match:byUser:",
+        `match:${matchId}:state`,
+        JSON.stringify(matchState),
+        String(3600),
+      ],
+    );
+
+    if (committed !== 1) {
+      return false;
+    }
+
+    this.metricsService.observeMatchDuration(playerA.queuedAt, now);
+    this.metricsService.observeMatchDuration(playerB.queuedAt, now);
+
+    await this.publishMatchFound(playerA, playerB, matchId);
+    await this.publishMatchFound(playerB, playerA, matchId);
+
+    this.logger.log(
+      { matchId, playerA: playerA.userId, playerB: playerB.userId },
+      "matchmaking pair created",
+    );
+
+    return true;
+  }
+
+  private async publishMatchFound(
+    player: QueueMemberMeta,
+    opponent: QueueMemberMeta,
+    matchId: string,
+  ): Promise<void> {
+    const event: MatchFoundEvent = {
+      userId: player.userId,
+      queuedAt: player.queuedAt,
+      payload: {
+        matchId,
+        opponent: {
+          displayName: opponent.displayName,
+          rating: opponent.rating,
+        },
+        bestOf: BEST_OF,
+      },
+    };
+
+    await this.redisService.publish(MATCHMAKING_MATCH_FOUND_CHANNEL, JSON.stringify(event));
+  }
+}

--- a/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
@@ -93,16 +93,23 @@ export class MatchmakingWorkerService implements OnModuleInit, OnModuleDestroy {
       }
 
       const members = await this.matchmakingService.listQueueMembers();
+      const pairedUserIds = new Set<string>();
       let matchesCreated = 0;
 
       for (const candidate of members) {
-        const opponent = this.findOpponent(candidate, members, now);
+        if (pairedUserIds.has(candidate.userId)) {
+          continue;
+        }
+
+        const opponent = this.findOpponent(candidate, members, now, pairedUserIds);
         if (!opponent) {
           continue;
         }
 
         const paired = await this.tryPairPlayers(candidate, opponent, now);
         if (paired) {
+          pairedUserIds.add(candidate.userId);
+          pairedUserIds.add(opponent.userId);
           matchesCreated += 1;
         }
       }
@@ -117,11 +124,16 @@ export class MatchmakingWorkerService implements OnModuleInit, OnModuleDestroy {
     player: QueueMemberMeta,
     members: QueueMemberMeta[],
     now: number,
+    pairedUserIds: ReadonlySet<string> = new Set(),
   ): QueueMemberMeta | null {
     const playerWindow = getEloWindow(now - player.queuedAt);
 
     for (const candidate of members) {
       if (candidate.userId === player.userId) {
+        continue;
+      }
+
+      if (pairedUserIds.has(candidate.userId)) {
         continue;
       }
 

--- a/apps/game-service/src/matchmaking/matchmaking-worker.spec.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.spec.ts
@@ -94,6 +94,23 @@ describe("MatchmakingWorkerService", () => {
     expect(matches).toBe(1);
   });
 
+  it("pairs multiple compatible groups in a single tick", async () => {
+    const now = Date.now();
+    await seedQueueMember(client, "player-a", 1000, "Ace", now);
+    await seedQueueMember(client, "player-b", 1020, "Bob", now);
+    await seedQueueMember(client, "player-c", 1040, "Cara", now);
+    await seedQueueMember(client, "player-d", 1060, "Dan", now);
+
+    const matches = await worker.tick(now + 100);
+
+    expect(matches).toBe(2);
+    expect(await client.zcard(MATCHMAKING_QUEUE_KEY)).toBe(0);
+    expect(await client.get(matchByUserKey("player-a"))).not.toBeNull();
+    expect(await client.get(matchByUserKey("player-b"))).not.toBeNull();
+    expect(await client.get(matchByUserKey("player-c"))).not.toBeNull();
+    expect(await client.get(matchByUserKey("player-d"))).not.toBeNull();
+  });
+
   it("allows only one worker to commit the same pair", async () => {
     const now = Date.now();
     await seedQueueMember(client, "player-a", 1000, "Ace", now);

--- a/apps/game-service/src/matchmaking/matchmaking-worker.spec.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.spec.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import Redis from "ioredis-mock";
+import { Logger } from "nestjs-pino";
+import { RedisService } from "../redis/redis.service.js";
+import { MatchSessionService } from "./match-session.service.js";
+import {
+  MATCHMAKING_QUEUE_KEY,
+  matchByUserKey,
+  matchmakingMetaKey,
+  matchmakingPairLockKey,
+  USER_RATING_PREFIX,
+} from "./matchmaking.constants.js";
+import { MatchmakingService } from "./matchmaking.service.js";
+import { MatchmakingMetricsService } from "./matchmaking-metrics.service.js";
+import { MatchmakingWorkerService } from "./matchmaking-worker.service.js";
+import { RatingService } from "./rating.service.js";
+
+function createWorker(redisService: RedisService): MatchmakingWorkerService {
+  const ratingService = new RatingService(redisService);
+  const matchmakingService = new MatchmakingService(redisService, ratingService);
+  const matchSessionService = new MatchSessionService(redisService);
+  const metricsService = new MatchmakingMetricsService();
+  const logger = { log: jest.fn() } as unknown as Logger;
+
+  return new MatchmakingWorkerService(
+    redisService,
+    matchmakingService,
+    matchSessionService,
+    metricsService,
+    logger,
+  );
+}
+
+async function seedQueueMember(
+  client: InstanceType<typeof Redis>,
+  userId: string,
+  rating: number,
+  displayName: string,
+  queuedAt: number,
+): Promise<void> {
+  await client.set(`${USER_RATING_PREFIX}${userId}`, String(rating));
+  await client.zadd(MATCHMAKING_QUEUE_KEY, rating, userId);
+  await client.hset(matchmakingMetaKey(userId), {
+    userId,
+    rating: String(rating),
+    displayName,
+    queuedAt: String(queuedAt),
+  });
+}
+
+describe("MatchmakingWorkerService", () => {
+  let client: InstanceType<typeof Redis>;
+  let redisService: RedisService;
+  let worker: MatchmakingWorkerService;
+
+  beforeEach(() => {
+    client = new Redis(`redis://matchmaking-worker-test/${Date.now()}-${Math.random()}`);
+    redisService = new RedisService({ url: "redis://localhost:6379" });
+    Object.assign(redisService, { client });
+    worker = createWorker(redisService);
+  });
+
+  it("pairs players within the initial ±50 rating window", async () => {
+    const now = Date.now();
+    await seedQueueMember(client, "player-a", 1000, "Ace", now);
+    await seedQueueMember(client, "player-b", 1040, "Bob", now);
+
+    const matches = await worker.tick(now + 100);
+
+    expect(matches).toBe(1);
+    expect(await client.zcard(MATCHMAKING_QUEUE_KEY)).toBe(0);
+    expect(await client.get(matchByUserKey("player-a"))).not.toBeNull();
+    expect(await client.get(matchByUserKey("player-b"))).not.toBeNull();
+  });
+
+  it("does not pair players outside the current ELO window", async () => {
+    const now = Date.now();
+    await seedQueueMember(client, "player-a", 1000, "Ace", now);
+    await seedQueueMember(client, "player-b", 1100, "Bob", now);
+
+    const matches = await worker.tick(now + 100);
+
+    expect(matches).toBe(0);
+    expect(await client.zcard(MATCHMAKING_QUEUE_KEY)).toBe(2);
+  });
+
+  it("widens the ELO window after 10 seconds", async () => {
+    const now = Date.now();
+    await seedQueueMember(client, "player-a", 1000, "Ace", now);
+    await seedQueueMember(client, "player-b", 1090, "Bob", now);
+
+    const matches = await worker.tick(now + 10_500);
+
+    expect(matches).toBe(1);
+  });
+
+  it("allows only one worker to commit the same pair", async () => {
+    const now = Date.now();
+    await seedQueueMember(client, "player-a", 1000, "Ace", now);
+    await seedQueueMember(client, "player-b", 1020, "Bob", now);
+
+    const workerB = createWorker(redisService);
+    const [first, second] = await Promise.all([worker.tick(now + 100), workerB.tick(now + 100)]);
+
+    expect(first + second).toBe(1);
+    expect(await client.zcard(MATCHMAKING_QUEUE_KEY)).toBe(0);
+    expect(await client.exists(matchmakingPairLockKey("player-a", "player-b"))).toBe(0);
+  });
+});

--- a/apps/game-service/src/matchmaking/matchmaking.constants.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.constants.ts
@@ -1,0 +1,55 @@
+export const MATCHMAKING_QUEUE_KEY = "matchmaking:queue";
+export const MATCHMAKING_META_PREFIX = "matchmaking:meta:";
+export const MATCHMAKING_LOCK_PREFIX = "matchmaking:lock:";
+export const MATCHMAKING_RATE_PREFIX = "matchmaking:rate:";
+export const MATCH_BY_USER_PREFIX = "match:byUser:";
+export const MATCHMAKING_PAIR_LOCK_PREFIX = "matchmaking:pair-lock:";
+export const USER_RATING_PREFIX = "user:rating:";
+export const MATCH_STATE_PREFIX = "match:";
+export const MATCH_STATE_SUFFIX = ":state";
+export const MATCHMAKING_MATCH_FOUND_CHANNEL = "matchmaking:match-found";
+
+export const MATCHMAKING_LOCK_TTL_SECONDS = 5;
+export const MATCHMAKING_PAIR_LOCK_TTL_SECONDS = 5;
+export const MATCH_BY_USER_TTL_SECONDS = 3600;
+export const MATCH_STATE_TTL_SECONDS = 3600;
+export const MATCHMAKING_RATE_LIMIT_TTL_SECONDS = 1;
+export const MATCHMAKING_WORKER_INTERVAL_MS = 500;
+export const DEFAULT_RATING = 1000;
+export const BEST_OF = 3;
+
+export type QueueMemberMeta = {
+  userId: string;
+  rating: number;
+  displayName: string;
+  queuedAt: number;
+};
+
+export type MatchFoundPayload = {
+  matchId: string;
+  opponent: { displayName: string; rating: number };
+  bestOf: number;
+};
+
+export type MatchFoundEvent = {
+  userId: string;
+  payload: MatchFoundPayload;
+  queuedAt: number;
+};
+
+export function matchmakingMetaKey(userId: string): string {
+  return `${MATCHMAKING_META_PREFIX}${userId}`;
+}
+
+export function matchByUserKey(userId: string): string {
+  return `${MATCH_BY_USER_PREFIX}${userId}`;
+}
+
+export function matchmakingPairLockKey(userA: string, userB: string): string {
+  const [first, second] = userA < userB ? [userA, userB] : [userB, userA];
+  return `${MATCHMAKING_PAIR_LOCK_PREFIX}${first}:${second}`;
+}
+
+export function matchStateKey(matchId: string): string {
+  return `${MATCH_STATE_PREFIX}${matchId}${MATCH_STATE_SUFFIX}`;
+}

--- a/apps/game-service/src/matchmaking/matchmaking.gateway.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.gateway.ts
@@ -1,0 +1,38 @@
+import { ConnectedSocket, SubscribeMessage, WebSocketGateway } from "@nestjs/websockets";
+import type { Socket } from "socket.io";
+import { resolveCorsOrigins } from "../cors.js";
+import { MatchmakingService } from "./matchmaking.service.js";
+
+@WebSocketGateway({
+  namespace: "/game",
+  cors: {
+    origin: resolveCorsOrigins(),
+  },
+})
+export class MatchmakingGateway {
+  constructor(private readonly matchmakingService: MatchmakingService) {}
+
+  @SubscribeMessage("joinQueue")
+  async handleJoinQueue(@ConnectedSocket() client: Socket): Promise<void> {
+    const userId = client.data.userId as string;
+    const displayName = client.data.displayName as string;
+
+    const result = await this.matchmakingService.joinQueue(userId, displayName);
+    if (!result.ok) {
+      client.emit("error", { code: result.code, message: result.code });
+      return;
+    }
+
+    client.emit("queueJoined", {
+      queuedAt: new Date(result.queuedAt).toISOString(),
+      currentRating: result.currentRating,
+    });
+  }
+
+  @SubscribeMessage("leaveQueue")
+  async handleLeaveQueue(@ConnectedSocket() client: Socket): Promise<void> {
+    const userId = client.data.userId as string;
+    await this.matchmakingService.leaveQueue(userId);
+    client.emit("queueLeft", {});
+  }
+}

--- a/apps/game-service/src/matchmaking/matchmaking.module.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.module.ts
@@ -1,0 +1,26 @@
+import { Module } from "@nestjs/common";
+import { MetricsController } from "../metrics/metrics.controller.js";
+import { RedisModule } from "../redis/redis.module.js";
+import { MatchSessionService } from "./match-session.service.js";
+import { MatchmakingGateway } from "./matchmaking.gateway.js";
+import { MatchmakingService } from "./matchmaking.service.js";
+import { MatchmakingEventsService } from "./matchmaking-events.service.js";
+import { MatchmakingMetricsService } from "./matchmaking-metrics.service.js";
+import { MatchmakingWorkerService } from "./matchmaking-worker.service.js";
+import { RatingService } from "./rating.service.js";
+
+@Module({
+  imports: [RedisModule],
+  controllers: [MetricsController],
+  providers: [
+    RatingService,
+    MatchmakingService,
+    MatchSessionService,
+    MatchmakingWorkerService,
+    MatchmakingEventsService,
+    MatchmakingMetricsService,
+    MatchmakingGateway,
+  ],
+  exports: [MatchmakingService, MatchmakingEventsService, MatchmakingMetricsService],
+})
+export class MatchmakingModule {}

--- a/apps/game-service/src/matchmaking/matchmaking.service.spec.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.service.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import Redis from "ioredis-mock";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  MATCHMAKING_QUEUE_KEY,
+  matchByUserKey,
+  matchmakingMetaKey,
+} from "./matchmaking.constants.js";
+import { MatchmakingService } from "./matchmaking.service.js";
+import { RatingService } from "./rating.service.js";
+
+describe("MatchmakingService", () => {
+  let client: InstanceType<typeof Redis>;
+  let service: MatchmakingService;
+
+  beforeEach(() => {
+    client = new Redis(`redis://matchmaking-service-test/${Date.now()}-${Math.random()}`);
+    const redisService = new RedisService({ url: "redis://localhost:6379" });
+    Object.assign(redisService, { client });
+    service = new MatchmakingService(redisService, new RatingService(redisService));
+  });
+
+  it("enqueues a player and returns queue metadata", async () => {
+    const result = await service.joinQueue("user-enqueue", "Ace");
+
+    expect(result).toEqual({
+      ok: true,
+      queuedAt: expect.any(Number),
+      currentRating: 1000,
+    });
+    expect(await client.zscore(MATCHMAKING_QUEUE_KEY, "user-enqueue")).toBe("1000");
+    expect(await client.hget(matchmakingMetaKey("user-enqueue"), "displayName")).toBe("Ace");
+  });
+
+  it("rejects duplicate joinQueue with ALREADY_IN_QUEUE", async () => {
+    await service.joinQueue("user-dup", "Ace");
+    const result = await service.joinQueue("user-dup", "Ace");
+
+    expect(result).toEqual({ ok: false, code: "ALREADY_IN_QUEUE" });
+  });
+
+  it("rejects joinQueue when the player is already in a match", async () => {
+    await client.set(matchByUserKey("user-in-match"), "match-123");
+
+    const result = await service.joinQueue("user-in-match", "Ace");
+
+    expect(result).toEqual({ ok: false, code: "ALREADY_IN_MATCH" });
+  });
+
+  it("rate limits joinQueue to one call per second", async () => {
+    const first = await service.joinQueue("user-rate", "Ace");
+    expect(first).toEqual({
+      ok: true,
+      queuedAt: expect.any(Number),
+      currentRating: 1000,
+    });
+    await service.leaveQueue("user-rate");
+
+    const second = await service.joinQueue("user-rate", "Ace");
+    expect(second).toEqual({ ok: false, code: "RATE_LIMITED" });
+  });
+
+  it("removes a player from the queue on leaveQueue", async () => {
+    const joined = await service.joinQueue("user-leave", "Ace");
+    expect(joined.ok).toBe(true);
+
+    const removed = await service.leaveQueue("user-leave");
+
+    expect(removed).toBe(true);
+    expect(await client.zscore(MATCHMAKING_QUEUE_KEY, "user-leave")).toBeNull();
+  });
+});

--- a/apps/game-service/src/matchmaking/matchmaking.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.service.ts
@@ -1,0 +1,121 @@
+import { Injectable } from "@nestjs/common";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  MATCH_BY_USER_PREFIX,
+  MATCHMAKING_LOCK_PREFIX,
+  MATCHMAKING_LOCK_TTL_SECONDS,
+  MATCHMAKING_QUEUE_KEY,
+  MATCHMAKING_RATE_LIMIT_TTL_SECONDS,
+  MATCHMAKING_RATE_PREFIX,
+  matchByUserKey,
+  matchmakingMetaKey,
+  type QueueMemberMeta,
+} from "./matchmaking.constants.js";
+import { RatingService } from "./rating.service.js";
+
+export type JoinQueueResult =
+  | { ok: true; queuedAt: number; currentRating: number }
+  | { ok: false; code: "ALREADY_IN_QUEUE" | "ALREADY_IN_MATCH" | "RATE_LIMITED" };
+
+@Injectable()
+export class MatchmakingService {
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly ratingService: RatingService,
+  ) {}
+
+  async joinQueue(userId: string, displayName: string): Promise<JoinQueueResult> {
+    const existingMatch = await this.redisService.get(matchByUserKey(userId));
+    if (existingMatch) {
+      return { ok: false, code: "ALREADY_IN_MATCH" };
+    }
+
+    const queueScore = await this.redisService.getClient().zscore(MATCHMAKING_QUEUE_KEY, userId);
+    if (queueScore !== null) {
+      return { ok: false, code: "ALREADY_IN_QUEUE" };
+    }
+
+    const rateCount = await this.redisService.incrWithExpiry(
+      `${MATCHMAKING_RATE_PREFIX}${userId}`,
+      MATCHMAKING_RATE_LIMIT_TTL_SECONDS,
+    );
+    if (rateCount > 1) {
+      return { ok: false, code: "RATE_LIMITED" };
+    }
+
+    const lockKey = `${MATCHMAKING_LOCK_PREFIX}${userId}`;
+    const lockAcquired = await this.redisService.setnx(lockKey, MATCHMAKING_LOCK_TTL_SECONDS);
+    if (!lockAcquired) {
+      return { ok: false, code: "ALREADY_IN_QUEUE" };
+    }
+
+    try {
+      const queueScoreAfterLock = await this.redisService
+        .getClient()
+        .zscore(MATCHMAKING_QUEUE_KEY, userId);
+      if (queueScoreAfterLock !== null) {
+        return { ok: false, code: "ALREADY_IN_QUEUE" };
+      }
+
+      const rating = await this.ratingService.getRating(userId);
+      const queuedAt = Date.now();
+
+      await this.redisService.zadd(MATCHMAKING_QUEUE_KEY, rating, userId);
+      await this.redisService.hset(matchmakingMetaKey(userId), {
+        userId,
+        rating: String(rating),
+        displayName,
+        queuedAt: String(queuedAt),
+      });
+
+      return { ok: true, queuedAt, currentRating: rating };
+    } finally {
+      await this.redisService.del(lockKey);
+    }
+  }
+
+  async leaveQueue(userId: string): Promise<boolean> {
+    const removed = await this.redisService.getClient().zrem(MATCHMAKING_QUEUE_KEY, userId);
+    await this.redisService.del(matchmakingMetaKey(userId));
+    return Number(removed) > 0;
+  }
+
+  async isInQueue(userId: string): Promise<boolean> {
+    const score = await this.redisService.getClient().zscore(MATCHMAKING_QUEUE_KEY, userId);
+    return score !== null;
+  }
+
+  async isInMatch(userId: string): Promise<boolean> {
+    const matchId = await this.redisService.get(matchByUserKey(userId));
+    return matchId !== null;
+  }
+
+  async getQueueSize(): Promise<number> {
+    return this.redisService.zcard(MATCHMAKING_QUEUE_KEY);
+  }
+
+  async listQueueMembers(): Promise<QueueMemberMeta[]> {
+    const entries = await this.redisService.zrangeWithScores(MATCHMAKING_QUEUE_KEY);
+    const members: QueueMemberMeta[] = [];
+
+    for (const entry of entries) {
+      const meta = await this.redisService.hgetall(matchmakingMetaKey(entry.userId));
+      if (!meta.userId || !meta.displayName || !meta.queuedAt || !meta.rating) {
+        continue;
+      }
+
+      members.push({
+        userId: meta.userId,
+        displayName: meta.displayName,
+        rating: Number.parseInt(meta.rating, 10),
+        queuedAt: Number.parseInt(meta.queuedAt, 10),
+      });
+    }
+
+    return members.sort((left, right) => left.queuedAt - right.queuedAt);
+  }
+
+  async getMatchIdForUser(userId: string): Promise<string | null> {
+    return this.redisService.get(`${MATCH_BY_USER_PREFIX}${userId}`);
+  }
+}

--- a/apps/game-service/src/matchmaking/rating.service.ts
+++ b/apps/game-service/src/matchmaking/rating.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@nestjs/common";
+import { RedisService } from "../redis/redis.service.js";
+import { DEFAULT_RATING, USER_RATING_PREFIX } from "./matchmaking.constants.js";
+
+@Injectable()
+export class RatingService {
+  constructor(private readonly redisService: RedisService) {}
+
+  async getRating(userId: string): Promise<number> {
+    const stored = await this.redisService.get(`${USER_RATING_PREFIX}${userId}`);
+    if (!stored) {
+      return DEFAULT_RATING;
+    }
+
+    const rating = Number.parseInt(stored, 10);
+    return Number.isFinite(rating) ? rating : DEFAULT_RATING;
+  }
+}

--- a/apps/game-service/src/metrics/metrics.controller.ts
+++ b/apps/game-service/src/metrics/metrics.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Header } from "@nestjs/common";
+import { MatchmakingMetricsService } from "../matchmaking/matchmaking-metrics.service.js";
+
+@Controller("metrics")
+export class MetricsController {
+  constructor(private readonly matchmakingMetricsService: MatchmakingMetricsService) {}
+
+  @Get()
+  @Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+  async getMetrics(): Promise<string> {
+    return this.matchmakingMetricsService.getMetrics();
+  }
+}

--- a/apps/game-service/src/redis/redis.service.ts
+++ b/apps/game-service/src/redis/redis.service.ts
@@ -20,7 +20,6 @@ end
 @Injectable()
 export class RedisService implements OnModuleInit, OnModuleDestroy {
   private client: Redis | null = null;
-  private subscriber: Redis | null = null;
 
   constructor(@Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig) {}
 
@@ -33,8 +32,8 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleDestroy(): Promise<void> {
-    await this.subscriber?.quit();
     await this.client?.quit();
+    this.client = null;
   }
 
   getClient(): Redis {
@@ -112,18 +111,6 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
 
   async publish(channel: string, message: string): Promise<void> {
     await this.requireClient().publish(channel, message);
-  }
-
-  async subscribe(channel: string, listener: (message: string) => void): Promise<Redis> {
-    const subscriber = this.createSubscriber();
-    await subscriber.subscribe(channel);
-    subscriber.on("message", (receivedChannel, message) => {
-      if (receivedChannel === channel) {
-        listener(message);
-      }
-    });
-    this.subscriber = subscriber;
-    return subscriber;
   }
 
   async evalScript<T>(script: string, keys: string[], args: string[]): Promise<T> {

--- a/apps/game-service/src/redis/redis.service.ts
+++ b/apps/game-service/src/redis/redis.service.ts
@@ -4,6 +4,11 @@ import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
 
 const USER_SOCKET_TTL_SECONDS = 3600;
 
+export type RedisQueueEntry = {
+  userId: string;
+  rating: number;
+};
+
 const REMOVE_USER_SOCKET_IF_MATCH_SCRIPT = `
 if redis.call("GET", KEYS[1]) == ARGV[1] then
   return redis.call("DEL", KEYS[1])
@@ -15,6 +20,7 @@ end
 @Injectable()
 export class RedisService implements OnModuleInit, OnModuleDestroy {
   private client: Redis | null = null;
+  private subscriber: Redis | null = null;
 
   constructor(@Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig) {}
 
@@ -27,7 +33,101 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleDestroy(): Promise<void> {
+    await this.subscriber?.quit();
     await this.client?.quit();
+  }
+
+  getClient(): Redis {
+    return this.requireClient();
+  }
+
+  createSubscriber(): Redis {
+    return new Redis(this.redisConfig.url);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return (await this.requireClient().get(key)) ?? null;
+  }
+
+  async setex(key: string, ttlSeconds: number, value: string): Promise<void> {
+    await this.requireClient().setex(key, ttlSeconds, value);
+  }
+
+  async setnx(key: string, ttlSeconds: number, value = "1"): Promise<boolean> {
+    const result = await this.requireClient().set(key, value, "EX", ttlSeconds, "NX");
+    return result === "OK";
+  }
+
+  async del(key: string): Promise<void> {
+    await this.requireClient().del(key);
+  }
+
+  async hset(key: string, values: Record<string, string>): Promise<void> {
+    await this.requireClient().hset(key, values);
+  }
+
+  async hgetall(key: string): Promise<Record<string, string>> {
+    return this.requireClient().hgetall(key);
+  }
+
+  async zadd(key: string, score: number, member: string): Promise<void> {
+    await this.requireClient().zadd(key, score, member);
+  }
+
+  async zrem(key: string, member: string): Promise<void> {
+    await this.requireClient().zrem(key, member);
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.requireClient().zcard(key);
+  }
+
+  async zrangeWithScores(key: string): Promise<RedisQueueEntry[]> {
+    const entries = await this.requireClient().zrange(key, 0, -1, "WITHSCORES");
+    const result: RedisQueueEntry[] = [];
+
+    for (let index = 0; index < entries.length; index += 2) {
+      const userId = entries[index];
+      const rating = entries[index + 1];
+      if (userId && rating) {
+        result.push({ userId, rating: Number.parseFloat(rating) });
+      }
+    }
+
+    return result;
+  }
+
+  async zrangebyscore(key: string, min: number | string, max: number | string): Promise<string[]> {
+    return this.requireClient().zrangebyscore(key, min, max);
+  }
+
+  async incrWithExpiry(key: string, ttlSeconds: number): Promise<number> {
+    const client = this.requireClient();
+    const count = await client.incr(key);
+    if (count === 1) {
+      await client.expire(key, ttlSeconds);
+    }
+    return count;
+  }
+
+  async publish(channel: string, message: string): Promise<void> {
+    await this.requireClient().publish(channel, message);
+  }
+
+  async subscribe(channel: string, listener: (message: string) => void): Promise<Redis> {
+    const subscriber = this.createSubscriber();
+    await subscriber.subscribe(channel);
+    subscriber.on("message", (receivedChannel, message) => {
+      if (receivedChannel === channel) {
+        listener(message);
+      }
+    });
+    this.subscriber = subscriber;
+    return subscriber;
+  }
+
+  async evalScript<T>(script: string, keys: string[], args: string[]): Promise<T> {
+    return this.requireClient().eval(script, keys.length, ...keys, ...args) as Promise<T>;
   }
 
   async isAccessTokenRevoked(jti: string): Promise<boolean> {

--- a/apps/game-service/test/game-ws.e2e-spec.ts
+++ b/apps/game-service/test/game-ws.e2e-spec.ts
@@ -14,6 +14,7 @@ config({ path: resolve(repoRoot, ".env") });
 
 process.env.JWT_PUBLIC_KEY = testJwtKeys.publicKey;
 process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.MATCHMAKING_WORKER_ENABLED = "false";
 
 type ConnectedPayload = { userId: string; displayName: string };
 

--- a/apps/game-service/test/matchmaking.e2e-spec.ts
+++ b/apps/game-service/test/matchmaking.e2e-spec.ts
@@ -48,7 +48,7 @@ function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
 
 async function connectAndJoin(
   port: number,
-  input: { userId: string; displayName: string; rating: number },
+  input: { userId: string; displayName: string },
 ): Promise<{ socket: Socket; queueJoined: QueueJoinedPayload }> {
   const token = await issueTestAccessToken({
     userId: input.userId,
@@ -112,12 +112,10 @@ describe("Matchmaking (e2e)", () => {
     const playerA = await connectAndJoin(port, {
       userId: "player-a",
       displayName: "Ace",
-      rating: 1000,
     });
     const playerB = await connectAndJoin(port, {
       userId: "player-b",
       displayName: "Bob",
-      rating: 1040,
     });
 
     const matchFoundA = waitForEvent<MatchFoundPayload>(playerA.socket, "matchFound");

--- a/apps/game-service/test/matchmaking.e2e-spec.ts
+++ b/apps/game-service/test/matchmaking.e2e-spec.ts
@@ -1,0 +1,177 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { config } from "dotenv";
+import { io, type Socket } from "socket.io-client";
+import { AppModule } from "../src/app.module.js";
+import { JWT_CONFIG } from "../src/config/jwt.config.js";
+import { MATCHMAKING_WORKER_INTERVAL_MS } from "../src/matchmaking/matchmaking.constants.js";
+import { MatchmakingWorkerService } from "../src/matchmaking/matchmaking-worker.service.js";
+import { RedisService } from "../src/redis/redis.service.js";
+import { issueTestAccessToken, testJwtKeys } from "../src/testing/issue-test-access-token.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+process.env.JWT_PUBLIC_KEY = testJwtKeys.publicKey;
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.MATCHMAKING_WORKER_ENABLED = "false";
+
+type ConnectedPayload = { userId: string; displayName: string };
+type QueueJoinedPayload = { queuedAt: string; currentRating: number };
+type MatchFoundPayload = {
+  matchId: string;
+  opponent: { displayName: string; rating: number };
+  bestOf: number;
+};
+type ErrorPayload = { code: string; message: string };
+
+function connectClient(port: number, token: string): Socket {
+  return io(`http://127.0.0.1:${port}/game`, {
+    transports: ["websocket"],
+    forceNew: true,
+    reconnection: false,
+    query: { token },
+  });
+}
+
+function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${event} timeout`)), 10_000);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timeout);
+      resolvePromise(payload);
+    });
+  });
+}
+
+async function connectAndJoin(
+  port: number,
+  input: { userId: string; displayName: string; rating: number },
+): Promise<{ socket: Socket; queueJoined: QueueJoinedPayload }> {
+  const token = await issueTestAccessToken({
+    userId: input.userId,
+    displayName: input.displayName,
+  });
+  const socket = connectClient(port, token);
+
+  await new Promise<void>((resolvePromise, reject) => {
+    socket.once("connect", () => resolvePromise());
+    socket.once("connect_error", reject);
+  });
+
+  await waitForEvent<ConnectedPayload>(socket, "connected");
+  socket.emit("joinQueue", {});
+  const queueJoined = await waitForEvent<QueueJoinedPayload>(socket, "queueJoined");
+
+  return { socket, queueJoined };
+}
+
+describe("Matchmaking (e2e)", () => {
+  let app: INestApplication;
+  let port: number;
+  let redisService: RedisService;
+  let worker: MatchmakingWorkerService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(JWT_CONFIG)
+      .useValue({ publicKey: testJwtKeys.publicKey })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0, "127.0.0.1");
+    port = app.getHttpServer().address().port as number;
+    redisService = app.get(RedisService);
+    worker = app.get(MatchmakingWorkerService);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  beforeEach(async () => {
+    const client = redisService.getClient();
+    const keys = await client.keys("*");
+    if (keys.length > 0) {
+      await client.del(...keys);
+    }
+  });
+
+  it("pairs two players and emits matchFound", async () => {
+    await redisService.setex("user:rating:player-a", 60, "1000");
+    await redisService.setex("user:rating:player-b", 60, "1040");
+
+    const playerA = await connectAndJoin(port, {
+      userId: "player-a",
+      displayName: "Ace",
+      rating: 1000,
+    });
+    const playerB = await connectAndJoin(port, {
+      userId: "player-b",
+      displayName: "Bob",
+      rating: 1040,
+    });
+
+    const matchFoundA = waitForEvent<MatchFoundPayload>(playerA.socket, "matchFound");
+    const matchFoundB = waitForEvent<MatchFoundPayload>(playerB.socket, "matchFound");
+
+    const matches = await worker.tick();
+    expect(matches).toBe(1);
+
+    const payloadA = await matchFoundA;
+    const payloadB = await matchFoundB;
+
+    expect(payloadA.matchId).toBe(payloadB.matchId);
+    expect(payloadA.bestOf).toBe(3);
+    expect(payloadA.opponent).toEqual({ displayName: "Bob", rating: 1040 });
+    expect(payloadB.opponent).toEqual({ displayName: "Ace", rating: 1000 });
+
+    expect(await redisService.get("match:byUser:player-a")).toBe(payloadA.matchId);
+    expect(await redisService.get("match:byUser:player-b")).toBe(payloadA.matchId);
+    expect(await redisService.getClient().zcard("matchmaking:queue")).toBe(0);
+
+    playerA.socket.disconnect();
+    playerB.socket.disconnect();
+  });
+
+  it("rejects duplicate joinQueue with ALREADY_IN_QUEUE", async () => {
+    const token = await issueTestAccessToken({ userId: "dup-user", displayName: "Dup" });
+    const socket = connectClient(port, token);
+
+    await new Promise<void>((resolvePromise, reject) => {
+      socket.once("connect", () => resolvePromise());
+      socket.once("connect_error", reject);
+    });
+    await waitForEvent<ConnectedPayload>(socket, "connected");
+
+    socket.emit("joinQueue", {});
+    await waitForEvent<QueueJoinedPayload>(socket, "queueJoined");
+
+    const errorPromise = waitForEvent<ErrorPayload>(socket, "error");
+    socket.emit("joinQueue", {});
+    const error = await errorPromise;
+
+    expect(error.code).toBe("ALREADY_IN_QUEUE");
+    socket.disconnect();
+  });
+
+  it("exposes matchmaking prometheus metrics", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/metrics`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("matchmaking_queue_size");
+    expect(body).toContain("matchmaking_match_duration_seconds");
+  });
+
+  it("runs the worker on a 500ms interval when enabled", () => {
+    expect(MATCHMAKING_WORKER_INTERVAL_MS).toBe(500);
+  });
+});

--- a/apps/game-service/test/matchmaking.e2e-spec.ts
+++ b/apps/game-service/test/matchmaking.e2e-spec.ts
@@ -55,13 +55,14 @@ async function connectAndJoin(
     displayName: input.displayName,
   });
   const socket = connectClient(port, token);
+  const connectedPromise = waitForEvent<ConnectedPayload>(socket, "connected");
 
   await new Promise<void>((resolvePromise, reject) => {
     socket.once("connect", () => resolvePromise());
     socket.once("connect_error", reject);
   });
 
-  await waitForEvent<ConnectedPayload>(socket, "connected");
+  await connectedPromise;
   socket.emit("joinQueue", {});
   const queueJoined = await waitForEvent<QueueJoinedPayload>(socket, "queueJoined");
 
@@ -144,12 +145,13 @@ describe("Matchmaking (e2e)", () => {
   it("rejects duplicate joinQueue with ALREADY_IN_QUEUE", async () => {
     const token = await issueTestAccessToken({ userId: "dup-user", displayName: "Dup" });
     const socket = connectClient(port, token);
+    const connectedPromise = waitForEvent<ConnectedPayload>(socket, "connected");
 
     await new Promise<void>((resolvePromise, reject) => {
       socket.once("connect", () => resolvePromise());
       socket.once("connect_error", reject);
     });
-    await waitForEvent<ConnectedPayload>(socket, "connected");
+    await connectedPromise;
 
     socket.emit("joinQueue", {});
     await waitForEvent<QueueJoinedPayload>(socket, "queueJoined");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       pino-http:
         specifier: 10.4.0
         version: 10.4.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -956,6 +959,10 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
     hasBin: true
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
@@ -1454,6 +1461,9 @@ packages:
 
   better-result@2.9.2:
     resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -2794,6 +2804,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3099,6 +3113,9 @@ packages:
 
   swagger-ui-dist@5.18.2:
     resolution: {integrity: sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -4018,6 +4035,8 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.130.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
@@ -4540,6 +4559,8 @@ snapshots:
   baseline-browser-mapping@2.10.31: {}
 
   better-result@2.9.2: {}
+
+  bintrees@1.0.2: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -6043,6 +6064,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -6388,6 +6414,10 @@ snapshots:
   swagger-ui-dist@5.18.2:
     dependencies:
       '@scarf/scarf': 1.4.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   test-exclude@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Implement US-018 matchmaking queue: ``joinQueue`` / ``leaveQueue`` WS handlers with Redis sorted set, distributed locks, rate limiting, and disconnect cleanup.
- Implement US-019 matchmaking worker: 500ms loop, progressive ELO window (±50 → ±100 → ±200 → ±∞), distributed pair lock, match session bootstrap in Redis, and ``matchFound`` delivery via Redis pub/sub for multi-instance scale-out.
- Expose Prometheus metrics ``matchmaking_queue_size`` and ``matchmaking_match_duration_seconds`` on ``GET /metrics``.

## Dependencies
This branch is based on ``feature/us-017-game-ws-auth`` (US-017). Merge US-017 first or review both stories together.

## Test plan
- [x] Unit tests: ELO window tiers, queue service, worker pairing/concurrency, multi-pair per tick
- [x] E2E tests: two players matched with ``matchFound``, duplicate ``joinQueue`` error, metrics endpoint
- [x] CI green on latest commit