### PR TITLE
feat(db): seed initial admin user and reference data stubs (US-029)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 # PostgreSQL connection used by Prisma and the API.
 DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi
 
+# Default admin account created by `pnpm db:seed` on first launch.
+# Change both values in production — never ship these defaults.
+ADMIN_DEFAULT_EMAIL=admin@chifoumi.local
+ADMIN_DEFAULT_PASSWORD=admin-CHANGE-ME!
+
 # Redis connection used by cache, pub-sub and BullMQ workers.
 REDIS_URL=redis://localhost:6379
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,19 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: chifoumi_dev
+          POSTGRES_DB: chifoumi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       redis:
         image: redis:7
         ports:
@@ -61,6 +74,9 @@ jobs:
 
       - name: Build database package
         run: pnpm --filter @chifoumi/db build
+
+      - name: Apply database migrations
+        run: pnpm --filter @chifoumi/db migrate:deploy
 
       - name: Test with coverage
         run: pnpm -r run --if-present test

--- a/README.md
+++ b/README.md
@@ -29,8 +29,32 @@ pnpm install
 cp .env.example .env
 docker compose up -d
 pnpm --filter @chifoumi/db generate
+pnpm --filter @chifoumi/db migrate:deploy
 pnpm dev
 ```
+
+## Premier lancement
+
+Au premier demarrage (base Postgres vide), appliquer les migrations puis le seed :
+
+```bash
+docker compose up -d postgres
+pnpm --filter @chifoumi/db migrate:deploy
+pnpm db:seed
+```
+
+Le seed cree un compte admin par defaut :
+
+| Champ | Valeur dev |
+|---|---|
+| Email | `admin@chifoumi.local` |
+| Mot de passe | `admin-CHANGE-ME!` |
+| Role | `admin` |
+| ELO initial | `1000` |
+
+**En production**, definir obligatoirement `ADMIN_DEFAULT_EMAIL` et `ADMIN_DEFAULT_PASSWORD` dans l'environnement — ne jamais conserver les valeurs par defaut.
+
+Le seed est idempotent : relance sur une base deja initialisee, il ne duplique rien. En conteneur Docker, l'entrypoint API execute `migrate deploy` puis `db:seed` avant le demarrage (skip si l'admin existe deja).
 
 Services lances par `pnpm dev` :
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,6 +27,8 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV API_PORT=3000
 COPY --from=builder /app /app
+COPY apps/api/docker-entrypoint.sh /app/apps/api/docker-entrypoint.sh
+RUN chmod +x /app/apps/api/docker-entrypoint.sh
 USER node
 EXPOSE 3000
-CMD ["node", "apps/api/dist/main.js"]
+ENTRYPOINT ["/app/apps/api/docker-entrypoint.sh"]

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+cd /app
+
+pnpm --filter @chifoumi/db generate
+pnpm --filter @chifoumi/db migrate:deploy
+pnpm db:seed
+
+exec node apps/api/dist/main.js

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "biome:check": "biome check apps packages .github biome.json lefthook.yml",
     "biome:fix": "biome check --write apps packages .github biome.json lefthook.yml",
     "typecheck": "pnpm --filter @chifoumi/db typecheck && pnpm -r typecheck",
+    "db:seed": "pnpm --filter @chifoumi/db seed",
     "docs:openapi": "pnpm --filter @chifoumi/api docs:openapi",
     "lefthook:install": "lefthook install"
   },

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -9,9 +9,10 @@ pnpm --filter @chifoumi/db generate
 pnpm --filter @chifoumi/db migrate:dev
 pnpm --filter @chifoumi/db migrate:deploy
 pnpm --filter @chifoumi/db typecheck
+pnpm --filter @chifoumi/db seed
 ```
 
-Requires `DATABASE_URL` (see root `.env.example`).
+Requires `DATABASE_URL` (see root `.env.example`). Optional seed overrides: `ADMIN_DEFAULT_EMAIL`, `ADMIN_DEFAULT_PASSWORD`.
 
 ## Tables
 
