### PR TITLE
feat(ops): docker-compose multi-replicas with Traefik (US-030)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Ajouter les entrees suivantes au fichier hosts local (`C:\Windows\System32\drive
 docker compose -f docker-compose.yml -f docker-compose.scale.yml up -d --build
 ```
 
-Services demarres : `postgres` x1, `redis` x1, `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
+Services demarres : `postgres` x1, `redis` x1, `db-migrate` (one-shot), `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
 
 | Service | URL via Traefik | Port direct |
 |---|---:|---|

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Plateforme web competitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties 
 
 - [Pre-requis](#pre-requis)
 - [Demarrage rapide](#demarrage-rapide)
+- [Stack multi-replicas (US-030)](#stack-multi-replicas-us-030)
 - [Tech stack](#tech-stack)
 - [Architecture](#architecture)
 - [Commandes utiles](#commandes-utiles)
@@ -42,6 +43,60 @@ Services lances par `pnpm dev` :
 | Job runner | terminal uniquement | Workers et traitements asynchrones |
 
 Si le schema Postgres evolue, relancer une base vide avec `docker compose down -v`, puis `docker compose up -d`.
+
+## Stack multi-replicas (US-030)
+
+Stack containerisee complete avec Traefik, 2 replicas API, 2 replicas Game Service et observabilite.
+
+### Pre-requis supplementaires
+
+Generer les cles JWT de dev (une seule fois) :
+
+```bash
+mkdir -p infra/keys
+openssl genrsa -out infra/keys/jwt-private.pem 2048
+openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+```
+
+Ajouter les entrees suivantes au fichier hosts local (`C:\Windows\System32\drivers\etc\hosts` ou `/etc/hosts`) :
+
+```text
+127.0.0.1 api.localhost front.localhost game.localhost traefik.localhost grafana.localhost prometheus.localhost
+```
+
+### Lancer la stack
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.scale.yml up -d --build
+```
+
+Services demarres : `postgres` x1, `redis` x1, `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
+
+| Service | URL via Traefik | Port direct |
+|---|---:|---|
+| Front | `http://front.localhost` | — |
+| API (round-robin) | `http://api.localhost/health` | — |
+| Game WS (sticky) | `ws://game.localhost/game` | — |
+| Traefik dashboard | `http://traefik.localhost` | — |
+| Grafana | `http://grafana.localhost` | `http://localhost:3002` |
+| Prometheus | `http://prometheus.localhost` | `http://localhost:9090` |
+| MailHog | — | `http://localhost:8025` |
+
+Verifier le round-robin API : `curl http://api.localhost/health` plusieurs fois et comparer le champ `instance` (`api-1` / `api-2`) dans les logs ou la reponse JSON.
+
+Demo de resilience : arreter une instance API puis verifier que `/health` repond toujours :
+
+```bash
+docker stop chifoumi-api-1
+curl http://api.localhost/health
+docker start chifoumi-api-1
+```
+
+Arreter la stack :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.scale.yml down
+```
 
 ## Tech stack
 
@@ -103,7 +158,7 @@ pnpm --filter @chifoumi/front dev
 | Swagger | `http://localhost:3000/api/docs` | disponible |
 | OpenAPI JSON | `http://localhost:3000/api/docs-json` | disponible |
 | MailHog | `http://localhost:8025` | disponible apres `docker compose up -d` |
-| Grafana | `http://localhost:3002` | prevu avec la stack observabilite |
+| Grafana | `http://localhost:3002` | disponible avec `docker-compose.scale.yml` |
 
 En production, la documentation Swagger est protegee par Basic Auth via `SWAGGER_USER` et `SWAGGER_PASSWORD`.
 Sans ces deux variables en production, les routes `/api/docs` et `/api/docs-json` ne sont pas exposees.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,6 +27,8 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV API_PORT=3000
 COPY --from=builder /app /app
+COPY apps/api/docker-entrypoint.sh /app/apps/api/docker-entrypoint.sh
+RUN chmod +x /app/apps/api/docker-entrypoint.sh
 USER node
 EXPOSE 3000
-CMD ["node", "apps/api/dist/main.js"]
+ENTRYPOINT ["/app/apps/api/docker-entrypoint.sh"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -21,14 +21,14 @@ RUN pnpm install --frozen-lockfile
 FROM deps AS builder
 COPY apps ./apps
 COPY packages ./packages
-RUN pnpm --filter @chifoumi/api build
+RUN pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/api build
 
 FROM base AS runner
 ENV NODE_ENV=production
 ENV API_PORT=3000
-COPY --from=builder /app /app
-COPY apps/api/docker-entrypoint.sh /app/apps/api/docker-entrypoint.sh
-RUN chmod +x /app/apps/api/docker-entrypoint.sh
+COPY --from=builder --chown=node:node /app /app
+COPY --chown=node:node apps/api/docker-migrate.sh /app/apps/api/docker-migrate.sh
+RUN chmod +x /app/apps/api/docker-migrate.sh
 USER node
 EXPOSE 3000
-ENTRYPOINT ["/app/apps/api/docker-entrypoint.sh"]
+CMD ["node", "apps/api/dist/main.js"]

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+cd /app
+
+pnpm --filter @chifoumi/db generate
+pnpm --filter @chifoumi/db migrate:deploy
+
+exec node apps/api/dist/main.js

--- a/apps/api/docker-migrate.sh
+++ b/apps/api/docker-migrate.sh
@@ -3,7 +3,4 @@ set -e
 
 cd /app
 
-pnpm --filter @chifoumi/db generate
 pnpm --filter @chifoumi/db migrate:deploy
-
-exec node apps/api/dist/main.js

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -7,6 +7,7 @@ export class HealthController {
     return {
       status: "ok",
       service: "api",
+      instance: process.env.INSTANCE_ID ?? "api",
       version: "1.0.0",
     };
   }

--- a/apps/front/Dockerfile
+++ b/apps/front/Dockerfile
@@ -19,10 +19,13 @@ COPY packages/tsconfig/package.json packages/tsconfig/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS builder
+ARG VITE_API_BASE_URL=http://localhost:3000
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 COPY apps ./apps
 COPY packages ./packages
 RUN pnpm --filter @chifoumi/front build
 
 FROM nginx:1.27-alpine AS runner
+COPY apps/front/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/apps/front/dist /usr/share/nginx/html
 EXPOSE 80

--- a/apps/front/nginx.conf
+++ b/apps/front/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/game-service/src/health/health.controller.ts
+++ b/apps/game-service/src/health/health.controller.ts
@@ -7,6 +7,7 @@ export class HealthController {
     return {
       status: "ok",
       service: "game-service",
+      instance: process.env.INSTANCE_ID ?? "game-service",
       version: "0.0.0",
     };
   }

--- a/docker-compose.scale.yml
+++ b/docker-compose.scale.yml
@@ -1,0 +1,267 @@
+x-api-common: &api-common
+  build:
+    context: .
+    dockerfile: apps/api/Dockerfile
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  environment: &api-env
+    DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+    REDIS_URL: redis://redis:6379
+    API_PORT: "3000"
+    CORS_ORIGINS: http://front.localhost,http://localhost:5173
+    FRONTEND_URL: http://front.localhost
+    JWT_PRIVATE_KEY_PATH: infra/keys/jwt-private.pem
+    JWT_PUBLIC_KEY_PATH: infra/keys/jwt-public.pem
+    JWT_ACCESS_TTL_SECONDS: "900"
+    JWT_REFRESH_TTL_SECONDS: "604800"
+    BULLMQ_PREFIX: rps
+    MAIL_TRANSPORT: mailhog
+    MAIL_HOST: mailhog
+    MAIL_PORT: "1025"
+    MAIL_FROM: noreply@chifoumi.local
+  volumes:
+    - ./infra/keys:/app/infra/keys:ro
+  healthcheck:
+    test:
+      [
+        "CMD",
+        "node",
+        "-e",
+        "fetch('http://127.0.0.1:3000/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+      ]
+    interval: 10s
+    timeout: 5s
+    retries: 6
+    start_period: 40s
+  restart: unless-stopped
+  networks:
+    - chifoumi
+
+x-game-common: &game-common
+  build:
+    context: .
+    dockerfile: apps/game-service/Dockerfile
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  environment: &game-env
+    DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+    REDIS_URL: redis://redis:6379
+    GAME_SERVICE_PORT: "3001"
+    CORS_ORIGINS: http://front.localhost,http://localhost:5173
+    FRONTEND_URL: http://front.localhost
+    JWT_PUBLIC_KEY_PATH: infra/keys/jwt-public.pem
+    BULLMQ_PREFIX: rps
+  volumes:
+    - ./infra/keys:/app/infra/keys:ro
+  healthcheck:
+    test:
+      [
+        "CMD",
+        "node",
+        "-e",
+        "fetch('http://127.0.0.1:3001/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+      ]
+    interval: 10s
+    timeout: 5s
+    retries: 6
+    start_period: 30s
+  restart: unless-stopped
+  networks:
+    - chifoumi
+
+x-traefik-api-labels: &traefik-api-labels
+  traefik.enable: "true"
+  traefik.http.routers.api.rule: Host(`api.localhost`)
+  traefik.http.routers.api.entrypoints: web
+  traefik.http.services.api.loadbalancer.server.port: "3000"
+
+x-traefik-game-labels: &traefik-game-labels
+  traefik.enable: "true"
+  traefik.http.routers.game.rule: Host(`game.localhost`)
+  traefik.http.routers.game.entrypoints: web
+  traefik.http.services.game.loadbalancer.server.port: "3001"
+  traefik.http.services.game.loadbalancer.sticky.cookie: "true"
+  traefik.http.services.game.loadbalancer.sticky.cookie.name: chifoumi_game
+
+services:
+  postgres:
+    networks:
+      - chifoumi
+
+  redis:
+    networks:
+      - chifoumi
+
+  mailhog:
+    networks:
+      - chifoumi
+
+  job-runner-match:
+    networks:
+      - chifoumi
+
+  job-runner-misc:
+    networks:
+      - chifoumi
+
+  traefik:
+    image: traefik:v3.3
+    container_name: chifoumi-traefik
+    command:
+      - --api.dashboard=true
+      - --api.insecure=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.traefik.rule: Host(`traefik.localhost`)
+      traefik.http.routers.traefik.entrypoints: web
+      traefik.http.routers.traefik.service: api@internal
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:80/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+  api-1:
+    <<: *api-common
+    container_name: chifoumi-api-1
+    environment:
+      <<: *api-env
+      INSTANCE_ID: api-1
+    labels:
+      <<: *traefik-api-labels
+
+  api-2:
+    <<: *api-common
+    container_name: chifoumi-api-2
+    environment:
+      <<: *api-env
+      INSTANCE_ID: api-2
+    labels:
+      <<: *traefik-api-labels
+
+  game-1:
+    <<: *game-common
+    container_name: chifoumi-game-1
+    environment:
+      <<: *game-env
+      INSTANCE_ID: game-1
+    labels:
+      <<: *traefik-game-labels
+
+  game-2:
+    <<: *game-common
+    container_name: chifoumi-game-2
+    environment:
+      <<: *game-env
+      INSTANCE_ID: game-2
+    labels:
+      <<: *traefik-game-labels
+
+  front:
+    build:
+      context: .
+      dockerfile: apps/front/Dockerfile
+      args:
+        VITE_API_BASE_URL: http://api.localhost
+    container_name: chifoumi-front
+    depends_on:
+      api-1:
+        condition: service_healthy
+      api-2:
+        condition: service_healthy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.front.rule: Host(`front.localhost`)
+      traefik.http.routers.front.entrypoints: web
+      traefik.http.services.front.loadbalancer.server.port: "80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    container_name: chifoumi-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+    volumes:
+      - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.prometheus.rule: Host(`prometheus.localhost`)
+      traefik.http.routers.prometheus.entrypoints: web
+      traefik.http.services.prometheus.loadbalancer.server.port: "9090"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:9090/-/healthy || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    container_name: chifoumi-grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3002:3000"
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.grafana.rule: Host(`grafana.localhost`)
+      traefik.http.routers.grafana.entrypoints: web
+      traefik.http.services.grafana.loadbalancer.server.port: "3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+networks:
+  chifoumi:
+    name: chifoumi
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/docker-compose.scale.yml
+++ b/docker-compose.scale.yml
@@ -3,8 +3,8 @@ x-api-common: &api-common
     context: .
     dockerfile: apps/api/Dockerfile
   depends_on:
-    postgres:
-      condition: service_healthy
+    db-migrate:
+      condition: service_completed_successfully
     redis:
       condition: service_healthy
   environment: &api-env
@@ -107,6 +107,21 @@ services:
       - chifoumi
 
   job-runner-misc:
+    networks:
+      - chifoumi
+
+  db-migrate:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: chifoumi-db-migrate
+    entrypoint: ["/app/apps/api/docker-migrate.sh"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+    restart: "no"
     networks:
       - chifoumi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "ps -o comm= 1 | grep -qE 'node|sh'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     environment:
       DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
       REDIS_URL: redis://redis:6379
@@ -80,6 +86,12 @@ services:
         condition: service_healthy
       mailhog:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "ps -o comm= 1 | grep -qE 'node|sh'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     environment:
       DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
       REDIS_URL: redis://redis:6379

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,3 +1,6 @@
+# Prometheus self-scrape only for US-030 stack bootstrap.
+# Application targets (API, game-service, job-runner) are planned in US-039.
+
 global:
   scrape_interval: 15s
   evaluation_interval: 15s


### PR DESCRIPTION
## Summary
- Add `docker-compose.scale.yml` overlay with Traefik reverse proxy, 2 API replicas, 2 game-service replicas (sticky WS), front, Prometheus and Grafana
- API containers run Prisma migrations on startup; health endpoints expose `instance` for round-robin demo
- Document scaled stack launch, hosts entries, URLs and resilience demo in README

## Test plan
- [ ] Generate JWT dev keys in `infra/keys/`
- [ ] Add `*.localhost` entries to hosts file
- [ ] Run `docker compose -f docker-compose.yml -f docker-compose.scale.yml up -d --build`
- [ ] Verify `curl http://api.localhost/health` alternates between `api-1` and `api-2`
- [ ] Verify `docker stop chifoumi-api-1` then health still responds via `api-2`
- [ ] Verify WS sticky routing on `ws://game.localhost/game`
- [ ] CI lint, typecheck, test and build jobs pass