### PR TITLE
feat(notifications): welcome email on registration (US-025)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ VITE_API_BASE_URL=http://localhost:3000
 MAIL_TRANSPORT=mailhog
 MAIL_HOST=localhost
 MAIL_PORT=1025
+MAIL_FROM=noreply@chifoumi.local
 
 # Prefix used by BullMQ queues to avoid collisions between environments.
 BULLMQ_PREFIX=rps

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "argon2": "0.41.1",
+    "bullmq": "^5.49.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "dotenv": "^17.2.3",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { JwksModule } from "./jwks/jwks.module.js";
 import { LeaderboardModule } from "./leaderboard/leaderboard.module.js";
 import { MeModule } from "./me/me.module.js";
 import { PrismaModule } from "./prisma/prisma.module.js";
+import { QueuesModule } from "./queues/queues.module.js";
 import { RedisModule } from "./redis/redis.module.js";
 import { UsersModule } from "./users/users.module.js";
 
@@ -29,6 +30,7 @@ import { UsersModule } from "./users/users.module.js";
     AppConfigModule,
     PrismaModule,
     RedisModule,
+    QueuesModule,
     HealthModule,
     UsersModule,
     AuthModule,

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { JWT_CONFIG, type JwtConfig } from "../config/jwt.config.js";
+import { QueuesModule } from "../queues/queues.module.js";
 import { RedisModule } from "../redis/redis.module.js";
 import { UsersModule } from "../users/users.module.js";
 import { AuthController } from "./auth.controller.js";