@@ -63,6 +64,26 @@ pnpm --filter @chifoumi/db migrate:deploy
 ```
 
 Re-running `migrate:deploy` on an already migrated database is a no-op.
+
+## Initial seed (US-029)
+
+Create the default admin account and ELO rating:
+
+```bash
+pnpm --filter @chifoumi/db migrate:deploy
+pnpm --filter @chifoumi/db seed
+# or from repo root:
+pnpm db:seed
+```
+
+Default credentials (override via env — **change in production**):
+
+| Variable | Dev default |
+|---|---|
+| `ADMIN_DEFAULT_EMAIL` | `admin@chifoumi.local` |
+| `ADMIN_DEFAULT_PASSWORD` | `admin-CHANGE-ME!` |
+
+The seed is idempotent: re-running it does not duplicate the admin user.
 
 ## Exports
 

--- a/packages/db/jest.config.cjs
+++ b/packages/db/jest.config.cjs
@@ -1,0 +1,21 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testEnvironment: "node",
+  maxWorkers: 1,
+  roots: ["<rootDir>/src"],
+  testRegex: ".*\\.spec\\.ts$",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.spec.json",
+      },
+    ],
+  },
+};

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,9 @@
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
     "build": "prisma generate && tsc -p tsconfig.json",
-    "typecheck": "prisma generate && tsc -p tsconfig.json"
+    "typecheck": "prisma generate && tsc -p tsconfig.json",
+    "seed": "tsx prisma/seed.ts",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "keywords": [],
   "author": "",
@@ -21,9 +23,18 @@
     "prisma": "*"
   },
   "devDependencies": {
+    "@jest/globals": "29.7.0",
+    "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@types/jest": "29.5.14",
+    "@types/node": "^24.12.4",
+    "argon2": "0.41.1",
     "dotenv": "^17.4.2",
+    "jest": "29.7.0",
+    "pg": "^8.16.3",
     "prisma": "^7.8.0",
+    "ts-jest": "29.2.5",
+    "tsx": "^4.19.3",
     "typescript": "~5.7.3"
   }
 }

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "tsx prisma/seed.ts",
   },
   datasource: {
     url: env("DATABASE_URL"),

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,0 +1,21 @@
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import { runSeed } from "../src/seed/admin-user.js";
+import { getSeedConfig } from "../src/seed/config.js";
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) });
+
+runSeed(prisma, getSeedConfig())
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/db/src/seed/admin-user.ts
+++ b/packages/db/src/seed/admin-user.ts
@@ -1,0 +1,60 @@
+import { type PrismaClient, UserRole } from "@prisma/client";
+import { getSeedConfig, type SeedConfig } from "./config.js";
+import { hashPassword } from "./password.js";
+
+const DEFAULT_ELO_RATING = 1000;
+
+export async function adminUserExists(prisma: PrismaClient, adminEmail: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { email: adminEmail },
+    select: { id: true, role: true },
+  });
+
+  return user?.role === UserRole.admin;
+}
+
+export async function seedAdminUser(
+  prisma: PrismaClient,
+  config: SeedConfig = getSeedConfig(),
+): Promise<void> {
+  const passwordHash = await hashPassword(config.adminPassword);
+
+  const user = await prisma.user.upsert({
+    where: { email: config.adminEmail },
+    create: {
+      email: config.adminEmail,
+      displayName: config.adminDisplayName,
+      passwordHash,
+      role: UserRole.admin,
+    },
+    update: {
+      role: UserRole.admin,
+    },
+  });
+
+  await prisma.eloRating.upsert({
+    where: { userId: user.id },
+    create: {
+      userId: user.id,
+      rating: DEFAULT_ELO_RATING,
+      gamesPlayed: 0,
+    },
+    update: {},
+  });
+}
+
+export async function runSeed(
+  prisma: PrismaClient,
+  config: SeedConfig = getSeedConfig(),
+): Promise<void> {
+  // TODO sprint 2: seed leagues reference data
+  // TODO sprint 4: seed default skins reference data
+
+  if (await adminUserExists(prisma, config.adminEmail)) {
+    console.log(`Admin user ${config.adminEmail} already exists, skipping seed.`);
+    return;
+  }
+
+  await seedAdminUser(prisma, config);
+  console.log(`Seeded admin user ${config.adminEmail}.`);
+}

--- a/packages/db/src/seed/config.ts
+++ b/packages/db/src/seed/config.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_ADMIN_EMAIL = "admin@chifoumi.local";
+export const DEFAULT_ADMIN_PASSWORD = "admin-CHANGE-ME!";
+export const DEFAULT_ADMIN_DISPLAY_NAME = "admin";
+
+export type SeedConfig = {
+  adminEmail: string;
+  adminPassword: string;
+  adminDisplayName: string;
+};
+
+export function getSeedConfig(env: NodeJS.ProcessEnv = process.env): SeedConfig {
+  return {
+    adminEmail: env.ADMIN_DEFAULT_EMAIL ?? DEFAULT_ADMIN_EMAIL,
+    adminPassword: env.ADMIN_DEFAULT_PASSWORD ?? DEFAULT_ADMIN_PASSWORD,
+    adminDisplayName: DEFAULT_ADMIN_DISPLAY_NAME,
+  };
+}

--- a/packages/db/src/seed/password.ts
+++ b/packages/db/src/seed/password.ts
@@ -1,0 +1,16 @@
+import * as argon2 from "argon2";
+
+const ARGON2_OPTIONS: argon2.Options & { type: typeof argon2.argon2id } = {
+  type: argon2.argon2id,
+  memoryCost: 19456,
+  timeCost: 2,
+  parallelism: 1,
+};
+
+export function hashPassword(plain: string): Promise<string> {
+  return argon2.hash(plain, ARGON2_OPTIONS);
+}
+
+export function verifyPassword(hash: string, plain: string): Promise<boolean> {
+  return argon2.verify(hash, plain);
+}

--- a/packages/db/src/seed/seed.spec.ts
+++ b/packages/db/src/seed/seed.spec.ts
@@ -23,15 +23,17 @@ const seedConfig = getSeedConfig({
 });
 seedConfig.adminDisplayName = `seed_test_${runId}`;
 
+async function cleanupSeedUser(email: string): Promise<void> {
+  await prisma.user.deleteMany({ where: { email } });
+}
+
 describe("database seed", () => {
   beforeAll(async () => {
-    await prisma.eloRating.deleteMany({ where: { user: { email: seedConfig.adminEmail } } });
-    await prisma.user.deleteMany({ where: { email: seedConfig.adminEmail } });
+    await cleanupSeedUser(seedConfig.adminEmail);
   });
 
   afterAll(async () => {
-    await prisma.eloRating.deleteMany({ where: { user: { email: seedConfig.adminEmail } } });
-    await prisma.user.deleteMany({ where: { email: seedConfig.adminEmail } });
+    await cleanupSeedUser(seedConfig.adminEmail);
     await prisma.$disconnect();
   });
 

--- a/packages/db/src/seed/seed.spec.ts
+++ b/packages/db/src/seed/seed.spec.ts
@@ -1,0 +1,75 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient, UserRole } from "@prisma/client";
+import { config } from "dotenv";
+import { adminUserExists, runSeed, seedAdminUser } from "./admin-user.js";
+import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD, getSeedConfig } from "./config.js";
+import { verifyPassword } from "./password.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+const connectionString =
+  process.env.DATABASE_URL ?? "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+
+const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) });
+const runId = Date.now().toString();
+const seedConfig = getSeedConfig({
+  ...process.env,
+  ADMIN_DEFAULT_EMAIL: `seed-test-${runId}@chifoumi.local`,
+  ADMIN_DEFAULT_PASSWORD: DEFAULT_ADMIN_PASSWORD,
+});
+seedConfig.adminDisplayName = `seed_test_${runId}`;
+
+describe("database seed", () => {
+  beforeAll(async () => {
+    await prisma.eloRating.deleteMany({ where: { user: { email: seedConfig.adminEmail } } });
+    await prisma.user.deleteMany({ where: { email: seedConfig.adminEmail } });
+  });
+
+  afterAll(async () => {
+    await prisma.eloRating.deleteMany({ where: { user: { email: seedConfig.adminEmail } } });
+    await prisma.user.deleteMany({ where: { email: seedConfig.adminEmail } });
+    await prisma.$disconnect();
+  });
+
+  it("creates admin user with Argon2id hash and EloRating from empty database", async () => {
+    await runSeed(prisma, seedConfig);
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: seedConfig.adminEmail },
+      include: { eloRating: true },
+    });
+
+    expect(user.role).toBe(UserRole.admin);
+    expect(user.displayName).toBe(seedConfig.adminDisplayName);
+    expect(user.passwordHash).toMatch(/^\$argon2id\$/);
+    expect(await verifyPassword(user.passwordHash, seedConfig.adminPassword)).toBe(true);
+    expect(user.eloRating).toEqual(
+      expect.objectContaining({
+        rating: 1000,
+        gamesPlayed: 0,
+      }),
+    );
+  });
+
+  it("is idempotent when run on an existing database", async () => {
+    await seedAdminUser(prisma, seedConfig);
+
+    const beforeCount = await prisma.user.count({ where: { email: seedConfig.adminEmail } });
+    await runSeed(prisma, seedConfig);
+    const afterCount = await prisma.user.count({ where: { email: seedConfig.adminEmail } });
+
+    expect(beforeCount).toBe(1);
+    expect(afterCount).toBe(1);
+    expect(await adminUserExists(prisma, seedConfig.adminEmail)).toBe(true);
+  });
+
+  it("uses documented default credentials when env vars are unset", () => {
+    const defaults = getSeedConfig({});
+    expect(defaults.adminEmail).toBe(DEFAULT_ADMIN_EMAIL);
+    expect(defaults.adminPassword).toBe(DEFAULT_ADMIN_PASSWORD);
+  });
+});

--- a/packages/db/tsconfig.spec.json
+++ b/packages/db/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,15 +321,42 @@ importers:
 
   packages/db:
     devDependencies:
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
+      '@prisma/adapter-pg':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.7.3))(typescript@5.7.3)
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.12.4
+      argon2:
+        specifier: 0.41.1
+        version: 0.41.1
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@24.12.4)
+      pg:
+        specifier: ^8.16.3
+        version: 8.21.0
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.7.3)
+      ts-jest:
+        specifier: 29.2.5
+        version: 29.2.5(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.12.4))(typescript@5.7.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.22.2
       typescript:
         specifier: ~5.7.3
         version: 5.7.3


### PR DESCRIPTION
## Summary
- Add idempotent Prisma seed that creates the default admin account (`admin@chifoumi.local`) with Argon2id password hash and ELO rating at 1000
- Wire seed into `pnpm db:seed`, `prisma db seed`, and the API Docker entrypoint (`migrate deploy` then seed, skipping when admin already exists)
- Document dev credentials and production overrides (`ADMIN_DEFAULT_EMAIL` / `ADMIN_DEFAULT_PASSWORD`) in README and `.env.example`

## Test plan
- [x] `pnpm --filter @chifoumi/db test` — seed from empty DB + idempotence
- [x] `pnpm db:seed` on local Postgres — admin created, second run skips
- [ ] CI green on PR
- [ ] Manual login with seeded admin credentials via `POST /auth/login`
