### PR TITLE
feat(job-runner): configure BullMQ workers via env vars (US-023)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ MAIL_PORT=1025
 # Prefix used by BullMQ queues to avoid collisions between environments.
 BULLMQ_PREFIX=rps
 
+# Job-runner worker configuration (comma-separated queue names).
+WORKER_QUEUES=match-events,notifications
+WORKER_CONCURRENCY=4
+WORKER_ROLE=match-processor
+CRON_ENABLED=false
+
 # JWT RS256 — dev reads PEM files; prod uses env PEM strings
 JWT_PRIVATE_KEY_PATH=infra/keys/jwt-private.pem
 JWT_PUBLIC_KEY_PATH=infra/keys/jwt-public.pem

--- a/apps/job-runner/biome.json
+++ b/apps/job-runner/biome.json
@@ -1,3 +1,15 @@
 {
-  "extends": "//"
+  "extends": "//",
+  "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    }
+  },
+  "linter": {
+    "rules": {
+      "style": {
+        "useImportType": "off"
+      }
+    }
+  }
 }

--- a/apps/job-runner/jest.config.cjs
+++ b/apps/job-runner/jest.config.cjs
@@ -1,0 +1,20 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testRegex: ".*\\.spec\\.ts$",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.spec.json",
+      },
+    ],
+  },
+};

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -7,17 +7,29 @@
     "dev": "tsx watch src/main.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/main.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
+    "@jest/globals": "29.7.0",
+    "@types/jest": "29.5.14",
     "@types/node": "^24.12.4",
+    "jest": "29.7.0",
+    "ts-jest": "29.2.5",
     "tsx": "^4.22.2",
     "typescript": "~5.7.3"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.21",
     "@nestjs/core": "^11.1.21",
+    "bullmq": "^5.49.2",
+    "dotenv": "^17.2.3",
+    "ioredis": "^5.11.1",
+    "nestjs-pino": "4.2.0",
+    "pino-http": "10.4.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "zod": "^3.25.76"
   }
 }

--- a/apps/job-runner/src/app.module.ts
+++ b/apps/job-runner/src/app.module.ts
@@ -1,7 +1,20 @@
 import { Module } from "@nestjs/common";
+import { LoggerModule } from "nestjs-pino";
+import { ConfigModule } from "./config/config.module.js";
+import { CronSchedulerService } from "./cron/cron-scheduler.service.js";
+import { WorkerMetricsService } from "./metrics/worker-metrics.service.js";
 import { RunnerService } from "./runner.service.js";
+import { WorkerFactory } from "./workers/worker-factory.js";
 
 @Module({
-  providers: [RunnerService],
+  imports: [
+    LoggerModule.forRoot({
+      pinoHttp: {
+        autoLogging: false,
+      },
+    }),
+    ConfigModule,
+  ],
+  providers: [WorkerMetricsService, WorkerFactory, CronSchedulerService, RunnerService],
 })
 export class AppModule {}

--- a/apps/job-runner/src/config/config.module.ts
+++ b/apps/job-runner/src/config/config.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from "@nestjs/common";
+import { JOB_RUNNER_CONFIG, loadEnv } from "./env.js";
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: JOB_RUNNER_CONFIG,
+      useFactory: () => loadEnv(),
+    },
+  ],
+  exports: [JOB_RUNNER_CONFIG],
+})
+export class ConfigModule {}

--- a/apps/job-runner/src/config/env.spec.ts
+++ b/apps/job-runner/src/config/env.spec.ts
@@ -60,4 +60,14 @@ describe("loadEnv", () => {
     expect(() => loadEnv(env)).toThrow("process.exit:1");
     expect(console.error).toHaveBeenCalled();
   });
+
+  it("fails when WORKER_QUEUES contains an unknown queue", () => {
+    expect(() =>
+      loadEnv({
+        ...baseEnv,
+        WORKER_QUEUES: "match-events,unknown-queue",
+      }),
+    ).toThrow("process.exit:1");
+    expect(console.error).toHaveBeenCalled();
+  });
 });

