### PR TITLE
US-024 - Worker match-events persistence and ELO

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Game service WebSocket e2e tests
         run: pnpm --filter @chifoumi/game-service test:e2e
 
+      - name: Job-runner match-events integration tests
+        run: pnpm --filter @chifoumi/job-runner test:integration
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -128,6 +128,7 @@ jobs:
           mkdir -p infra/keys
           openssl genrsa -out infra/keys/jwt-private.pem 2048
           openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+          chmod a+r infra/keys/jwt-private.pem infra/keys/jwt-public.pem
 
       - name: Start E2E stack
         run: bash scripts/e2e/start-stack.sh

--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ pnpm --filter @chifoumi/job-runner dev
 pnpm --filter @chifoumi/front dev
 ```
 
+### Job-runner (deploiement)
+
+Le job-runner persiste les matchs termines et envoie les notifications. Il utilise la **meme base PostgreSQL que l'API** via Prisma.
+
+| Variable | Role |
+|---|---|
+| `DATABASE_URL` | Connexion PostgreSQL (obligatoire) — persistance des matchs, rounds, ELO et historique |
+| `REDIS_URL` | Redis pour BullMQ et publication `leaderboard:invalidate` |
+| `WORKER_QUEUES` | Queues a ecouter, ex. `match-events,notifications` |
+| `WORKER_CONCURRENCY` | Nombre de jobs traites en parallele par worker |
+| `WORKER_ROLE` | Role logique du processus (`match-processor`, `notifier`, etc.) |
+| `BULLMQ_PREFIX` | Prefixe des queues BullMQ (isole les environnements) |
+
+En local, copier `.env.example` vers `.env` : `DATABASE_URL` est partagee entre l'API et le job-runner. En production, pointer `DATABASE_URL` vers la base applicative et `REDIS_URL` vers le cluster Redis partage avec l'API et le game-service.
+
+Tests d'integration du worker match-events (Postgres + Redis requis) :
+
+```bash
+docker compose up -d
+pnpm --filter @chifoumi/db migrate:deploy
+pnpm --filter @chifoumi/job-runner test:integration
+```
+
 ## Liens utiles
 
 | Outil | URL | Statut |

--- a/apps/job-runner/jest-e2e.config.cjs
+++ b/apps/job-runner/jest-e2e.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
   testEnvironment: "node",
   maxWorkers: 1,
   testTimeout: 30_000,
+  forceExit: true,
   rootDir: ".",
   testRegex: "test/.*\\.integration-spec\\.ts$",
   transform: {

--- a/apps/job-runner/jest-e2e.config.cjs
+++ b/apps/job-runner/jest-e2e.config.cjs
@@ -9,7 +9,6 @@ module.exports = {
   testEnvironment: "node",
   maxWorkers: 1,
   testTimeout: 30_000,
-  forceExit: true,
   rootDir: ".",
   testRegex: "test/.*\\.integration-spec\\.ts$",
   transform: {

--- a/apps/job-runner/jest-e2e.config.cjs
+++ b/apps/job-runner/jest-e2e.config.cjs
@@ -1,0 +1,24 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^@chifoumi/db$": "@prisma/client",
+  },
+  testEnvironment: "node",
+  maxWorkers: 1,
+  testTimeout: 30_000,
+  rootDir: ".",
+  testRegex: "test/.*\\.integration-spec\\.ts$",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.e2e.json",
+      },
+    ],
+  },
+  transformIgnorePatterns: ["node_modules/(?!(@prisma/client|\\.prisma/client)/)"],
+};

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -9,10 +9,13 @@
     "start": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "pretest": "pnpm --filter @chifoumi/elo build",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "preintegration": "pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/db build",
+    "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./jest-e2e.config.cjs --runInBand"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",
+    "@nestjs/testing": "11.1.21",
     "@types/jest": "29.5.14",
     "@types/nodemailer": "^6.4.17",
     "@types/node": "^24.12.4",

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -p tsconfig.json && node scripts/copy-notification-templates.mjs",
     "start": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "pnpm --filter @chifoumi/elo build",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {

--- a/apps/job-runner/src/metrics/worker-metrics.service.spec.ts
+++ b/apps/job-runner/src/metrics/worker-metrics.service.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import type { JobRunnerConfig } from "../config/env.js";
+import { WorkerMetricsService } from "./worker-metrics.service.js";
+
+function createConfig(): JobRunnerConfig {
+  return {
+    WORKER_QUEUES: ["match-events"],
+    WORKER_CONCURRENCY: 4,
+    WORKER_ROLE: "match-processor",
+    BULLMQ_PREFIX: "rps",
+    REDIS_URL: "redis://localhost:6379",
+    DATABASE_URL: "postgresql://app:password@localhost:5432/chifoumi",
+    MAIL_TRANSPORT: "mailhog",
+    MAIL_HOST: "localhost",
+    MAIL_PORT: 1025,
+    MAIL_FROM: "noreply@chifoumi.local",
+    CRON_ENABLED: false,
+  };
+}
+
+describe("WorkerMetricsService", () => {
+  it("records completed, retry and permanent failure outcomes", async () => {
+    const metrics = new WorkerMetricsService(createConfig());
+
+    metrics.recordJobProcessed("match-events", "completed");
+    metrics.recordJobProcessed("match-events", "retry");
+    metrics.recordJobProcessed("match-events", "failed_permanent");
+
+    const rendered = await metrics.getMetrics();
+
+    expect(rendered).toContain(
+      'bullmq_jobs_processed_total{queue="match-events",role="match-processor",outcome="completed"} 1',
+    );
+    expect(rendered).toContain(
+      'bullmq_jobs_processed_total{queue="match-events",role="match-processor",outcome="retry"} 1',
+    );
+    expect(rendered).toContain(
+      'bullmq_jobs_processed_total{queue="match-events",role="match-processor",outcome="failed_permanent"} 1',
+    );
+  });
+});

--- a/apps/job-runner/src/metrics/worker-metrics.service.ts
+++ b/apps/job-runner/src/metrics/worker-metrics.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from "@nestjs/common";
 import { Counter, Registry } from "prom-client";
 import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
 
+export type JobProcessedOutcome = "completed" | "retry" | "failed_permanent";
+
 @Injectable()
 export class WorkerMetricsService {
   readonly registry = new Registry();
@@ -10,17 +12,17 @@ export class WorkerMetricsService {
   constructor(@Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig) {
     this.jobsProcessed = new Counter({
       name: "bullmq_jobs_processed_total",
-      help: "Total BullMQ jobs processed by queue, role and status",
-      labelNames: ["queue", "role", "status"],
+      help: "Total BullMQ job attempts by queue, role and outcome (completed, retry, failed_permanent)",
+      labelNames: ["queue", "role", "outcome"],
       registers: [this.registry],
     });
   }
 
-  recordJobProcessed(queue: string, status: "completed" | "failed"): void {
+  recordJobProcessed(queue: string, outcome: JobProcessedOutcome): void {
     this.jobsProcessed.inc({
       queue,
       role: this.config.WORKER_ROLE,
-      status,
+      outcome,
     });
   }
 

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -5,8 +5,10 @@ import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
 
 const workerCtor = jest.fn();
 
+class MockUnrecoverableError extends Error {}
+
 jest.unstable_mockModule("bullmq", () => ({
-  UnrecoverableError: class UnrecoverableError extends Error {},
+  UnrecoverableError: MockUnrecoverableError,
   Worker: workerCtor,
 }));
 
@@ -131,6 +133,12 @@ describe("WorkerFactory", () => {
     expect(recordSpy).toHaveBeenCalledWith("match-events", "retry");
     expect(recordSpy).toHaveBeenCalledWith("match-events", "failed_permanent");
     expect(recordSpy).toHaveBeenCalledWith("match-events", "completed");
+
+    recordSpy.mockClear();
+    handlers.get("failed")?.(failedJob, new MockUnrecoverableError("invalid payload"));
+
+    expect(recordSpy).toHaveBeenCalledWith("match-events", "failed_permanent");
+    expect(recordSpy).not.toHaveBeenCalledWith("match-events", "retry");
   });
 
   it("instantiates multiple workers for multiple queues", () => {

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -85,6 +85,54 @@ describe("WorkerFactory", () => {
     );
   });
 
+  it("records retry vs permanent failure metrics from worker events", () => {
+    const config = createConfig({ WORKER_QUEUES: ["match-events"] });
+    const metrics = new WorkerMetricsService(config);
+    const recordSpy = jest.spyOn(metrics, "recordJobProcessed");
+    type FailedJob = {
+      attemptsMade: number;
+      opts: { attempts?: number };
+      name: string;
+      id: string;
+      data: { matchId: string };
+    };
+    const handlers = new Map<string, (job?: FailedJob, error?: Error) => void>();
+    workerCtor.mockImplementation(() => ({
+      on: jest.fn((event: string, handler: (job?: FailedJob, error?: Error) => void) => {
+        handlers.set(event, handler);
+      }),
+      close: jest.fn(async () => undefined),
+    }));
+
+    const factory = new WorkerFactoryClass(
+      config,
+      metrics,
+      createMatchPersistence() as never,
+      createRedisInvalidation() as never,
+      createMailService() as never,
+      { log: jest.fn(), error: jest.fn() } as unknown as Logger,
+    );
+
+    factory.createWorkers();
+
+    const failedJob = {
+      attemptsMade: 1,
+      opts: { attempts: 3 },
+      name: "match-ended",
+      id: "job-1",
+      data: { matchId: "33333333-3333-4333-8333-333333333333" },
+    };
+    const permanentFailedJob = { ...failedJob, attemptsMade: 3 };
+
+    handlers.get("failed")?.(failedJob, new Error("transient"));
+    handlers.get("failed")?.(permanentFailedJob, new Error("permanent"));
+    handlers.get("completed")?.();
+
+    expect(recordSpy).toHaveBeenCalledWith("match-events", "retry");
+    expect(recordSpy).toHaveBeenCalledWith("match-events", "failed_permanent");
+    expect(recordSpy).toHaveBeenCalledWith("match-events", "completed");
+  });
+
   it("instantiates multiple workers for multiple queues", () => {
     const config = createConfig({
       WORKER_QUEUES: ["match-events", "notifications"],

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { Worker, type WorkerOptions } from "bullmq";
+import { UnrecoverableError, Worker, type WorkerOptions } from "bullmq";
 import { Logger } from "nestjs-pino";
 import { JOB_RUNNER_CONFIG, type JobRunnerConfig, type WorkerQueueName } from "../config/env.js";
 import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
@@ -51,10 +51,15 @@ export class WorkerFactory {
 
     worker.on("failed", (job, error) => {
       const maxAttempts = job?.opts.attempts ?? 1;
-      const isPermanentFailure = !job || job.attemptsMade >= maxAttempts;
+      const isPermanentFailure =
+        !job || error instanceof UnrecoverableError || job.attemptsMade >= maxAttempts;
       this.metrics.recordJobProcessed(queue, isPermanentFailure ? "failed_permanent" : "retry");
 
-      if (queue === "match-events" && job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
+      if (
+        queue === "match-events" &&
+        job &&
+        (error instanceof UnrecoverableError || job.attemptsMade >= (job.opts.attempts ?? 1))
+      ) {
         this.logger.error(
           {
             worker_role: this.config.WORKER_ROLE,

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -50,7 +50,9 @@ export class WorkerFactory {
     });
 
     worker.on("failed", (job, error) => {
-      this.metrics.recordJobProcessed(queue, "failed");
+      const maxAttempts = job?.opts.attempts ?? 1;
+      const isPermanentFailure = !job || job.attemptsMade >= maxAttempts;
+      this.metrics.recordJobProcessed(queue, isPermanentFailure ? "failed_permanent" : "retry");
 
       if (queue === "match-events" && job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
         this.logger.error(

--- a/apps/job-runner/test/match-events.integration-spec.ts
+++ b/apps/job-runner/test/match-events.integration-spec.ts
@@ -11,7 +11,6 @@ import { WorkerMetricsService } from "../src/metrics/worker-metrics.service.js";
 import { MatchPersistenceService } from "../src/persistence/match-persistence.service.js";
 import { PrismaService } from "../src/prisma/prisma.service.js";
 import { LEADERBOARD_INVALIDATE_CHANNEL } from "../src/redis/redis-invalidation.service.js";
-import { RunnerService } from "../src/runner.service.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 config({ path: resolve(repoRoot, ".env") });
@@ -97,7 +96,6 @@ function createPayload(matchId: string, playerAId: string, playerBId: string): M
 
 describe("match-events worker (integration)", () => {
   let moduleRef: TestingModule;
-  let runnerService: RunnerService;
   let prisma: PrismaService;
   let persistence: MatchPersistenceService;
   let metrics: WorkerMetricsService;
@@ -110,7 +108,6 @@ describe("match-events worker (integration)", () => {
     }).compile();
     await moduleRef.init();
 
-    runnerService = moduleRef.get(RunnerService);
     prisma = moduleRef.get(PrismaService);
     persistence = moduleRef.get(MatchPersistenceService);
     metrics = moduleRef.get(WorkerMetricsService);
@@ -132,7 +129,6 @@ describe("match-events worker (integration)", () => {
   });
 
   afterAll(async () => {
-    await runnerService.onModuleDestroy();
     await queue.close();
     await redisSubscriber.quit();
     await moduleRef.close();

--- a/apps/job-runner/test/match-events.integration-spec.ts
+++ b/apps/job-runner/test/match-events.integration-spec.ts
@@ -222,8 +222,16 @@ describe("match-events worker (integration)", () => {
     const job = await queue.add("match-ended", { invalid: true }, { attempts: 3 });
     const failedJob = await waitForJobState(queue, job, "failed");
 
-    expect(failedJob.attemptsMade).toBeGreaterThanOrEqual(1);
     expect(failedJob.failedReason).toContain("Invalid match-ended job payload");
+    // UnrecoverableError fails immediately without consuming retry attempts.
+    expect(failedJob.attemptsMade).toBeLessThan(3);
+
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
+    const stillFailed = await Job.fromId(queue, job.id as string);
+    expect(stillFailed && (await stillFailed.getState())).toBe("failed");
+
+    const renderedMetrics = await metrics.getMetrics();
+    expect(renderedMetrics).toContain('outcome="failed_permanent"');
   });
 
   it("retries transient persistence failures and records retry metrics", async () => {

--- a/apps/job-runner/test/match-events.integration-spec.ts
+++ b/apps/job-runner/test/match-events.integration-spec.ts
@@ -45,11 +45,20 @@ async function waitForJobState(
   job: Job,
   expected: string,
   timeoutMs = 15_000,
+  options?: { failedReasonContains?: string },
 ): Promise<Job> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const current = await Job.fromId(bullQueue, job.id as string);
     if (current && (await current.getState()) === expected) {
+      if (
+        expected === "failed" &&
+        options?.failedReasonContains &&
+        !current.failedReason?.includes(options.failedReasonContains)
+      ) {
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+        continue;
+      }
       return current;
     }
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
@@ -220,7 +229,9 @@ describe("match-events worker (integration)", () => {
 
   it("rejects invalid payloads permanently without retry", async () => {
     const job = await queue.add("match-ended", { invalid: true }, { attempts: 3 });
-    const failedJob = await waitForJobState(queue, job, "failed");
+    const failedJob = await waitForJobState(queue, job, "failed", 15_000, {
+      failedReasonContains: "Invalid match-ended job payload",
+    });
 
     expect(failedJob.failedReason).toContain("Invalid match-ended job payload");
     // UnrecoverableError fails immediately without consuming retry attempts.

--- a/apps/job-runner/test/match-events.integration-spec.ts
+++ b/apps/job-runner/test/match-events.integration-spec.ts
@@ -48,7 +48,7 @@ async function waitForJobState(
 ): Promise<Job> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const current = await Job.fromId(bullQueue, job.id!);
+    const current = await Job.fromId(bullQueue, job.id as string);
     if (current && (await current.getState()) === expected) {
       return current;
     }
@@ -108,7 +108,6 @@ describe("match-events worker (integration)", () => {
     queue = createQueue();
     redisSubscriber = new Redis(redisUrl);
 
-    runnerService.onModuleInit();
     await redisSubscriber.subscribe(LEADERBOARD_INVALIDATE_CHANNEL);
   }, 30_000);
 

--- a/apps/job-runner/test/match-events.integration-spec.ts
+++ b/apps/job-runner/test/match-events.integration-spec.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { jest } from "@jest/globals";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { Job, Queue } from "bullmq";
+import { config } from "dotenv";
+import { Redis } from "ioredis";
+import type { MatchEndedPayload } from "../src/match-events/match-ended.types.js";
+import { WorkerMetricsService } from "../src/metrics/worker-metrics.service.js";
+import { MatchPersistenceService } from "../src/persistence/match-persistence.service.js";
+import { PrismaService } from "../src/prisma/prisma.service.js";
+import { LEADERBOARD_INVALIDATE_CHANNEL } from "../src/redis/redis-invalidation.service.js";
+import { RunnerService } from "../src/runner.service.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+const redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";
+const bullmqPrefix = `rps-it-${process.pid}`;
+
+process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+process.env.REDIS_URL = redisUrl;
+process.env.WORKER_QUEUES = "match-events";
+process.env.WORKER_CONCURRENCY = "1";
+process.env.WORKER_ROLE = "match-processor";
+process.env.BULLMQ_PREFIX = bullmqPrefix;
+process.env.MAIL_TRANSPORT = "mailhog";
+process.env.MAIL_HOST = "localhost";
+process.env.MAIL_PORT = "1025";
+process.env.MAIL_FROM = "noreply@chifoumi.local";
+process.env.CRON_ENABLED = "false";
+
+const { AppModule } = await import("../src/app.module.js");
+
+function createQueue(): Queue {
+  return new Queue("match-events", {
+    connection: { url: redisUrl },
+    prefix: bullmqPrefix,
+  });
+}
+
+async function waitForJobState(
+  bullQueue: Queue,
+  job: Job,
+  expected: string,
+  timeoutMs = 15_000,
+): Promise<Job> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const current = await Job.fromId(bullQueue, job.id!);
+    if (current && (await current.getState()) === expected) {
+      return current;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  throw new Error(`Job ${job.id} did not reach state "${expected}" within ${timeoutMs}ms`);
+}
+
+function createPayload(matchId: string, playerAId: string, playerBId: string): MatchEndedPayload {
+  return {
+    matchId,
+    players: [
+      { userId: playerAId, displayName: "alice", rating: 1000 },
+      { userId: playerBId, displayName: "bob", rating: 1000 },
+    ],
+    rounds: [
+      {
+        roundNumber: 1,
+        moveA: "rock",
+        moveB: "scissors",
+        winner: "a",
+        resolvedAt: "2026-06-09T10:00:01.000Z",
+      },
+      {
+        roundNumber: 2,
+        moveA: "paper",
+        moveB: "rock",
+        winner: "a",
+        resolvedAt: "2026-06-09T10:00:02.000Z",
+      },
+    ],
+    winner: playerAId,
+    finalScore: { a: 2, b: 0 },
+    startedAt: "2026-06-09T10:00:00.000Z",
+  };
+}
+
+describe("match-events worker (integration)", () => {
+  let moduleRef: TestingModule;
+  let runnerService: RunnerService;
+  let prisma: PrismaService;
+  let persistence: MatchPersistenceService;
+  let metrics: WorkerMetricsService;
+  let queue: Queue;
+  let redisSubscriber: Redis;
+
+  beforeAll(async () => {
+    moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    await moduleRef.init();
+
+    runnerService = moduleRef.get(RunnerService);
+    prisma = moduleRef.get(PrismaService);
+    persistence = moduleRef.get(MatchPersistenceService);
+    metrics = moduleRef.get(WorkerMetricsService);
+    queue = createQueue();
+    redisSubscriber = new Redis(redisUrl);
+
+    runnerService.onModuleInit();
+    await redisSubscriber.subscribe(LEADERBOARD_INVALIDATE_CHANNEL);
+  }, 30_000);
+
+  beforeEach(async () => {
+    await queue.obliterate({ force: true });
+
+    await prisma.eloHistory.deleteMany();
+    await prisma.round.deleteMany();
+    await prisma.match.deleteMany();
+    await prisma.refreshToken.deleteMany();
+    await prisma.eloRating.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    await runnerService.onModuleDestroy();
+    await queue.close();
+    await redisSubscriber.quit();
+    await moduleRef.close();
+  }, 30_000);
+
+  async function seedPlayers() {
+    const playerAId = randomUUID();
+    const playerBId = randomUUID();
+
+    await prisma.user.create({
+      data: {
+        id: playerAId,
+        email: `alice-${playerAId}@example.com`,
+        passwordHash: "hash",
+        displayName: "alice",
+        eloRating: { create: { rating: 1000, gamesPlayed: 0 } },
+      },
+    });
+    await prisma.user.create({
+      data: {
+        id: playerBId,
+        email: `bob-${playerBId}@example.com`,
+        passwordHash: "hash",
+        displayName: "bob",
+        eloRating: { create: { rating: 1000, gamesPlayed: 0 } },
+      },
+    });
+
+    return { playerAId, playerBId };
+  }
+
+  it("persists a nominal match-ended event and invalidates the leaderboard cache", async () => {
+    const { playerAId, playerBId } = await seedPlayers();
+    const matchId = randomUUID();
+    const payload = createPayload(matchId, playerAId, playerBId);
+
+    const invalidationMessages: string[] = [];
+    redisSubscriber.removeAllListeners("message");
+    redisSubscriber.on("message", (channel, message) => {
+      if (channel === LEADERBOARD_INVALIDATE_CHANNEL) {
+        invalidationMessages.push(message);
+      }
+    });
+
+    const job = await queue.add("match-ended", payload, { attempts: 3 });
+    await waitForJobState(queue, job, "completed");
+
+    const match = await prisma.match.findUnique({ where: { id: matchId } });
+    expect(match).toMatchObject({
+      playerAId,
+      playerBId,
+      winnerId: playerAId,
+      scoreA: 2,
+      scoreB: 0,
+      status: "ended",
+    });
+
+    const rounds = await prisma.round.findMany({
+      where: { matchId },
+      orderBy: { roundNumber: "asc" },
+    });
+    expect(rounds).toHaveLength(2);
+
+    const history = await prisma.eloHistory.findMany({ where: { matchId } });
+    expect(history).toHaveLength(2);
+
+    const ratingA = await prisma.eloRating.findUnique({ where: { userId: playerAId } });
+    const ratingB = await prisma.eloRating.findUnique({ where: { userId: playerBId } });
+    expect(ratingA?.rating).toBe(1020);
+    expect(ratingB?.rating).toBe(980);
+    expect(invalidationMessages).toContain("*");
+  });
+
+  it("is idempotent when the same match-ended event is replayed", async () => {
+    const { playerAId, playerBId } = await seedPlayers();
+    const matchId = randomUUID();
+    const payload = createPayload(matchId, playerAId, playerBId);
+
+    const firstJob = await queue.add("match-ended", payload, { attempts: 3 });
+    await waitForJobState(queue, firstJob, "completed");
+
+    const ratingAfterFirst = await prisma.eloRating.findUnique({ where: { userId: playerAId } });
+
+    const replayJob = await queue.add("match-ended", payload, { attempts: 3 });
+    await waitForJobState(queue, replayJob, "completed");
+
+    const historyCount = await prisma.eloHistory.count({ where: { matchId } });
+    const ratingAfterReplay = await prisma.eloRating.findUnique({ where: { userId: playerAId } });
+
+    expect(historyCount).toBe(2);
+    expect(ratingAfterReplay?.rating).toBe(ratingAfterFirst?.rating);
+    expect(ratingAfterReplay?.gamesPlayed).toBe(ratingAfterFirst?.gamesPlayed);
+  });
+
+  it("rejects invalid payloads permanently without retry", async () => {
+    const job = await queue.add("match-ended", { invalid: true }, { attempts: 3 });
+    const failedJob = await waitForJobState(queue, job, "failed");
+
+    expect(failedJob.attemptsMade).toBeGreaterThanOrEqual(1);
+    expect(failedJob.failedReason).toContain("Invalid match-ended job payload");
+  });
+
+  it("retries transient persistence failures and records retry metrics", async () => {
+    const { playerAId, playerBId } = await seedPlayers();
+    const matchId = randomUUID();
+    const payload = createPayload(matchId, playerAId, playerBId);
+    const original = persistence.persistMatchEnded.bind(persistence);
+
+    const persistSpy = jest
+      .spyOn(persistence, "persistMatchEnded")
+      .mockRejectedValueOnce(new Error("database unavailable"))
+      .mockImplementation((jobPayload) => original(jobPayload));
+
+    const job = await queue.add("match-ended", payload, { attempts: 3 });
+    await waitForJobState(queue, job, "completed");
+
+    expect(persistSpy).toHaveBeenCalledTimes(2);
+
+    const renderedMetrics = await metrics.getMetrics();
+    expect(renderedMetrics).toContain('outcome="retry"');
+    expect(renderedMetrics).toContain('outcome="completed"');
+
+    persistSpy.mockRestore();
+  });
+});

--- a/apps/job-runner/tsconfig.e2e.json
+++ b/apps/job-runner/tsconfig.e2e.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../../packages/db/src/**/*.ts"]
+}

--- a/packages/elo/package.json
+++ b/packages/elo/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json",
+    "pretest": "tsc -p tsconfig.json",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@jest/globals':
         specifier: 29.7.0
         version: 29.7.0
+      '@nestjs/testing':
+        specifier: 11.1.21
+        version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(@nestjs/platform-express@11.1.21)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14

--- a/scripts/e2e/start-stack.sh
+++ b/scripts/e2e/start-stack.sh
@@ -4,5 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+if [ -d infra/keys ]; then
+  chmod a+r infra/keys/*.pem 2>/dev/null || true
+fi
+
 docker compose --project-name chifoumi-e2e -f docker-compose.e2e.yml up \
   --build --detach --wait --wait-timeout 180

--- a/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
+++ b/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
@@ -77,6 +77,7 @@ describe("US-031 BO3 cross-instance smoke @e2e", () => {
         apiUrl,
         playerA.tokens.access,
         (profile) => profile.gamesPlayed === 1 && profile.rating > baselineA.rating,
+        15_000,
       );
       expect(profileA.gamesPlayed).toBe(1);
 
@@ -104,5 +105,5 @@ describe("US-031 BO3 cross-instance smoke @e2e", () => {
       socketA?.disconnect();
       socketB?.disconnect();
     }
-  }, 30_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- Implement the `match-events` worker for `match-ended` jobs with payload validation and unrecoverable invalid-payload failures.
- Persist completed matches transactionally with rounds, ELO rating updates, and two ELO history rows using `@chifoumi/elo`.
- Add idempotence for replayed `matchId`s and publish `leaderboard:invalidate` on successful first processing.
- Enrich the game-service match-ended job payload with resolved rounds and configure BullMQ retries/backoff.
- Add Prisma and Redis services for the job-runner plus focused unit coverage.

## Validation
- `npx pnpm@9.15.9 --filter @chifoumi/job-runner run test -- --runInBand`
- `npx pnpm@9.15.9 --filter @chifoumi/game-service run test -- match-play.service.spec.ts --runInBand`
- `$env:DATABASE_URL='postgresql://app:chifoumi_dev@localhost:5432/chifoumi'; npx pnpm@9.15.9 -r typecheck`
- `$env:DATABASE_URL='postgresql://app:chifoumi_dev@localhost:5432/chifoumi'; npx pnpm@9.15.9 --filter @chifoumi/job-runner build`
- Pre-commit hook: Biome + workspace typecheck OK

Closes #25