@@ -15,6 +16,7 @@ import { TokenService } from "./token.service.js";
   imports: [
     UsersModule,
     RedisModule,
+    QueuesModule,
     PassportModule.register({ defaultStrategy: "jwt" }),
     JwtModule.registerAsync({
       inject: [JWT_CONFIG],

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -53,6 +53,7 @@ describe("AuthService", () => {
     redisService.setex.mockResolvedValue();
     redisService.setnx.mockResolvedValue(true);
     redisService.del.mockResolvedValue();
+    notificationsQueue.enqueueWelcomeMail.mockResolvedValue(undefined);
 
     (prisma.$transaction as jest.Mock).mockImplementation(async (callback: unknown) =>
       (callback as (tx: never) => Promise<unknown>)({
@@ -127,6 +128,45 @@ describe("AuthService", () => {
     });
     expect(result.tokens.access).toBe("access");
     expect(result.tokens.refresh).toBe("refresh");
+  });
+
+  it("register still returns tokens when welcome mail enqueue fails", async () => {
+    usersService.findByEmail.mockResolvedValue(null);
+    passwordService.hash.mockResolvedValue("hash");
+    usersService.createUser.mockResolvedValue({
+      id: "u1",
+      email: "a@b.com",
+      displayName: "alice",
+      role: "player",
+    } as Awaited<ReturnType<UsersService["createUser"]>>);
+    usersService.toSafeUser.mockReturnValue({
+      id: "u1",
+      email: "a@b.com",
+      displayName: "alice",
+      role: "player",
+    });
+    notificationsQueue.enqueueWelcomeMail.mockRejectedValue(new Error("queue unavailable"));
+    tokenService.issueAccessToken.mockResolvedValue({ accessToken: "access" });
+    tokenService.issueRefreshToken.mockReturnValue({
+      refreshToken: "refresh",
+      refreshTokenHash: "hashrefresh",
+    });
+    tokenService.getRefreshExpiresAt.mockReturnValue(new Date("2030-01-01"));
+    prisma.refreshToken.create.mockResolvedValue(
+      {} as Awaited<ReturnType<PrismaService["refreshToken"]["create"]>>,
+    );
+
+    const result = await authService.register({
+      email: "a@b.com",
+      password: "password1234",
+      displayName: "alice",
+    });
+
+    expect(notificationsQueue.enqueueWelcomeMail).toHaveBeenCalledWith({
+      to: "a@b.com",
+      displayName: "alice",
+    });
+    expect(result.tokens).toEqual({ access: "access", refresh: "refresh" });
   });
 
   it("register throws ConflictException on duplicate without leaking field", async () => {

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 import { ConflictException, UnauthorizedException } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { PrismaService } from "../prisma/prisma.service.js";
+import { NotificationsQueueService } from "../queues/notifications-queue.service.js";
 import { RedisService } from "../redis/redis.service.js";
 import { UsersService } from "../users/users.service.js";
 import { AuthService } from "./auth.service.js";
@@ -41,6 +42,9 @@ describe("AuthService", () => {
     setnx: jest.fn<RedisService["setnx"]>(),
     del: jest.fn<RedisService["del"]>(),
   };
+  const notificationsQueue = {
+    enqueueWelcomeMail: jest.fn<NotificationsQueueService["enqueueWelcomeMail"]>(),
+  };
   let authService: AuthService;
 
   beforeEach(async () => {
@@ -67,6 +71,7 @@ describe("AuthService", () => {
         { provide: PasswordService, useValue: passwordService },
         { provide: TokenService, useValue: tokenService },
         { provide: RedisService, useValue: redisService },
+        { provide: NotificationsQueueService, useValue: notificationsQueue },
       ],
     }).compile();
     authService = moduleRef.get(AuthService);
@@ -107,6 +112,10 @@ describe("AuthService", () => {
     expect(usersService.createUser).toHaveBeenCalledWith({
       email: "a@b.com",
       passwordHash: "hash",
+      displayName: "alice",
+    });
+    expect(notificationsQueue.enqueueWelcomeMail).toHaveBeenCalledWith({
+      to: "a@b.com",
       displayName: "alice",
     });
     expect(prisma.refreshToken.create).toHaveBeenCalledWith({

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
+import { NotificationsQueueService } from "../queues/notifications-queue.service.js";
 import { RedisService } from "../redis/redis.service.js";
 import { type SafeUser, UsersService } from "../users/users.service.js";
 import { PasswordService } from "./password.service.js";
@@ -21,6 +22,7 @@ export class AuthService {
     private readonly tokenService: TokenService,
     private readonly prisma: PrismaService,
     private readonly redisService: RedisService,
+    private readonly notificationsQueue: NotificationsQueueService,
   ) {}
 
   async register(input: {
@@ -40,6 +42,10 @@ export class AuthService {
       const user = await this.usersService.createUser({
         email,
         passwordHash,
+        displayName: input.displayName,
+      });
+      await this.notificationsQueue.enqueueWelcomeMail({
+        to: email,
         displayName: input.displayName,
       });
       return this.issueTokensForUser(user.id, user);

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -44,10 +44,12 @@ export class AuthService {
         passwordHash,
         displayName: input.displayName,
       });
-      await this.notificationsQueue.enqueueWelcomeMail({
-        to: email,
-        displayName: input.displayName,
-      });
+      void this.notificationsQueue
+        .enqueueWelcomeMail({
+          to: email,
+          displayName: input.displayName,
+        })
+        .catch(() => undefined);
       return this.issueTokensForUser(user.id, user);
     } catch (error) {
       if (this.usersService.isUniqueConstraintError(error)) {

--- a/apps/api/src/config/queue.config.ts
+++ b/apps/api/src/config/queue.config.ts
@@ -1,0 +1,18 @@
+export const QUEUE_CONFIG = Symbol("QUEUE_CONFIG");
+
+export type QueueConfig = {
+  redisUrl: string;
+  bullmqPrefix: string;
+};
+
+export function loadQueueConfig(): QueueConfig {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) {
+    throw new Error("REDIS_URL is required");
+  }
+
+  return {
+    redisUrl,
+    bullmqPrefix: process.env.BULLMQ_PREFIX ?? "rps",
+  };
+}

--- a/apps/api/src/queues/notifications-queue.service.spec.ts
+++ b/apps/api/src/queues/notifications-queue.service.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { QueueConfig } from "../config/queue.config.js";
+
+const queueAdd = jest.fn<() => Promise<unknown>>();
+const queueClose = jest.fn<() => Promise<void>>();
+
+jest.unstable_mockModule("bullmq", () => ({
+  Queue: jest.fn(() => ({
+    add: queueAdd,
+    close: queueClose,
+  })),
+}));
+
+const { NotificationsQueueService: NotificationsQueueServiceClass } = await import(
+  "./notifications-queue.service.js"
+);
+
+function createConfig(): QueueConfig {
+  return {
+    redisUrl: "redis://localhost:6379",
+    bullmqPrefix: "rps",
+  };
+}
+
+describe("NotificationsQueueService", () => {
+  beforeEach(() => {
+    queueAdd.mockReset();
+    queueClose.mockReset();
+    queueAdd.mockResolvedValue({ id: "job-1" });
+    queueClose.mockResolvedValue();
+    delete process.env.SKIP_REDIS_CONNECT;
+  });
+
+  it("enqueues welcome mail jobs with retry options", async () => {
+    const service = new NotificationsQueueServiceClass(createConfig());
+    await service.onModuleInit();
+
+    await service.enqueueWelcomeMail({
+      to: "player@example.com",
+      displayName: "alice",
+    });
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      "send-mail",
+      {
+        to: "player@example.com",
+        template: "welcome",
+        data: { displayName: "alice" },
+      },
+      {
+        attempts: 3,
+        backoff: {
+          type: "exponential",
+          delay: 1000,
+        },
+      },
+    );
+  });
+});

--- a/apps/api/src/queues/notifications-queue.service.ts
+++ b/apps/api/src/queues/notifications-queue.service.ts
@@ -1,0 +1,63 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { QUEUE_CONFIG, type QueueConfig } from "../config/queue.config.js";
+
+export type SendMailJobData = {
+  to: string;
+  template: string;
+  data: Record<string, string>;
+};
+
+const NOTIFICATIONS_QUEUE_NAME = "notifications";
+const SEND_MAIL_JOB_NAME = "send-mail";
+
+const SEND_MAIL_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: {
+    type: "exponential" as const,
+    delay: 1000,
+  },
+};
+
+@Injectable()
+export class NotificationsQueueService implements OnModuleInit, OnModuleDestroy {
+  private queue: Queue | null = null;
+
+  constructor(@Inject(QUEUE_CONFIG) private readonly queueConfig: QueueConfig) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.queue = new Queue(NOTIFICATIONS_QUEUE_NAME, {
+      connection: { url: this.queueConfig.redisUrl },
+      prefix: this.queueConfig.bullmqPrefix,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.queue?.close();
+    this.queue = null;
+  }
+
+  async enqueueWelcomeMail(input: { to: string; displayName: string }): Promise<void> {
+    await this.enqueueSendMail({
+      to: input.to,
+      template: "welcome",
+      data: { displayName: input.displayName },
+    });
+  }
+
+  async enqueueSendMail(payload: SendMailJobData): Promise<void> {
+    await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, SEND_MAIL_JOB_OPTIONS);
+  }
+
+  private requireQueue(): Queue {
+    if (!this.queue) {
+      throw new Error("Notifications queue is not connected");
+    }
+
+    return this.queue;
+  }
+}

--- a/apps/api/src/queues/queues.module.ts
+++ b/apps/api/src/queues/queues.module.ts
@@ -1,0 +1,16 @@
+import { Global, Module } from "@nestjs/common";
+import { loadQueueConfig, QUEUE_CONFIG } from "../config/queue.config.js";
+import { NotificationsQueueService } from "./notifications-queue.service.js";
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: QUEUE_CONFIG,
+      useFactory: () => loadQueueConfig(),
+    },
+    NotificationsQueueService,
+  ],
+  exports: [NotificationsQueueService],
+})
+export class QueuesModule {}

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -25,7 +25,6 @@
     "@nestjs/core": "^11.1.21",
     "bullmq": "^5.49.2",
     "dotenv": "^17.2.3",
-    "handlebars": "^4.7.8",
     "nodemailer": "^6.10.1",
     "ioredis": "^5.11.1",
     "nestjs-pino": "4.2.0",

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@jest/globals": "29.7.0",
     "@types/jest": "29.5.14",
+    "@types/nodemailer": "^6.4.17",
     "@types/node": "^24.12.4",
     "jest": "29.7.0",
     "ts-jest": "29.2.5",
@@ -24,6 +25,8 @@
     "@nestjs/core": "^11.1.21",
     "bullmq": "^5.49.2",
     "dotenv": "^17.2.3",
+    "handlebars": "^4.7.8",
+    "nodemailer": "^6.10.1",
     "ioredis": "^5.11.1",
     "nestjs-pino": "4.2.0",
     "pino-http": "10.4.0",

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/main.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node scripts/copy-notification-templates.mjs",
     "start": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"

--- a/apps/job-runner/scripts/copy-notification-templates.mjs
+++ b/apps/job-runner/scripts/copy-notification-templates.mjs
@@ -1,0 +1,9 @@
+import { cpSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+cpSync(join(root, "src/notifications/templates"), join(root, "dist/notifications/templates"), {
+  recursive: true,
+});

--- a/apps/job-runner/src/app.module.ts
+++ b/apps/job-runner/src/app.module.ts
@@ -3,6 +3,8 @@ import { LoggerModule } from "nestjs-pino";
 import { ConfigModule } from "./config/config.module.js";
 import { CronSchedulerService } from "./cron/cron-scheduler.service.js";
 import { WorkerMetricsService } from "./metrics/worker-metrics.service.js";
+import { MailService } from "./notifications/mail.service.js";
+import { TemplateService } from "./notifications/template.service.js";
 import { RunnerService } from "./runner.service.js";
 import { WorkerFactory } from "./workers/worker-factory.js";
 
@@ -15,6 +17,13 @@ import { WorkerFactory } from "./workers/worker-factory.js";
     }),
     ConfigModule,
   ],
-  providers: [WorkerMetricsService, WorkerFactory, CronSchedulerService, RunnerService],
+  providers: [
+    WorkerMetricsService,
+    TemplateService,
+    MailService,
+    WorkerFactory,
+    CronSchedulerService,
+    RunnerService,
+  ],
 })
 export class AppModule {}

--- a/apps/job-runner/src/config/env.spec.ts
+++ b/apps/job-runner/src/config/env.spec.ts
@@ -24,6 +24,9 @@ describe("loadEnv", () => {
     expect(config.BULLMQ_PREFIX).toBe("rps");
     expect(config.CRON_ENABLED).toBe(false);
     expect(config.MAIL_TRANSPORT).toBe("mailhog");
+    expect(config.MAIL_HOST).toBe("localhost");
+    expect(config.MAIL_PORT).toBe(1025);
+    expect(config.MAIL_FROM).toBe("noreply@chifoumi.local");
   });
 
   it("parses multiple queues and custom values", () => {

--- a/apps/job-runner/src/config/env.ts
+++ b/apps/job-runner/src/config/env.ts
@@ -34,6 +34,9 @@ const envSchema = z.object({
   REDIS_URL: z.string().min(1, "REDIS_URL is required"),
   DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
   MAIL_TRANSPORT: z.enum(["smtp", "mailhog"]).default("mailhog"),
+  MAIL_HOST: z.string().min(1).default("localhost"),
+  MAIL_PORT: z.coerce.number().int().positive().default(1025),
+  MAIL_FROM: z.string().email().default("noreply@chifoumi.local"),
   CRON_ENABLED: z
     .enum(["true", "false"])
     .default("false")

--- a/apps/job-runner/src/notifications/mail.service.spec.ts
+++ b/apps/job-runner/src/notifications/mail.service.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { JobRunnerConfig } from "../config/env.js";
+
+const sendMail = jest.fn<() => Promise<unknown>>();
+
+jest.unstable_mockModule("nodemailer", () => ({
+  default: {
+    createTransport: jest.fn(() => ({
+      sendMail,
+    })),
+  },
+}));
+
+const { MailService: MailServiceClass } = await import("./mail.service.js");
+const { TemplateService } = await import("./template.service.js");
+
+function createConfig(): JobRunnerConfig {
+  return {
+    WORKER_QUEUES: ["notifications"],
+    WORKER_CONCURRENCY: 4,
+    WORKER_ROLE: "notifier",
+    BULLMQ_PREFIX: "rps",
+    REDIS_URL: "redis://localhost:6379",
+    DATABASE_URL: "postgresql://app:password@localhost:5432/chifoumi",
+    MAIL_TRANSPORT: "mailhog",
+    MAIL_HOST: "localhost",
+    MAIL_PORT: 1025,
+    MAIL_FROM: "noreply@chifoumi.local",
+    CRON_ENABLED: false,
+  };
+}
+
+describe("MailService", () => {
+  beforeEach(() => {
+    sendMail.mockReset();
+    sendMail.mockResolvedValue({ messageId: "test-id" });
+  });
+
+  it("sends welcome mail with html and text bodies", async () => {
+    const service = new MailServiceClass(createConfig(), new TemplateService());
+
+    await service.send({
+      to: "player@example.com",
+      template: "welcome",
+      data: { displayName: "alice" },
+    });
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "noreply@chifoumi.local",
+        to: "player@example.com",
+        subject: "Bienvenue sur Chifoumi",
+        html: expect.stringContaining("alice"),
+        text: expect.stringContaining("alice"),
+      }),
+    );
+  });
+
+  it("propagates transport failures for BullMQ retry", async () => {
+    sendMail.mockRejectedValue(new Error("SMTP connection refused"));
+    const service = new MailServiceClass(createConfig(), new TemplateService());
+
+    await expect(
+      service.send({
+        to: "player@example.com",
+        template: "welcome",
+        data: { displayName: "alice" },
+      }),
+    ).rejects.toThrow("SMTP connection refused");
+  });
+
+  it("throws a clear error when template is missing", async () => {
+    const templateService = new TemplateService();
+    const renderSpy = jest.spyOn(templateService, "render").mockImplementation(() => {
+      throw new Error("Missing mail template file: welcome.html");
+    });
+    const service = new MailServiceClass(createConfig(), templateService);
+
+    await expect(
+      service.send({
+        to: "player@example.com",
+        template: "welcome",
+        data: { displayName: "alice" },
+      }),
+    ).rejects.toThrow("Missing mail template file: welcome.html");
+
+    renderSpy.mockRestore();
+  });
+});

--- a/apps/job-runner/src/notifications/mail.service.ts
+++ b/apps/job-runner/src/notifications/mail.service.ts
@@ -1,0 +1,39 @@
+import { Inject, Injectable } from "@nestjs/common";
+import nodemailer, { type Transporter } from "nodemailer";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+import { TemplateService } from "./template.service.js";
+
+@Injectable()
+export class MailService {
+  private transporter: Transporter | null = null;
+
+  constructor(
+    @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
+    private readonly templateService: TemplateService,
+  ) {}
+
+  async send(input: { to: string; template: string; data: Record<string, string> }): Promise<void> {
+    const rendered = this.templateService.render(input.template, input.data);
+    const transporter = this.getTransporter();
+
+    await transporter.sendMail({
+      from: this.config.MAIL_FROM,
+      to: input.to,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+    });
+  }
+
+  private getTransporter(): Transporter {
+    if (!this.transporter) {
+      this.transporter = nodemailer.createTransport({
+        host: this.config.MAIL_HOST,
+        port: this.config.MAIL_PORT,
+        secure: false,
+      });
+    }
+
+    return this.transporter;
+  }
+}

--- a/apps/job-runner/src/notifications/notifications.processor.spec.ts
+++ b/apps/job-runner/src/notifications/notifications.processor.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { Job } from "bullmq";
+import type { MailService } from "./mail.service.js";
+import { createNotificationsProcessor } from "./notifications.processor.js";
+
+function createJob(overrides: Partial<Job> = {}): Job {
+  return {
+    name: "send-mail",
+    data: {
+      to: "player@example.com",
+      template: "welcome",
+      data: { displayName: "alice" },
+    },
+    ...overrides,
+  } as Job;
+}
+
+describe("createNotificationsProcessor", () => {
+  it("delegates valid send-mail jobs to MailService", async () => {
+    const mailService = {
+      send: jest.fn<MailService["send"]>().mockResolvedValue(),
+    };
+    const processor = createNotificationsProcessor(mailService as unknown as MailService);
+
+    await processor(createJob());
+
+    expect(mailService.send).toHaveBeenCalledWith({
+      to: "player@example.com",
+      template: "welcome",
+      data: { displayName: "alice" },
+    });
+  });
+
+  it("rejects unsupported job names", async () => {
+    const mailService = {
+      send: jest.fn<MailService["send"]>(),
+    };
+    const processor = createNotificationsProcessor(mailService as unknown as MailService);
+
+    await expect(processor(createJob({ name: "other-job" }))).rejects.toThrow(
+      "Unsupported job name on notifications: other-job",
+    );
+  });
+
+  it("rejects invalid payloads", async () => {
+    const mailService = {
+      send: jest.fn<MailService["send"]>(),
+    };
+    const processor = createNotificationsProcessor(mailService as unknown as MailService);
+
+    await expect(processor(createJob({ data: { invalid: true } }))).rejects.toThrow(
+      "Invalid send-mail job payload",
+    );
+  });
+});

--- a/apps/job-runner/src/notifications/notifications.processor.ts
+++ b/apps/job-runner/src/notifications/notifications.processor.ts
@@ -1,0 +1,33 @@
+import type { Job } from "bullmq";
+import type { WorkerProcessor } from "../workers/worker-processors.js";
+import type { MailService } from "./mail.service.js";
+import type { SendMailJobPayload } from "./send-mail.types.js";
+
+function isSendMailPayload(data: unknown): data is SendMailJobPayload {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const payload = data as Partial<SendMailJobPayload>;
+  return (
+    typeof payload.to === "string" &&
+    typeof payload.template === "string" &&
+    payload.data !== null &&
+    typeof payload.data === "object" &&
+    !Array.isArray(payload.data)
+  );
+}
+
+export function createNotificationsProcessor(mailService: MailService): WorkerProcessor {
+  return async (job: Job) => {
+    if (job.name !== "send-mail") {
+      throw new Error(`Unsupported job name on notifications: ${job.name}`);
+    }
+
+    if (!isSendMailPayload(job.data)) {
+      throw new Error("Invalid send-mail job payload");
+    }
+
+    await mailService.send(job.data);
+  };
+}

--- a/apps/job-runner/src/notifications/send-mail.types.ts
+++ b/apps/job-runner/src/notifications/send-mail.types.ts
@@ -1,0 +1,9 @@
+export type SendMailJobPayload = {
+  to: string;
+  template: string;
+  data: Record<string, string>;
+};
+
+export type WelcomeMailData = {
+  displayName: string;
+};

--- a/apps/job-runner/src/notifications/template-build.spec.ts
+++ b/apps/job-runner/src/notifications/template-build.spec.ts
@@ -1,0 +1,17 @@
+import { execSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@jest/globals";
+
+describe("notification template build output", () => {
+  const distTemplatesDir = join(process.cwd(), "dist/notifications/templates");
+
+  it("copy script places welcome templates in dist", () => {
+    rmSync(distTemplatesDir, { recursive: true, force: true });
+
+    execSync("node scripts/copy-notification-templates.mjs", { cwd: process.cwd() });
+
+    expect(existsSync(join(distTemplatesDir, "welcome.html"))).toBe(true);
+    expect(existsSync(join(distTemplatesDir, "welcome.txt"))).toBe(true);
+  });
+});

--- a/apps/job-runner/src/notifications/template.service.spec.ts
+++ b/apps/job-runner/src/notifications/template.service.spec.ts
@@ -10,8 +10,8 @@ describe("TemplateService", () => {
     expect(rendered.subject).toBe("Bienvenue sur Chifoumi");
     expect(rendered.html).toContain("alice");
     expect(rendered.text).toContain("alice");
-    expect(rendered.html).not.toContain("{{displayName}}");
-    expect(rendered.text).not.toContain("{{displayName}}");
+    expect(rendered.html).not.toContain("__DISPLAY_NAME__");
+    expect(rendered.text).not.toContain("__DISPLAY_NAME__");
   });
 
   it("throws a clear error when template is unknown", () => {

--- a/apps/job-runner/src/notifications/template.service.spec.ts
+++ b/apps/job-runner/src/notifications/template.service.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "@jest/globals";
+import { TemplateService } from "./template.service.js";
+
+describe("TemplateService", () => {
+  const service = new TemplateService();
+
+  it("renders welcome template with interpolated displayName", () => {
+    const rendered = service.render("welcome", { displayName: "alice" });
+
+    expect(rendered.subject).toBe("Bienvenue sur Chifoumi");
+    expect(rendered.html).toContain("alice");
+    expect(rendered.text).toContain("alice");
+    expect(rendered.html).not.toContain("{{displayName}}");
+    expect(rendered.text).not.toContain("{{displayName}}");
+  });
+
+  it("throws a clear error when template is unknown", () => {
+    expect(() => service.render("missing-template", {})).toThrow(
+      "Unknown mail template: missing-template",
+    );
+  });
+});

--- a/apps/job-runner/src/notifications/template.service.ts
+++ b/apps/job-runner/src/notifications/template.service.ts
@@ -2,7 +2,6 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Injectable } from "@nestjs/common";
-import Handlebars from "handlebars";
 
 export type RenderedMail = {
   subject: string;
@@ -29,9 +28,16 @@ export class TemplateService {
 
     return {
       subject,
-      html: Handlebars.compile(htmlSource)(data),
-      text: Handlebars.compile(textSource)(data),
+      html: this.interpolate(htmlSource, data),
+      text: this.interpolate(textSource, data),
     };
+  }
+
+  private interpolate(source: string, data: Record<string, string>): string {
+    return Object.entries(data).reduce((content, [key, value]) => {
+      const placeholder = `__${key.replace(/([A-Z])/g, "_$1").toUpperCase()}__`;
+      return content.replaceAll(placeholder, value);
+    }, source);
   }
 
   private readTemplate(template: string, extension: "html" | "txt"): string {

--- a/apps/job-runner/src/notifications/template.service.ts
+++ b/apps/job-runner/src/notifications/template.service.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Injectable } from "@nestjs/common";
+import Handlebars from "handlebars";
+
+export type RenderedMail = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+const TEMPLATE_SUBJECTS: Record<string, string> = {
+  welcome: "Bienvenue sur Chifoumi",
+};
+
+@Injectable()
+export class TemplateService {
+  private readonly templatesDir = join(dirname(fileURLToPath(import.meta.url)), "templates");
+
+  render(template: string, data: Record<string, string>): RenderedMail {
+    const subject = TEMPLATE_SUBJECTS[template];
+    if (!subject) {
+      throw new Error(`Unknown mail template: ${template}`);
+    }
+
+    const htmlSource = this.readTemplate(template, "html");
+    const textSource = this.readTemplate(template, "txt");
+
+    return {
+      subject,
+      html: Handlebars.compile(htmlSource)(data),
+      text: Handlebars.compile(textSource)(data),
+    };
+  }
+
+  private readTemplate(template: string, extension: "html" | "txt"): string {
+    const filePath = join(this.templatesDir, `${template}.${extension}`);
+
+    try {
+      return readFileSync(filePath, "utf8");
+    } catch {
+      throw new Error(`Missing mail template file: ${template}.${extension}`);
+    }
+  }
+}

--- a/apps/job-runner/src/notifications/templates/welcome.html
+++ b/apps/job-runner/src/notifications/templates/welcome.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Bienvenue sur Chifoumi</title>
+  </head>
+  <body>
+    <h1>Bienvenue sur Chifoumi, {{displayName}} !</h1>
+    <p>
+      Ton compte est prêt. Tu peux maintenant rejoindre la file de matchmaking et grimper dans le
+      classement.
+    </p>
+    <p>À très vite sur le terrain.</p>
+  </body>
+</html>

--- a/apps/job-runner/src/notifications/templates/welcome.html
+++ b/apps/job-runner/src/notifications/templates/welcome.html
@@ -5,7 +5,7 @@
     <title>Bienvenue sur Chifoumi</title>
   </head>
   <body>
-    <h1>Bienvenue sur Chifoumi, {{displayName}} !</h1>
+    <h1>Bienvenue sur Chifoumi, __DISPLAY_NAME__ !</h1>
     <p>
       Ton compte est prêt. Tu peux maintenant rejoindre la file de matchmaking et grimper dans le
       classement.

--- a/apps/job-runner/src/notifications/templates/welcome.txt
+++ b/apps/job-runner/src/notifications/templates/welcome.txt
@@ -1,0 +1,5 @@
+Bienvenue sur Chifoumi, {{displayName}} !
+
+Ton compte est prêt. Tu peux maintenant rejoindre la file de matchmaking et grimper dans le classement.
+
+À très vite sur le terrain.

--- a/apps/job-runner/src/notifications/templates/welcome.txt
+++ b/apps/job-runner/src/notifications/templates/welcome.txt
@@ -1,4 +1,4 @@
-Bienvenue sur Chifoumi, {{displayName}} !
+Bienvenue sur Chifoumi, __DISPLAY_NAME__ !
 
 Ton compte est prêt. Tu peux maintenant rejoindre la file de matchmaking et grimper dans le classement.
 

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -20,8 +20,17 @@ function createConfig(overrides: Partial<JobRunnerConfig> = {}): JobRunnerConfig
     REDIS_URL: "redis://localhost:6379",
     DATABASE_URL: "postgresql://app:password@localhost:5432/chifoumi",
     MAIL_TRANSPORT: "mailhog",
+    MAIL_HOST: "localhost",
+    MAIL_PORT: 1025,
+    MAIL_FROM: "noreply@chifoumi.local",
     CRON_ENABLED: false,
     ...overrides,
+  };
+}
+
+function createMailService(): { send: () => Promise<void> } {
+  return {
+    send: jest.fn(async () => undefined),
   };
 }
 
@@ -38,7 +47,7 @@ describe("WorkerFactory", () => {
     const config = createConfig({ WORKER_QUEUES: ["match-events"] });
     const metrics = new WorkerMetricsService(config);
     const logger = { log: jest.fn() } as unknown as Logger;
-    const factory = new WorkerFactoryClass(config, metrics, logger);
+    const factory = new WorkerFactoryClass(config, metrics, createMailService() as never, logger);
 
     const workers = factory.createWorkers();
 
@@ -64,7 +73,7 @@ describe("WorkerFactory", () => {
     });
     const metrics = new WorkerMetricsService(config);
     const logger = { log: jest.fn() } as unknown as Logger;
-    const factory = new WorkerFactoryClass(config, metrics, logger);
+    const factory = new WorkerFactoryClass(config, metrics, createMailService() as never, logger);
 
     const workers = factory.createWorkers();
 

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -3,6 +3,7 @@ import { Worker, type WorkerOptions } from "bullmq";
 import { Logger } from "nestjs-pino";
 import { JOB_RUNNER_CONFIG, type JobRunnerConfig, type WorkerQueueName } from "../config/env.js";
 import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
+import { MailService } from "../notifications/mail.service.js";
 import { getProcessorForQueue } from "./worker-processors.js";
 
 export type ManagedWorker = {
@@ -15,6 +16,7 @@ export class WorkerFactory {
   constructor(
     @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
     private readonly metrics: WorkerMetricsService,
+    private readonly mailService: MailService,
     private readonly logger: Logger,
   ) {}
 
@@ -29,14 +31,34 @@ export class WorkerFactory {
       concurrency: this.config.WORKER_CONCURRENCY,
     };
 
-    const worker = new Worker(queue, getProcessorForQueue(queue), workerOptions);
+    const worker = new Worker(
+      queue,
+      getProcessorForQueue(queue, { mailService: this.mailService }),
+      workerOptions,
+    );
 
     worker.on("completed", () => {
       this.metrics.recordJobProcessed(queue, "completed");
     });
 
-    worker.on("failed", () => {
+    worker.on("failed", (job, error) => {
       this.metrics.recordJobProcessed(queue, "failed");
+
+      if (queue === "notifications" && job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
+        this.logger.error(
+          {
+            worker_role: this.config.WORKER_ROLE,
+            queue,
+            job_name: job.name,
+            job_id: job.id,
+            to: (job.data as { to?: string }).to,
+            template: (job.data as { template?: string }).template,
+            attempts_made: job.attemptsMade,
+            err: error,
+          },
+          "Notification job failed permanently",
+        );
+      }
     });
 
     worker.on("error", (error) => {

--- a/apps/job-runner/src/workers/worker-processors.ts
+++ b/apps/job-runner/src/workers/worker-processors.ts
@@ -1,17 +1,18 @@
 import type { Job } from "bullmq";
 import type { WorkerQueueName } from "../config/env.js";
+import type { MailService } from "../notifications/mail.service.js";
+import { createNotificationsProcessor } from "../notifications/notifications.processor.js";
 
 export type WorkerProcessor = (job: Job) => Promise<void>;
 
-const STUB_PROCESSORS: Record<WorkerQueueName, WorkerProcessor> = {
+export type ProcessorDependencies = {
+  mailService: MailService;
+};
+
+const STUB_PROCESSORS: Record<Exclude<WorkerQueueName, "notifications">, WorkerProcessor> = {
   "match-events": async (job) => {
     if (job.name !== "match-ended") {
       throw new Error(`Unsupported job name on match-events: ${job.name}`);
-    }
-  },
-  notifications: async (job) => {
-    if (job.name !== "send-mail") {
-      throw new Error(`Unsupported job name on notifications: ${job.name}`);
     }
   },
   seasons: async (job) => {
@@ -26,6 +27,13 @@ const STUB_PROCESSORS: Record<WorkerQueueName, WorkerProcessor> = {
   },
 };
 
-export function getProcessorForQueue(queue: WorkerQueueName): WorkerProcessor {
+export function getProcessorForQueue(
+  queue: WorkerQueueName,
+  deps: ProcessorDependencies,
+): WorkerProcessor {
+  if (queue === "notifications") {
+    return createNotificationsProcessor(deps.mailService);
+  }
+
   return STUB_PROCESSORS[queue];
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       MAIL_TRANSPORT: mailhog
       MAIL_HOST: mailhog
       MAIL_PORT: 1025
+      MAIL_FROM: noreply@chifoumi.local
     restart: unless-stopped
 
 volumes:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       argon2:
         specifier: 0.41.1
         version: 0.41.1
+      bullmq:
+        specifier: ^5.49.2
+        version: 5.78.0
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -260,12 +263,18 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.9
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
       nestjs-pino:
         specifier: 4.2.0
         version: 4.2.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.4.0)
+      nodemailer:
+        specifier: ^6.10.1
+        version: 6.10.1
       pino-http:
         specifier: 10.4.0
         version: 10.4.0
@@ -291,6 +300,9 @@ importers:
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      '@types/nodemailer':
+        specifier: ^6.4.17
+        version: 6.4.23
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@24.12.4)
@@ -1379,6 +1391,9 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/nodemailer@6.4.23':
+    resolution: {integrity: sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==}
+
   '@types/passport-jwt@4.0.1':
     resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
 
@@ -2060,6 +2075,11 @@ packages:
   graphmatch@1.1.1:
     resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2643,6 +2663,9 @@ packages:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2681,6 +2704,9 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
   nestjs-pino@4.2.0:
     resolution: {integrity: sha512-+YpNb+ZyWq+vZqhMLRGyV8838n/sjdvLsHjPjmw+yW8+hnE9yVP50MdehtGcHA9d7z2XVccT/GUp8pI1U+nDvA==}
     engines: {node: '>= 14'}
@@ -2708,6 +2734,10 @@ packages:
 
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  nodemailer@6.10.1:
+    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3328,6 +3358,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
     engines: {node: '>=8'}
@@ -3430,6 +3465,9 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4515,6 +4553,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/nodemailer@6.4.23':
+    dependencies:
+      '@types/node': 24.12.4
+
   '@types/passport-jwt@4.0.1':
     dependencies:
       '@types/jsonwebtoken': 9.0.7
@@ -5273,6 +5315,15 @@ snapshots:
 
   graphmatch@1.1.1: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -5994,6 +6045,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.0
 
+  minimist@1.2.8: {}
+
   ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
@@ -6043,6 +6096,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo-async@2.6.2: {}
+
   nestjs-pino@4.2.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.4.0):
     dependencies:
       '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6062,6 +6117,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.44: {}
+
+  nodemailer@6.10.1: {}
 
   normalize-path@3.0.0: {}
 
@@ -6702,6 +6759,9 @@ snapshots:
 
   typescript@5.7.3: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   uid@2.0.2:
     dependencies:
       '@lukeed/csprng': 1.1.0
@@ -6759,6 +6819,8 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,6 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
-      handlebars:
-        specifier: ^4.7.8
-        version: 4.7.9
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
@@ -2075,11 +2072,6 @@ packages:
   graphmatch@1.1.1:
     resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
 
-  handlebars@4.7.9:
-    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2663,9 +2655,6 @@ packages:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2703,9 +2692,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  neo-async@2.6.2:
-    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   nestjs-pino@4.2.0:
     resolution: {integrity: sha512-+YpNb+ZyWq+vZqhMLRGyV8838n/sjdvLsHjPjmw+yW8+hnE9yVP50MdehtGcHA9d7z2XVccT/GUp8pI1U+nDvA==}
@@ -3358,11 +3344,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
     engines: {node: '>=8'}
@@ -3465,9 +3446,6 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
-
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -5315,15 +5293,6 @@ snapshots:
 
   graphmatch@1.1.1: {}
 
-  handlebars@4.7.9:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -6045,8 +6014,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.0
 
-  minimist@1.2.8: {}
-
   ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
@@ -6095,8 +6062,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
-
-  neo-async@2.6.2: {}
 
   nestjs-pino@4.2.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.4.0):
     dependencies:
@@ -6759,9 +6724,6 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  uglify-js@3.19.3:
-    optional: true
-
   uid@2.0.2:
     dependencies:
       '@lukeed/csprng': 1.1.0
@@ -6819,8 +6781,6 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-
-  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Enqueue a `notifications.send-mail` job with template `welcome` after successful `POST /auth/register`
- Implement job-runner notifications worker with Nodemailer + Handlebars templates (subject: Bienvenue sur Chifoumi)
- Configure 3 retries with exponential backoff and permanent-failure error logging

## Test plan
- [x] job-runner unit tests (template, mail service, processor, worker factory)
- [x] API unit tests (auth register enqueues job, notifications queue service)
- [x] pre-commit typecheck passes
- [ ] CI green on PR
- [ ] Manual: register via API, verify mail in MailHog at http://localhost:8025

Made with [Cursor](https://cursor.com)