--- a/apps/job-runner/src/config/env.spec.ts
+++ b/apps/job-runner/src/config/env.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { loadEnv } from "./env.js";
+
+describe("loadEnv", () => {
+  const baseEnv: NodeJS.ProcessEnv = {
+    WORKER_QUEUES: "match-events",
+    REDIS_URL: "redis://localhost:6379",
+    DATABASE_URL: "postgresql://app:password@localhost:5432/chifoumi",
+  };
+
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as typeof process.exit);
+  });
+
+  it("parses requested queues and defaults", () => {
+    const config = loadEnv(baseEnv);
+
+    expect(config.WORKER_QUEUES).toEqual(["match-events"]);
+    expect(config.WORKER_CONCURRENCY).toBe(4);
+    expect(config.WORKER_ROLE).toBe("match-processor");
+    expect(config.BULLMQ_PREFIX).toBe("rps");
+    expect(config.CRON_ENABLED).toBe(false);
+    expect(config.MAIL_TRANSPORT).toBe("mailhog");
+  });
+
+  it("parses multiple queues and custom values", () => {
+    const config = loadEnv({
+      ...baseEnv,
+      WORKER_QUEUES: "match-events,notifications",
+      WORKER_CONCURRENCY: "8",
+      WORKER_ROLE: "notifier",
+      BULLMQ_PREFIX: "rps-staging",
+      CRON_ENABLED: "true",
+      MAIL_TRANSPORT: "smtp",
+    });
+
+    expect(config.WORKER_QUEUES).toEqual(["match-events", "notifications"]);
+    expect(config.WORKER_CONCURRENCY).toBe(8);
+    expect(config.WORKER_ROLE).toBe("notifier");
+    expect(config.BULLMQ_PREFIX).toBe("rps-staging");
+    expect(config.CRON_ENABLED).toBe(true);
+    expect(config.MAIL_TRANSPORT).toBe("smtp");
+  });
+
+  it("fails when REDIS_URL is missing", () => {
+    const env = { ...baseEnv };
+    delete env.REDIS_URL;
+
+    expect(() => loadEnv(env)).toThrow("process.exit:1");
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("fails when DATABASE_URL is missing", () => {
+    const env = { ...baseEnv };
+    delete env.DATABASE_URL;
+
+    expect(() => loadEnv(env)).toThrow("process.exit:1");
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/job-runner/src/config/env.ts
+++ b/apps/job-runner/src/config/env.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const WORKER_QUEUE_NAMES = [
+  "match-events",
+  "notifications",
+  "seasons",
+  "tournaments",
+] as const;
+
+export type WorkerQueueName = (typeof WORKER_QUEUE_NAMES)[number];
+
+export const WORKER_ROLES = ["match-processor", "notifier", "cron", "bracket-generator"] as const;
+
+export type WorkerRole = (typeof WORKER_ROLES)[number];
+
+const envSchema = z.object({
+  WORKER_QUEUES: z
+    .string()
+    .min(1, "WORKER_QUEUES is required")
+    .transform((value) =>
+      value
+        .split(",")
+        .map((queue) => queue.trim())
+        .filter((queue) => queue.length > 0),
+    )
+    .pipe(
+      z
+        .array(z.enum(WORKER_QUEUE_NAMES))
+        .min(1, "WORKER_QUEUES must contain at least one valid queue"),
+    ),
+  WORKER_CONCURRENCY: z.coerce.number().int().positive().default(4),
+  WORKER_ROLE: z.enum(WORKER_ROLES).default("match-processor"),
+  BULLMQ_PREFIX: z.string().min(1).default("rps"),
+  REDIS_URL: z.string().min(1, "REDIS_URL is required"),
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  MAIL_TRANSPORT: z.enum(["smtp", "mailhog"]).default("mailhog"),
+  CRON_ENABLED: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((value) => value === "true"),
+});
+
+export type JobRunnerConfig = z.infer<typeof envSchema>;
+
+export const JOB_RUNNER_CONFIG = Symbol("JOB_RUNNER_CONFIG");
+
+export function loadEnv(raw: NodeJS.ProcessEnv = process.env): JobRunnerConfig {
+  const result = envSchema.safeParse(raw);
+
+  if (!result.success) {
+    const messages = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "env"}: ${issue.message}`)
+      .join("\n");
+
+    console.error(`[job-runner] Invalid environment configuration:\n${messages}`);
+    process.exit(1);
+  }
+
+  return result.data;
+}

--- a/apps/job-runner/src/cron/cron-scheduler.service.ts
+++ b/apps/job-runner/src/cron/cron-scheduler.service.ts
@@ -4,13 +4,13 @@ import { Redis } from "ioredis";
 import { Logger } from "nestjs-pino";
 import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
 
-const CRON_LOCK_KEY = "job-runner:cron-scheduler-lock";
 const CRON_LOCK_TTL_SECONDS = 60;
 
 @Injectable()
 export class CronSchedulerService implements OnModuleInit, OnModuleDestroy {
   private redis: Redis | null = null;
   private seasonsQueue: Queue | null = null;
+  private lockHeld = false;
 
   constructor(
     @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
@@ -27,10 +27,6 @@ export class CronSchedulerService implements OnModuleInit, OnModuleDestroy {
     }
 
     this.redis = new Redis(this.config.REDIS_URL);
-    this.seasonsQueue = new Queue("seasons", {
-      connection: { url: this.config.REDIS_URL },
-      prefix: this.config.BULLMQ_PREFIX,
-    });
 
     const lockAcquired = await this.acquireSchedulerLock();
     if (!lockAcquired) {
@@ -38,8 +34,16 @@ export class CronSchedulerService implements OnModuleInit, OnModuleDestroy {
         { worker_role: this.config.WORKER_ROLE, queue: "seasons" },
         "Cron scheduler lock not acquired; skipping repeatable job registration",
       );
+      await this.redis.quit();
+      this.redis = null;
       return;
     }
+
+    this.lockHeld = true;
+    this.seasonsQueue = new Queue("seasons", {
+      connection: { url: this.config.REDIS_URL },
+      prefix: this.config.BULLMQ_PREFIX,
+    });
 
     await this.seasonsQueue.add(
       "season-reset",
@@ -58,9 +62,17 @@ export class CronSchedulerService implements OnModuleInit, OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     await this.seasonsQueue?.close();
+    if (this.lockHeld && this.redis) {
+      await this.redis.del(this.cronLockKey());
+    }
     await this.redis?.quit();
     this.seasonsQueue = null;
     this.redis = null;
+    this.lockHeld = false;
+  }
+
+  private cronLockKey(): string {
+    return `${this.config.BULLMQ_PREFIX}:job-runner:cron-scheduler-lock`;
   }
 
   private async acquireSchedulerLock(): Promise<boolean> {
@@ -69,7 +81,7 @@ export class CronSchedulerService implements OnModuleInit, OnModuleDestroy {
     }
 
     const result = await this.redis.set(
-      CRON_LOCK_KEY,
+      this.cronLockKey(),
       this.config.WORKER_ROLE,
       "EX",
       CRON_LOCK_TTL_SECONDS,

--- a/apps/job-runner/src/cron/cron-scheduler.service.ts
+++ b/apps/job-runner/src/cron/cron-scheduler.service.ts
@@ -1,0 +1,81 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { Redis } from "ioredis";
+import { Logger } from "nestjs-pino";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+
+const CRON_LOCK_KEY = "job-runner:cron-scheduler-lock";
+const CRON_LOCK_TTL_SECONDS = 60;
+
+@Injectable()
+export class CronSchedulerService implements OnModuleInit, OnModuleDestroy {
+  private redis: Redis | null = null;
+  private seasonsQueue: Queue | null = null;
+
+  constructor(
+    @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    if (!this.config.CRON_ENABLED) {
+      this.logger.log(
+        { worker_role: this.config.WORKER_ROLE, cron_enabled: false },
+        "Cron scheduler disabled",
+      );
+      return;
+    }
+
+    this.redis = new Redis(this.config.REDIS_URL);
+    this.seasonsQueue = new Queue("seasons", {
+      connection: { url: this.config.REDIS_URL },
+      prefix: this.config.BULLMQ_PREFIX,
+    });
+
+    const lockAcquired = await this.acquireSchedulerLock();
+    if (!lockAcquired) {
+      this.logger.warn(
+        { worker_role: this.config.WORKER_ROLE, queue: "seasons" },
+        "Cron scheduler lock not acquired; skipping repeatable job registration",
+      );
+      return;
+    }
+
+    await this.seasonsQueue.add(
+      "season-reset",
+      { source: "cron-scheduler" },
+      {
+        repeat: { pattern: "0 0 1 * *" },
+        jobId: "season-reset-cron",
+      },
+    );
+
+    this.logger.log(
+      { worker_role: this.config.WORKER_ROLE, queue: "seasons" },
+      "Cron scheduler registered repeatable season-reset job",
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.seasonsQueue?.close();
+    await this.redis?.quit();
+    this.seasonsQueue = null;
+    this.redis = null;
+  }
+
+  private async acquireSchedulerLock(): Promise<boolean> {
+    if (!this.redis) {
+      return false;
+    }
+
+    const result = await this.redis.set(
+      CRON_LOCK_KEY,
+      this.config.WORKER_ROLE,
+      "EX",
+      CRON_LOCK_TTL_SECONDS,
+      "NX",
+    );
+
+    return result === "OK";
+  }
+}

--- a/apps/job-runner/src/main.ts
+++ b/apps/job-runner/src/main.ts
@@ -1,11 +1,21 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { config as dotenvConfig } from "dotenv";
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
+import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module.js";
-import { RunnerService } from "./runner.service.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+dotenvConfig({ path: resolve(repoRoot, ".env") });
 
 async function bootstrap() {
-  const app = await NestFactory.createApplicationContext(AppModule);
-  app.get(RunnerService).markReady();
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    bufferLogs: true,
+  });
+  // biome-ignore lint/correctness/useHookAtTopLevel: NestJS bootstrap, not React hooks
+  app.useLogger(app.get(Logger));
+  app.enableShutdownHooks();
 
   let isShuttingDown = false;
   const shutdown = async () => {

--- a/apps/job-runner/src/metrics/worker-metrics.service.ts
+++ b/apps/job-runner/src/metrics/worker-metrics.service.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Counter, Registry } from "prom-client";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+
+@Injectable()
+export class WorkerMetricsService {
+  readonly registry = new Registry();
+  readonly jobsProcessed: Counter<string>;
+
+  constructor(@Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig) {
+    this.jobsProcessed = new Counter({
+      name: "bullmq_jobs_processed_total",
+      help: "Total BullMQ jobs processed by queue, role and status",
+      labelNames: ["queue", "role", "status"],
+      registers: [this.registry],
+    });
+  }
+
+  recordJobProcessed(queue: string, status: "completed" | "failed"): void {
+    this.jobsProcessed.inc({
+      queue,
+      role: this.config.WORKER_ROLE,
+      status,
+    });
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/apps/job-runner/src/runner.service.ts
+++ b/apps/job-runner/src/runner.service.ts
@@ -1,8 +1,35 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Logger } from "nestjs-pino";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "./config/env.js";
+import { type ManagedWorker, WorkerFactory } from "./workers/worker-factory.js";
 
 @Injectable()
-export class RunnerService {
-  markReady() {
-    console.log("[job-runner] ready");
+export class RunnerService implements OnModuleInit, OnModuleDestroy {
+  private workers: ManagedWorker[] = [];
+
+  constructor(
+    @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
+    private readonly workerFactory: WorkerFactory,
+    private readonly logger: Logger,
+  ) {}
+
+  onModuleInit(): void {
+    this.workers = this.workerFactory.createWorkers();
+
+    this.logger.log(
+      {
+        worker_role: this.config.WORKER_ROLE,
+        queues: this.config.WORKER_QUEUES,
+        concurrency: this.config.WORKER_CONCURRENCY,
+        prefix: this.config.BULLMQ_PREFIX,
+        cron_enabled: this.config.CRON_ENABLED,
+      },
+      "job-runner ready",
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await Promise.all(this.workers.map(({ worker }) => worker.close()));
+    this.workers = [];
   }
 }

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Logger } from "nestjs-pino";
+import type { JobRunnerConfig } from "../config/env.js";
+import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
+
+const workerCtor = jest.fn();
+
+jest.unstable_mockModule("bullmq", () => ({
+  Worker: workerCtor,
+}));
+
+const { WorkerFactory: WorkerFactoryClass } = await import("./worker-factory.js");
+
+function createConfig(overrides: Partial<JobRunnerConfig> = {}): JobRunnerConfig {
+  return {
+    WORKER_QUEUES: ["match-events"],
+    WORKER_CONCURRENCY: 4,
+    WORKER_ROLE: "match-processor",
+    BULLMQ_PREFIX: "rps",
+    REDIS_URL: "redis://localhost:6379",
+    DATABASE_URL: "postgresql://app:password@localhost:5432/chifoumi",
+    MAIL_TRANSPORT: "mailhog",
+    CRON_ENABLED: false,
+    ...overrides,
+  };
+}
+
+describe("WorkerFactory", () => {
+  beforeEach(() => {
+    workerCtor.mockReset();
+    workerCtor.mockImplementation(() => ({
+      on: jest.fn(),
+      close: jest.fn(async () => undefined),
+    }));
+  });
+
+  it("instantiates only the requested queues", () => {
+    const config = createConfig({ WORKER_QUEUES: ["match-events"] });
+    const metrics = new WorkerMetricsService(config);
+    const logger = { log: jest.fn() } as unknown as Logger;
+    const factory = new WorkerFactoryClass(config, metrics, logger);
+
+    const workers = factory.createWorkers();
+
+    expect(workers).toHaveLength(1);
+    expect(workers[0]?.queue).toBe("match-events");
+    expect(workerCtor).toHaveBeenCalledTimes(1);
+    expect(workerCtor).toHaveBeenCalledWith(
+      "match-events",
+      expect.any(Function),
+      expect.objectContaining({
+        connection: { url: config.REDIS_URL },
+        prefix: config.BULLMQ_PREFIX,
+        concurrency: config.WORKER_CONCURRENCY,
+      }),
+    );
+  });
+
+  it("instantiates multiple workers for multiple queues", () => {
+    const config = createConfig({
+      WORKER_QUEUES: ["match-events", "notifications"],
+      WORKER_CONCURRENCY: 8,
+      BULLMQ_PREFIX: "rps-staging",
+    });
+    const metrics = new WorkerMetricsService(config);
+    const logger = { log: jest.fn() } as unknown as Logger;
+    const factory = new WorkerFactoryClass(config, metrics, logger);
+
+    const workers = factory.createWorkers();
+
+    expect(workers).toHaveLength(2);
+    expect(workers.map((worker) => worker.queue)).toEqual(["match-events", "notifications"]);
+    expect(workerCtor).toHaveBeenCalledTimes(2);
+    expect(workerCtor).toHaveBeenNthCalledWith(
+      1,
+      "match-events",
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 8, prefix: "rps-staging" }),
+    );
+    expect(workerCtor).toHaveBeenNthCalledWith(
+      2,
+      "notifications",
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 8, prefix: "rps-staging" }),
+    );
+  });
+});

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Worker, type WorkerOptions } from "bullmq";
+import { Logger } from "nestjs-pino";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig, type WorkerQueueName } from "../config/env.js";
+import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
+import { getProcessorForQueue } from "./worker-processors.js";
+
+export type ManagedWorker = {
+  queue: WorkerQueueName;
+  worker: Worker;
+};
+
+@Injectable()
+export class WorkerFactory {
+  constructor(
+    @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
+    private readonly metrics: WorkerMetricsService,
+    private readonly logger: Logger,
+  ) {}
+
+  createWorkers(): ManagedWorker[] {
+    return this.config.WORKER_QUEUES.map((queue) => this.createWorker(queue));
+  }
+
+  private createWorker(queue: WorkerQueueName): ManagedWorker {
+    const workerOptions: WorkerOptions = {
+      connection: { url: this.config.REDIS_URL },
+      prefix: this.config.BULLMQ_PREFIX,
+      concurrency: this.config.WORKER_CONCURRENCY,
+    };
+
+    const worker = new Worker(queue, getProcessorForQueue(queue), workerOptions);
+
+    worker.on("completed", () => {
+      this.metrics.recordJobProcessed(queue, "completed");
+    });
+
+    worker.on("failed", () => {
+      this.metrics.recordJobProcessed(queue, "failed");
+    });
+
+    this.logger.log(
+      {
+        worker_role: this.config.WORKER_ROLE,
+        queue,
+        concurrency: this.config.WORKER_CONCURRENCY,
+        prefix: this.config.BULLMQ_PREFIX,
+      },
+      "BullMQ worker started",
+    );
+
+    return { queue, worker };
+  }
+}

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -39,6 +39,13 @@ export class WorkerFactory {
       this.metrics.recordJobProcessed(queue, "failed");
     });
 
+    worker.on("error", (error) => {
+      this.logger.error(
+        { worker_role: this.config.WORKER_ROLE, queue, err: error },
+        "BullMQ worker error",
+      );
+    });
+
     this.logger.log(
       {
         worker_role: this.config.WORKER_ROLE,

--- a/apps/job-runner/src/workers/worker-processors.ts
+++ b/apps/job-runner/src/workers/worker-processors.ts
@@ -1,0 +1,31 @@
+import type { Job } from "bullmq";
+import type { WorkerQueueName } from "../config/env.js";
+
+export type WorkerProcessor = (job: Job) => Promise<void>;
+
+const STUB_PROCESSORS: Record<WorkerQueueName, WorkerProcessor> = {
+  "match-events": async (job) => {
+    if (job.name !== "match-ended") {
+      throw new Error(`Unsupported job name on match-events: ${job.name}`);
+    }
+  },
+  notifications: async (job) => {
+    if (job.name !== "send-mail") {
+      throw new Error(`Unsupported job name on notifications: ${job.name}`);
+    }
+  },
+  seasons: async (job) => {
+    if (job.name !== "season-reset") {
+      throw new Error(`Unsupported job name on seasons: ${job.name}`);
+    }
+  },
+  tournaments: async (job) => {
+    if (job.name !== "generate-bracket") {
+      throw new Error(`Unsupported job name on tournaments: ${job.name}`);
+    }
+  },
+};
+
+export function getProcessorForQueue(queue: WorkerQueueName): WorkerProcessor {
+  return STUB_PROCESSORS[queue];
+}

--- a/apps/job-runner/tsconfig.spec.json
+++ b/apps/job-runner/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,52 @@ services:
       start_period: 5s
     restart: unless-stopped
 
+  job-runner-match:
+    build:
+      context: .
+      dockerfile: apps/job-runner/Dockerfile
+    container_name: chifoumi-job-runner-match
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+      REDIS_URL: redis://redis:6379
+      WORKER_QUEUES: match-events
+      WORKER_CONCURRENCY: 8
+      WORKER_ROLE: match-processor
+      CRON_ENABLED: "false"
+      BULLMQ_PREFIX: rps
+      MAIL_TRANSPORT: mailhog
+    restart: unless-stopped
+
+  job-runner-misc:
+    build:
+      context: .
+      dockerfile: apps/job-runner/Dockerfile
+    container_name: chifoumi-job-runner-misc
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mailhog:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+      REDIS_URL: redis://redis:6379
+      WORKER_QUEUES: notifications,tournaments
+      WORKER_CONCURRENCY: 4
+      WORKER_ROLE: notifier
+      CRON_ENABLED: "true"
+      BULLMQ_PREFIX: rps
+      MAIL_TRANSPORT: mailhog
+      MAIL_HOST: mailhog
+      MAIL_PORT: 1025
+    restart: unless-stopped
+
 volumes:
   pg_data:
   redis_data:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,16 +254,49 @@ importers:
       '@nestjs/core':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(@nestjs/websockets@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      bullmq:
+        specifier: ^5.49.2
+        version: 5.78.0
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.4.2
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
+      nestjs-pino:
+        specifier: 4.2.0
+        version: 4.2.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.4.0)
+      pino-http:
+        specifier: 10.4.0
+        version: 10.4.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@24.12.4)
+      ts-jest:
+        specifier: 29.2.5
+        version: 29.2.5(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.12.4))(typescript@5.7.3)
       tsx:
         specifier: ^4.22.2
         version: 4.22.2
@@ -3462,6 +3495,9 @@ packages:
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -6767,3 +6803,5 @@ snapshots:
     dependencies:
       grammex: 3.1.12
       graphmatch: 1.1.1
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary
- Add Zod-validated job-runner config (`WORKER_QUEUES`, `WORKER_CONCURRENCY`, `BULLMQ_PREFIX`, `CRON_ENABLED`, etc.) with boot-time failure on missing critical env vars
- Introduce `WorkerFactory` to instantiate BullMQ workers dynamically per queue, with Prometheus `bullmq_jobs_processed_total` metrics and structured Pino logs
- Add `job-runner-match` and `job-runner-misc` services to `docker-compose.yml` for specialized worker instances

Closes Team-3-Ynov/Chifoumi#24

## Test plan
- [x] `pnpm --filter @chifoumi/job-runner test` (env validation + worker factory unit tests)
- [x] `pnpm biome:check`
- [x] `pnpm typecheck`
- [x] CI lint / typecheck / test / build jobs pass on PR
- [ ] Verify `WORKER_QUEUES=match-events` starts only the match-events worker (logs)
- [ ] Verify `docker compose up job-runner-match job-runner-misc` boots both specialized instances