### PR TITLE
feat(db): sprint 1 ranked schema — matches, rounds, elo_history (US-027)

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,69 @@
+# @chifoumi/db
+
+Shared Prisma schema, migrations, and generated client for the Chifoumi monorepo.
+
+## Commands
+
+```bash
+pnpm --filter @chifoumi/db generate
+pnpm --filter @chifoumi/db migrate:dev
+pnpm --filter @chifoumi/db migrate:deploy
+pnpm --filter @chifoumi/db typecheck
+```
+
+Requires `DATABASE_URL` (see root `.env.example`).
+
+## Tables
+
+| Table | Purpose |
+|---|---|
+| `users` | Accounts (`player` / `admin`), sprint 0 |
+| `refresh_tokens` | Opaque refresh token hashes, sprint 0 |
+| `elo_ratings` | Current ELO rating per user, sprint 0 |
+| `matches` | Ranked match sessions (players, score, status, timestamps), sprint 1 |
+| `rounds` | Individual BO3 rounds with commit-reveal audit fields, sprint 1 |
+| `elo_history` | ELO delta audit trail per user and match, sprint 1 |
+
+## Sprint 1 ranked models (US-027)
+
+### Enums
+
+- `MatchStatus`: `in_progress`, `ended`, `aborted`
+- `Move`: `rock`, `paper`, `scissors`
+- `RoundWinner`: `a`, `b`, `draw`
+
+### `matches`
+
+- FKs: `player_a_id`, `player_b_id`, optional `winner_id` → `users`
+- CHECK: `player_a_id <> player_b_id`
+- Columns: `score_a`, `score_b`, `started_at`, `ended_at`, `status`
+
+### `rounds`
+
+- FK: `match_id` → `matches` (cascade delete)
+- Unique index: `(match_id, round_number)`
+- Nullable commit-reveal fields: `move_a/b`, `commit_a/b`, `nonce_a/b`
+- Required: `winner`, `resolved_at`
+
+### `elo_history`
+
+- FKs: `user_id`, `match_id`
+- Columns: `rating_before`, `rating_after`, `delta`, `created_at`
+
+## Migration
+
+Sprint 1 tables are created by migration `20260608120000_sprint_1_ranked_tables`.
+
+Apply on a clean database:
+
+```bash
+docker compose down -v
+docker compose up -d postgres
+pnpm --filter @chifoumi/db migrate:deploy
+```
+
+Re-running `migrate:deploy` on an already migrated database is a no-op.
+
+## Exports
+
+`src/index.ts` re-exports `Match`, `Round`, `EloHistory` types and `MatchStatus`, `Move`, `RoundWinner` enums from `@prisma/client`.


### PR DESCRIPTION
## Summary

- Sprint 1 ranked persistence is in `packages/db`: enums (`MatchStatus`, `Move`, `RoundWinner`), models (`Match`, `Round`, `EloHistory`), and migration `20260608120000_sprint_1_ranked_tables`.
- `matches` includes CHECK `player_a_id <> player_b_id`; `rounds` has unique `(match_id, round_number)`; `elo_history` tracks rating deltas per user/match.
- `@chifoumi/db` re-exports `Match`, `Round`, `EloHistory` types and related enums.
- Adds `packages/db/README.md` documenting tables, migration workflow, and exports (US-027 technical task).

> Note: schema/migration landed on `develop` with US-011 (#60); this PR formalizes US-027 documentation and acceptance verification.

## Acceptance criteria

- [x] AC1 — migration `sprint_1_ranked_tables` applies cleanly (`pnpm --filter @chifoumi/db migrate:deploy`)
- [x] AC2 — `matches` columns + different-players CHECK constraint
- [x] AC3 — `rounds` columns + unique `(match_id, round_number)`
- [x] AC4 — `elo_history` columns
- [x] AC5 — migration idempotent (re-deploy = no pending migrations)
- [x] AC6 — types exported from `packages/db/src/index.ts`

## Test plan

- [x] `pnpm --filter @chifoumi/db migrate:deploy` against local Postgres
- [x] `pnpm --filter @chifoumi/db typecheck`
- [x] Pre-commit hook typecheck (full monorepo)