### PR TITLE
feat(ops): US-031 cross-instance BO3 smoke E2E test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Local development only. Do not use these values in production.
 
-# PostgreSQL connection used by Prisma and the API.
+# PostgreSQL connection used by Prisma, the API and match-event job-runner persistence.
 DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi
 
 # Redis connection used by cache, pub-sub and BullMQ workers.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: chifoumi_dev
+          POSTGRES_DB: chifoumi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U app -d chifoumi"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     env:
       DATABASE_URL: postgresql://app:chifoumi_dev@localhost:5432/chifoumi
@@ -59,14 +72,22 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - name: Build database package
-        run: pnpm --filter @chifoumi/db build
+      - name: Build workspace packages for tests
+        run: |
+          pnpm --filter @chifoumi/db build
+          pnpm --filter @chifoumi/elo build
+
+      - name: Apply database migrations
+        run: pnpm --filter @chifoumi/db migrate:deploy
 
       - name: Test with coverage
         run: pnpm -r run --if-present test
 
       - name: Game service WebSocket e2e tests
         run: pnpm --filter @chifoumi/game-service test:e2e
+
+      - name: Job-runner match-events integration tests
+        run: pnpm --filter @chifoumi/job-runner test:integration
 
       - name: Upload coverage artifact
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,6 +138,12 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
 
+      - name: Generate dev JWT keys for E2E
+        run: |
+          mkdir -p infra/keys
+          openssl genrsa -out infra/keys/jwt-private.pem 2048
+          openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+
       - name: Build E2E stack
         run: |
           pnpm --filter @chifoumi/db build
@@ -149,6 +155,22 @@ jobs:
 
       - name: Start E2E stack
         run: bash scripts/e2e/start-stack.sh
+
+      - name: Wait for E2E health endpoints
+        run: |
+          for url in http://127.0.0.1:3000/health http://127.0.0.1:3101/health http://127.0.0.1:3102/health; do
+            for attempt in $(seq 1 30); do
+              if curl -fsS "$url" >/dev/null; then
+                echo "$url is healthy"
+                break
+              fi
+              if [ "$attempt" -eq 30 ]; then
+                echo "$url failed health check"
+                exit 1
+              fi
+              sleep 2
+            done
+          done
 
       - name: BO3 cross-instance smoke test (US-031)
         run: pnpm --filter @chifoumi/e2e test:smoke

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -91,3 +91,68 @@ jobs:
 
       - name: Build
         run: pnpm -r run --if-present build
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: chifoumi_dev
+          POSTGRES_DB: chifoumi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://app:chifoumi_dev@localhost:5432/chifoumi
+      REDIS_URL: redis://localhost:6379
+      BULLMQ_PREFIX: rps
+      JWT_PRIVATE_KEY_PATH: infra/keys/jwt-private.pem
+      JWT_PUBLIC_KEY_PATH: infra/keys/jwt-public.pem
+      MATCHMAKING_WORKER_ENABLED: "true"
+      WORKER_QUEUES: match-events
+      WORKER_CONCURRENCY: 8
+      CRON_ENABLED: "false"
+      E2E_API_URL: http://127.0.0.1:3000
+      E2E_GAME_1_URL: http://127.0.0.1:3101
+      E2E_GAME_2_URL: http://127.0.0.1:3102
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Build E2E stack
+        run: |
+          pnpm --filter @chifoumi/db build
+          pnpm --filter @chifoumi/elo build
+          pnpm --filter @chifoumi/api build
+          pnpm --filter @chifoumi/game-service build
+          pnpm --filter @chifoumi/job-runner build
+          pnpm --filter @chifoumi/db migrate:deploy
+
+      - name: Start E2E stack
+        run: bash scripts/e2e/start-stack.sh
+
+      - name: BO3 cross-instance smoke test (US-031)
+        run: pnpm --filter @chifoumi/e2e test:smoke
+
+      - name: Stop E2E stack
+        if: always()
+        run: bash scripts/e2e/stop-stack.sh

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -19,14 +19,17 @@ COPY packages/tsconfig/package.json packages/tsconfig/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS builder
+ENV DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi
 COPY apps ./apps
 COPY packages ./packages
-RUN pnpm --filter @chifoumi/api build
+RUN pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/api build
 
 FROM base AS runner
 ENV NODE_ENV=production
 ENV API_PORT=3000
 COPY --from=builder /app /app
+COPY apps/api/docker-entrypoint.sh /app/apps/api/docker-entrypoint.sh
+RUN chmod +x /app/apps/api/docker-entrypoint.sh
 USER node
 EXPOSE 3000
-CMD ["node", "apps/api/dist/main.js"]
+ENTRYPOINT ["/app/apps/api/docker-entrypoint.sh"]

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+cd /app
+pnpm --filter @chifoumi/db migrate:deploy
+
+exec node apps/api/dist/main.js

--- a/apps/game-service/src/match-session/match-session.types.ts
+++ b/apps/game-service/src/match-session/match-session.types.ts
@@ -21,6 +21,14 @@ export type RoundPlays = {
   b: Move | null;
 };
 
+export type ResolvedRound = {
+  roundNumber: number;
+  moveA: Move | null;
+  moveB: Move | null;
+  winner: "a" | "b" | "draw";
+  resolvedAt: string;
+};
+
 export type MatchState = {
   matchId: string;
   players: [MatchPlayer, MatchPlayer];
@@ -31,6 +39,7 @@ export type MatchState = {
   startedAt: string;
   roundDeadline: string;
   roundPlays: RoundPlays;
+  rounds?: ResolvedRound[];
   winnerId?: string;
   endReason?: MatchEndReason;
 };

--- a/apps/game-service/src/match/match-ended-publisher.service.ts
+++ b/apps/game-service/src/match/match-ended-publisher.service.ts
@@ -5,6 +5,7 @@ import type { MatchEndedPayload, MatchState } from "../match-session/match-sessi
 
 export type MatchEndedJobPayload = MatchEndedPayload & {
   players: MatchState["players"];
+  rounds: NonNullable<MatchState["rounds"]>;
   endReason: MatchState["endReason"];
   startedAt: string;
 };
@@ -44,11 +45,17 @@ export class MatchEndedPublisher implements OnModuleInit, OnModuleDestroy {
       eloDelta: { a: 0, b: 0 },
       reason: state.endReason,
       players: state.players,
+      rounds: state.rounds ?? [],
       endReason: state.endReason,
       startedAt: state.startedAt,
     };
 
     await this.queue.add("match-ended", payload, {
+      attempts: 3,
+      backoff: {
+        type: "exponential",
+        delay: 1000,
+      },
       removeOnComplete: true,
       removeOnFail: 100,
     });

--- a/apps/game-service/src/match/match-play.service.spec.ts
+++ b/apps/game-service/src/match/match-play.service.spec.ts
@@ -88,6 +88,10 @@ describe("MatchPlayService", () => {
     expect(state?.scoreA).toBe(2);
     expect(state?.winnerId).toBe("a");
     expect(publishedJobs).toHaveLength(1);
+    expect(state?.rounds).toEqual([
+      expect.objectContaining({ roundNumber: 1, moveA: "rock", moveB: "scissors", winner: "a" }),
+      expect.objectContaining({ roundNumber: 2, moveA: "paper", moveB: "rock", winner: "a" }),
+    ]);
     expect(await client.get("match:byUser:a")).toBeNull();
   });
 

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -128,11 +128,28 @@ export class MatchPlayService implements OnModuleDestroy {
 
       const resolving = transitionMatchState(updated, { type: "PLAYS_RECEIVED" });
       const winner = resolveRps(roundPlays.a, roundPlays.b);
-      return transitionMatchState(resolving, {
-        type: "ROUND_RESOLVED",
-        winner,
-        now: new Date(),
-      });
+      const resolvedAt = new Date();
+      const winnerLabel = winner === "DRAW" ? "draw" : winner === "A" ? "a" : "b";
+      return transitionMatchState(
+        {
+          ...resolving,
+          rounds: [
+            ...(normalized.rounds ?? []),
+            {
+              roundNumber: normalized.currentRound,
+              moveA: roundPlays.a,
+              moveB: roundPlays.b,
+              winner: winnerLabel,
+              resolvedAt: resolvedAt.toISOString(),
+            },
+          ],
+        },
+        {
+          type: "ROUND_RESOLVED",
+          winner,
+          now: resolvedAt,
+        },
+      );
     });
 
     if (!resolution) {
@@ -154,12 +171,29 @@ export class MatchPlayService implements OnModuleDestroy {
           : state.roundPlays.b === null && state.roundPlays.a !== null
             ? "B"
             : "A";
+      const winnerLabel = silentPlayer === "A" ? "b" : "a";
 
-      return transitionMatchState(state, {
-        type: "TIMEOUT",
-        silentPlayer,
-        now: new Date(),
-      });
+      const resolvedAt = new Date();
+      return transitionMatchState(
+        {
+          ...state,
+          rounds: [
+            ...(state.rounds ?? []),
+            {
+              roundNumber,
+              moveA: state.roundPlays.a,
+              moveB: state.roundPlays.b,
+              winner: winnerLabel,
+              resolvedAt: resolvedAt.toISOString(),
+            },
+          ],
+        },
+        {
+          type: "TIMEOUT",
+          silentPlayer,
+          now: resolvedAt,
+        },
+      );
     });
 
     if (nextState.status === "ENDED") {

--- a/apps/job-runner/Dockerfile
+++ b/apps/job-runner/Dockerfile
@@ -19,9 +19,10 @@ COPY packages/tsconfig/package.json packages/tsconfig/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS builder
+ENV DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi
 COPY apps ./apps
 COPY packages ./packages
-RUN pnpm --filter @chifoumi/job-runner build
+RUN pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/job-runner build
 
 FROM base AS runner
 ENV NODE_ENV=production

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -20,12 +20,17 @@
     "typescript": "~5.7.3"
   },
   "dependencies": {
+    "@chifoumi/db": "workspace:*",
+    "@chifoumi/elo": "workspace:*",
     "@nestjs/common": "^11.1.21",
     "@nestjs/core": "^11.1.21",
+    "@prisma/adapter-pg": "^7.8.0",
+    "@prisma/client": "^7.8.0",
     "bullmq": "^5.49.2",
     "dotenv": "^17.2.3",
     "ioredis": "^5.11.1",
     "nestjs-pino": "4.2.0",
+    "pg": "^8.16.3",
     "pino-http": "10.4.0",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",

--- a/apps/job-runner/src/app.module.ts
+++ b/apps/job-runner/src/app.module.ts
@@ -3,6 +3,9 @@ import { LoggerModule } from "nestjs-pino";
 import { ConfigModule } from "./config/config.module.js";
 import { CronSchedulerService } from "./cron/cron-scheduler.service.js";
 import { WorkerMetricsService } from "./metrics/worker-metrics.service.js";
+import { MatchPersistenceService } from "./persistence/match-persistence.service.js";
+import { PrismaModule } from "./prisma/prisma.module.js";
+import { RedisInvalidationService } from "./redis/redis-invalidation.service.js";
 import { RunnerService } from "./runner.service.js";
 import { WorkerFactory } from "./workers/worker-factory.js";
 
@@ -14,7 +17,15 @@ import { WorkerFactory } from "./workers/worker-factory.js";
       },
     }),
     ConfigModule,
+    PrismaModule,
   ],
-  providers: [WorkerMetricsService, WorkerFactory, CronSchedulerService, RunnerService],
+  providers: [
+    WorkerMetricsService,
+    MatchPersistenceService,
+    RedisInvalidationService,
+    WorkerFactory,
+    CronSchedulerService,
+    RunnerService,
+  ],
 })
 export class AppModule {}

--- a/apps/job-runner/src/match-events/match-ended.processor.spec.ts
+++ b/apps/job-runner/src/match-events/match-ended.processor.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { type Job, UnrecoverableError } from "bullmq";
+import { createMatchEndedProcessor } from "./match-ended.processor.js";
+
+const validPayload = {
+  matchId: "33333333-3333-4333-8333-333333333333",
+  players: [
+    { userId: "11111111-1111-4111-8111-111111111111", displayName: "alice", rating: 1000 },
+    { userId: "22222222-2222-4222-8222-222222222222", displayName: "bob", rating: 1000 },
+  ],
+  rounds: [
+    {
+      roundNumber: 1,
+      moveA: "rock",
+      moveB: "scissors",
+      winner: "a",
+      resolvedAt: "2026-06-09T10:00:01.000Z",
+    },
+  ],
+  winner: "11111111-1111-4111-8111-111111111111",
+  finalScore: { a: 2, b: 0 },
+  startedAt: "2026-06-09T10:00:00.000Z",
+};
+
+function createJob(overrides: Partial<Job> = {}): Job {
+  return {
+    name: "match-ended",
+    data: validPayload,
+    ...overrides,
+  } as Job;
+}
+
+describe("createMatchEndedProcessor", () => {
+  it("persists valid match-ended jobs and invalidates the leaderboard", async () => {
+    const matchPersistence = {
+      persistMatchEnded: jest.fn(async () => true),
+    };
+    const redisInvalidation = {
+      invalidateLeaderboard: jest.fn(async () => undefined),
+    };
+    const processor = createMatchEndedProcessor({
+      matchPersistence: matchPersistence as never,
+      redisInvalidation: redisInvalidation as never,
+    });
+
+    await processor(createJob());
+
+    expect(matchPersistence.persistMatchEnded).toHaveBeenCalledWith(validPayload);
+    expect(redisInvalidation.invalidateLeaderboard).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate leaderboard for idempotent replays", async () => {
+    const matchPersistence = {
+      persistMatchEnded: jest.fn(async () => false),
+    };
+    const redisInvalidation = {
+      invalidateLeaderboard: jest.fn(async () => undefined),
+    };
+    const processor = createMatchEndedProcessor({
+      matchPersistence: matchPersistence as never,
+      redisInvalidation: redisInvalidation as never,
+    });
+
+    await processor(createJob());
+
+    expect(redisInvalidation.invalidateLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid payloads without retry", async () => {
+    const processor = createMatchEndedProcessor({
+      matchPersistence: { persistMatchEnded: jest.fn() } as never,
+      redisInvalidation: { invalidateLeaderboard: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob({ data: { invalid: true } }))).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+});

--- a/apps/job-runner/src/match-events/match-ended.processor.spec.ts
+++ b/apps/job-runner/src/match-events/match-ended.processor.spec.ts
@@ -33,7 +33,7 @@ function createJob(overrides: Partial<Job> = {}): Job {
 describe("createMatchEndedProcessor", () => {
   it("persists valid match-ended jobs and invalidates the leaderboard", async () => {
     const matchPersistence = {
-      persistMatchEnded: jest.fn(async () => true),
+      persistMatchEnded: jest.fn(async () => "created"),
     };
     const redisInvalidation = {
       invalidateLeaderboard: jest.fn(async () => undefined),
@@ -49,9 +49,9 @@ describe("createMatchEndedProcessor", () => {
     expect(redisInvalidation.invalidateLeaderboard).toHaveBeenCalledTimes(1);
   });
 
-  it("does not invalidate leaderboard for idempotent replays", async () => {
+  it("invalidates leaderboard for idempotent replays", async () => {
     const matchPersistence = {
-      persistMatchEnded: jest.fn(async () => false),
+      persistMatchEnded: jest.fn(async () => "already_exists"),
     };
     const redisInvalidation = {
       invalidateLeaderboard: jest.fn(async () => undefined),
@@ -63,7 +63,7 @@ describe("createMatchEndedProcessor", () => {
 
     await processor(createJob());
 
-    expect(redisInvalidation.invalidateLeaderboard).not.toHaveBeenCalled();
+    expect(redisInvalidation.invalidateLeaderboard).toHaveBeenCalledTimes(1);
   });
 
   it("rejects invalid payloads without retry", async () => {
@@ -75,5 +75,37 @@ describe("createMatchEndedProcessor", () => {
     await expect(processor(createJob({ data: { invalid: true } }))).rejects.toBeInstanceOf(
       UnrecoverableError,
     );
+  });
+
+  it("rejects payloads whose winner is not a match player without retry", async () => {
+    const processor = createMatchEndedProcessor({
+      matchPersistence: { persistMatchEnded: jest.fn() } as never,
+      redisInvalidation: { invalidateLeaderboard: jest.fn() } as never,
+    });
+
+    await expect(
+      processor(
+        createJob({
+          data: {
+            ...validPayload,
+            winner: "44444444-4444-4444-8444-444444444444",
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(UnrecoverableError);
+  });
+
+  it("propagates persistence failures so BullMQ can retry", async () => {
+    const error = new Error("database unavailable");
+    const processor = createMatchEndedProcessor({
+      matchPersistence: {
+        persistMatchEnded: jest.fn(async () => {
+          throw error;
+        }),
+      } as never,
+      redisInvalidation: { invalidateLeaderboard: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob())).rejects.toBe(error);
   });
 });

--- a/apps/job-runner/src/match-events/match-ended.processor.ts
+++ b/apps/job-runner/src/match-events/match-ended.processor.ts
@@ -8,36 +8,47 @@ import type { MatchEndedPayload } from "./match-ended.types.js";
 const moveSchema = z.enum(["rock", "paper", "scissors"]).nullable();
 const roundWinnerSchema = z.enum(["a", "b", "draw"]);
 
-const matchEndedPayloadSchema = z.object({
-  matchId: z.string().uuid(),
-  players: z.tuple([
-    z.object({
-      userId: z.string().uuid(),
-      displayName: z.string(),
-      rating: z.number(),
+const matchEndedPayloadSchema = z
+  .object({
+    matchId: z.string().uuid(),
+    players: z.tuple([
+      z.object({
+        userId: z.string().uuid(),
+        displayName: z.string(),
+        rating: z.number(),
+      }),
+      z.object({
+        userId: z.string().uuid(),
+        displayName: z.string(),
+        rating: z.number(),
+      }),
+    ]),
+    rounds: z.array(
+      z.object({
+        roundNumber: z.number().int().positive(),
+        moveA: moveSchema,
+        moveB: moveSchema,
+        winner: roundWinnerSchema,
+        resolvedAt: z.string().datetime(),
+      }),
+    ),
+    winner: z.string().uuid().nullable(),
+    finalScore: z.object({
+      a: z.number().int().nonnegative(),
+      b: z.number().int().nonnegative(),
     }),
-    z.object({
-      userId: z.string().uuid(),
-      displayName: z.string(),
-      rating: z.number(),
-    }),
-  ]),
-  rounds: z.array(
-    z.object({
-      roundNumber: z.number().int().positive(),
-      moveA: moveSchema,
-      moveB: moveSchema,
-      winner: roundWinnerSchema,
-      resolvedAt: z.string().datetime(),
-    }),
-  ),
-  winner: z.string().uuid().nullable(),
-  finalScore: z.object({
-    a: z.number().int().nonnegative(),
-    b: z.number().int().nonnegative(),
-  }),
-  startedAt: z.string().datetime(),
-});
+    startedAt: z.string().datetime(),
+  })
+  .refine(
+    (payload) =>
+      payload.winner === null ||
+      payload.winner === payload.players[0].userId ||
+      payload.winner === payload.players[1].userId,
+    {
+      message: "winner must be null or one of the match players",
+      path: ["winner"],
+    },
+  );
 
 export type MatchEventsProcessorDependencies = {
   matchPersistence: MatchPersistenceService;
@@ -55,10 +66,10 @@ export function createMatchEndedProcessor(deps: MatchEventsProcessorDependencies
       throw new UnrecoverableError("Invalid match-ended job payload");
     }
 
-    const persisted = await deps.matchPersistence.persistMatchEnded(
+    const persistenceStatus = await deps.matchPersistence.persistMatchEnded(
       parsed.data as MatchEndedPayload,
     );
-    if (persisted) {
+    if (persistenceStatus === "created" || persistenceStatus === "already_exists") {
       await deps.redisInvalidation.invalidateLeaderboard();
     }
   };

--- a/apps/job-runner/src/match-events/match-ended.processor.ts
+++ b/apps/job-runner/src/match-events/match-ended.processor.ts
@@ -1,0 +1,65 @@
+import { type Job, UnrecoverableError } from "bullmq";
+import { z } from "zod";
+import type { MatchPersistenceService } from "../persistence/match-persistence.service.js";
+import type { RedisInvalidationService } from "../redis/redis-invalidation.service.js";
+import type { WorkerProcessor } from "../workers/worker-processors.js";
+import type { MatchEndedPayload } from "./match-ended.types.js";
+
+const moveSchema = z.enum(["rock", "paper", "scissors"]).nullable();
+const roundWinnerSchema = z.enum(["a", "b", "draw"]);
+
+const matchEndedPayloadSchema = z.object({
+  matchId: z.string().uuid(),
+  players: z.tuple([
+    z.object({
+      userId: z.string().uuid(),
+      displayName: z.string(),
+      rating: z.number(),
+    }),
+    z.object({
+      userId: z.string().uuid(),
+      displayName: z.string(),
+      rating: z.number(),
+    }),
+  ]),
+  rounds: z.array(
+    z.object({
+      roundNumber: z.number().int().positive(),
+      moveA: moveSchema,
+      moveB: moveSchema,
+      winner: roundWinnerSchema,
+      resolvedAt: z.string().datetime(),
+    }),
+  ),
+  winner: z.string().uuid().nullable(),
+  finalScore: z.object({
+    a: z.number().int().nonnegative(),
+    b: z.number().int().nonnegative(),
+  }),
+  startedAt: z.string().datetime(),
+});
+
+export type MatchEventsProcessorDependencies = {
+  matchPersistence: MatchPersistenceService;
+  redisInvalidation: RedisInvalidationService;
+};
+
+export function createMatchEndedProcessor(deps: MatchEventsProcessorDependencies): WorkerProcessor {
+  return async (job: Job) => {
+    if (job.name !== "match-ended") {
+      throw new UnrecoverableError(`Unsupported job name on match-events: ${job.name}`);
+    }
+
+    const parsed = matchEndedPayloadSchema.safeParse(job.data);
+    if (!parsed.success) {
+      throw new UnrecoverableError("Invalid match-ended job payload");
+    }
+
+    const persisted = await deps.matchPersistence.persistMatchEnded(
+      parsed.data as MatchEndedPayload,
+    );
+    if (persisted) {
+      await deps.redisInvalidation.invalidateLeaderboard();
+    }
+  };
+}

--- a/apps/job-runner/src/match-events/match-ended.types.ts
+++ b/apps/job-runner/src/match-events/match-ended.types.ts
@@ -1,0 +1,24 @@
+import type { Move, RoundWinner } from "@chifoumi/db";
+
+export type MatchEndedPlayer = {
+  userId: string;
+  displayName: string;
+  rating: number;
+};
+
+export type MatchEndedRound = {
+  roundNumber: number;
+  moveA: Move | null;
+  moveB: Move | null;
+  winner: RoundWinner;
+  resolvedAt: string;
+};
+
+export type MatchEndedPayload = {
+  matchId: string;
+  players: [MatchEndedPlayer, MatchEndedPlayer];
+  rounds: MatchEndedRound[];
+  winner: string | null;
+  finalScore: { a: number; b: number };
+  startedAt: string;
+};

--- a/apps/job-runner/src/persistence/match-persistence.service.spec.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.spec.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@chifoumi/db";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { MatchEndedPayload } from "../match-events/match-ended.types.js";
 import type { PrismaService } from "../prisma/prisma.service.js";
@@ -91,7 +92,7 @@ describe("MatchPersistenceService", () => {
   it("persists a match-ended payload and updates both ELO ratings in one transaction", async () => {
     const persisted = await service.persistMatchEnded(createPayload());
 
-    expect(persisted).toBe(true);
+    expect(persisted).toBe("created");
     expect(tx.match.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -127,10 +128,24 @@ describe("MatchPersistenceService", () => {
 
     const persisted = await service.persistMatchEnded(createPayload());
 
-    expect(persisted).toBe(false);
+    expect(persisted).toBe("already_exists");
     expect(tx.match.create).not.toHaveBeenCalled();
     expect(tx.round.upsert).not.toHaveBeenCalled();
     expect(tx.eloRating.update).not.toHaveBeenCalled();
     expect(tx.eloHistory.createMany).not.toHaveBeenCalled();
+  });
+
+  it("treats unique match create conflicts as idempotent replay", async () => {
+    tx.match.create.mockImplementation(async () => {
+      throw new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["id"] },
+      });
+    });
+
+    const persisted = await service.persistMatchEnded(createPayload());
+
+    expect(persisted).toBe("already_exists");
   });
 });

--- a/apps/job-runner/src/persistence/match-persistence.service.spec.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.spec.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { MatchEndedPayload } from "../match-events/match-ended.types.js";
+import type { PrismaService } from "../prisma/prisma.service.js";
+import { MatchPersistenceService } from "./match-persistence.service.js";
+
+const playerAId = "11111111-1111-4111-8111-111111111111";
+const playerBId = "22222222-2222-4222-8222-222222222222";
+const matchId = "33333333-3333-4333-8333-333333333333";
+
+function createPayload(): MatchEndedPayload {
+  return {
+    matchId,
+    players: [
+      { userId: playerAId, displayName: "alice", rating: 1000 },
+      { userId: playerBId, displayName: "bob", rating: 1000 },
+    ],
+    rounds: [
+      {
+        roundNumber: 1,
+        moveA: "rock",
+        moveB: "scissors",
+        winner: "a",
+        resolvedAt: "2026-06-09T10:00:01.000Z",
+      },
+      {
+        roundNumber: 2,
+        moveA: "paper",
+        moveB: "rock",
+        winner: "a",
+        resolvedAt: "2026-06-09T10:00:02.000Z",
+      },
+    ],
+    winner: playerAId,
+    finalScore: { a: 2, b: 0 },
+    startedAt: "2026-06-09T10:00:00.000Z",
+  };
+}
+
+type MockTx = {
+  match: {
+    findUnique: jest.Mock;
+    create: jest.Mock;
+  };
+  round: {
+    upsert: jest.Mock;
+  };
+  eloRating: {
+    upsert: jest.Mock;
+    update: jest.Mock;
+  };
+  eloHistory: {
+    createMany: jest.Mock;
+  };
+};
+
+function createTx(overrides: Partial<MockTx> = {}): MockTx {
+  return {
+    match: {
+      findUnique: jest.fn(async () => null),
+      create: jest.fn(async () => ({})),
+    },
+    round: {
+      upsert: jest.fn(async () => ({})),
+    },
+    eloRating: {
+      upsert: jest.fn(async () => ({ rating: 1000, gamesPlayed: 30 })),
+      update: jest.fn(async () => ({})),
+    },
+    eloHistory: {
+      createMany: jest.fn(async () => ({})),
+    },
+    ...overrides,
+  };
+}
+
+describe("MatchPersistenceService", () => {
+  let tx: ReturnType<typeof createTx>;
+  let prisma: {
+    $transaction: (callback: (client: MockTx) => Promise<unknown>) => Promise<unknown>;
+  };
+  let service: MatchPersistenceService;
+
+  beforeEach(() => {
+    tx = createTx();
+    prisma = {
+      $transaction: async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx),
+    };
+    service = new MatchPersistenceService(prisma as unknown as PrismaService);
+  });
+
+  it("persists a match-ended payload and updates both ELO ratings in one transaction", async () => {
+    const persisted = await service.persistMatchEnded(createPayload());
+
+    expect(persisted).toBe(true);
+    expect(tx.match.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: matchId,
+          playerAId,
+          playerBId,
+          winnerId: playerAId,
+          scoreA: 2,
+          scoreB: 0,
+          status: "ended",
+        }),
+      }),
+    );
+    expect(tx.round.upsert).toHaveBeenCalledTimes(2);
+    expect(tx.eloRating.update).toHaveBeenCalledWith({
+      where: { userId: playerAId },
+      data: { rating: 1016, gamesPlayed: { increment: 1 } },
+    });
+    expect(tx.eloRating.update).toHaveBeenCalledWith({
+      where: { userId: playerBId },
+      data: { rating: 984, gamesPlayed: { increment: 1 } },
+    });
+    expect(tx.eloHistory.createMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({ userId: playerAId, ratingBefore: 1000, ratingAfter: 1016 }),
+        expect.objectContaining({ userId: playerBId, ratingBefore: 1000, ratingAfter: 984 }),
+      ]),
+    });
+  });
+
+  it("skips writes when the match already exists", async () => {
+    tx.match.findUnique.mockImplementation(async () => ({ id: matchId }));
+
+    const persisted = await service.persistMatchEnded(createPayload());
+
+    expect(persisted).toBe(false);
+    expect(tx.match.create).not.toHaveBeenCalled();
+    expect(tx.round.upsert).not.toHaveBeenCalled();
+    expect(tx.eloRating.update).not.toHaveBeenCalled();
+    expect(tx.eloHistory.createMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/job-runner/src/persistence/match-persistence.service.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.ts
@@ -7,104 +7,113 @@ import { PrismaService } from "../prisma/prisma.service.js";
 const DEFAULT_RATING = 1000;
 const DEFAULT_GAMES_PLAYED = 0;
 
+export type MatchPersistenceResult = "created" | "already_exists";
+
 @Injectable()
 export class MatchPersistenceService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async persistMatchEnded(payload: MatchEndedPayload): Promise<boolean> {
-    return this.prisma.$transaction(async (tx) => {
-      const existing = await tx.match.findUnique({
-        where: { id: payload.matchId },
-        select: { id: true },
-      });
-      if (existing) {
-        return false;
-      }
+  async persistMatchEnded(payload: MatchEndedPayload): Promise<MatchPersistenceResult> {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const existing = await tx.match.findUnique({
+          where: { id: payload.matchId },
+          select: { id: true },
+        });
+        if (existing) {
+          return "already_exists";
+        }
 
-      const [playerA, playerB] = payload.players;
-      const [ratingA, ratingB] = await Promise.all([
-        this.findOrCreateRating(tx, playerA.userId),
-        this.findOrCreateRating(tx, playerB.userId),
-      ]);
-      const elo = computeElo(
-        ratingA.rating,
-        ratingB.rating,
-        this.toEloOutcome(payload),
-        ratingA.gamesPlayed,
-        ratingB.gamesPlayed,
-      );
+        const [playerA, playerB] = payload.players;
+        const [ratingA, ratingB] = await Promise.all([
+          this.findOrCreateRating(tx, playerA.userId),
+          this.findOrCreateRating(tx, playerB.userId),
+        ]);
+        const elo = computeElo(
+          ratingA.rating,
+          ratingB.rating,
+          this.toEloOutcome(payload),
+          ratingA.gamesPlayed,
+          ratingB.gamesPlayed,
+        );
 
-      await tx.match.create({
-        data: {
-          id: payload.matchId,
-          playerAId: playerA.userId,
-          playerBId: playerB.userId,
-          winnerId: payload.winner,
-          scoreA: payload.finalScore.a,
-          scoreB: payload.finalScore.b,
-          startedAt: new Date(payload.startedAt),
-          endedAt: this.getEndedAt(payload),
-          status: MatchStatus.ended,
-        },
-      });
+        await tx.match.create({
+          data: {
+            id: payload.matchId,
+            playerAId: playerA.userId,
+            playerBId: playerB.userId,
+            winnerId: payload.winner,
+            scoreA: payload.finalScore.a,
+            scoreB: payload.finalScore.b,
+            startedAt: new Date(payload.startedAt),
+            endedAt: this.getEndedAt(payload),
+            status: MatchStatus.ended,
+          },
+        });
 
-      for (const round of payload.rounds) {
-        await tx.round.upsert({
-          where: {
-            matchId_roundNumber: {
+        for (const round of payload.rounds) {
+          await tx.round.upsert({
+            where: {
+              matchId_roundNumber: {
+                matchId: payload.matchId,
+                roundNumber: round.roundNumber,
+              },
+            },
+            create: {
               matchId: payload.matchId,
               roundNumber: round.roundNumber,
+              moveA: round.moveA,
+              moveB: round.moveB,
+              winner: round.winner,
+              resolvedAt: new Date(round.resolvedAt),
             },
-          },
-          create: {
-            matchId: payload.matchId,
-            roundNumber: round.roundNumber,
-            moveA: round.moveA,
-            moveB: round.moveB,
-            winner: round.winner,
-            resolvedAt: new Date(round.resolvedAt),
-          },
-          update: {},
-        });
+            update: {},
+          });
+        }
+
+        await Promise.all([
+          tx.eloRating.update({
+            where: { userId: playerA.userId },
+            data: {
+              rating: elo.newRatingA,
+              gamesPlayed: { increment: 1 },
+            },
+          }),
+          tx.eloRating.update({
+            where: { userId: playerB.userId },
+            data: {
+              rating: elo.newRatingB,
+              gamesPlayed: { increment: 1 },
+            },
+          }),
+          tx.eloHistory.createMany({
+            data: [
+              {
+                userId: playerA.userId,
+                matchId: payload.matchId,
+                ratingBefore: ratingA.rating,
+                ratingAfter: elo.newRatingA,
+                delta: elo.deltaA,
+              },
+              {
+                userId: playerB.userId,
+                matchId: payload.matchId,
+                ratingBefore: ratingB.rating,
+                ratingAfter: elo.newRatingB,
+                delta: elo.deltaB,
+              },
+            ],
+          }),
+        ]);
+
+        return "created";
+      });
+    } catch (error) {
+      if (this.isUniqueMatchConflict(error)) {
+        return "already_exists";
       }
-
-      await Promise.all([
-        tx.eloRating.update({
-          where: { userId: playerA.userId },
-          data: {
-            rating: elo.newRatingA,
-            gamesPlayed: { increment: 1 },
-          },
-        }),
-        tx.eloRating.update({
-          where: { userId: playerB.userId },
-          data: {
-            rating: elo.newRatingB,
-            gamesPlayed: { increment: 1 },
-          },
-        }),
-        tx.eloHistory.createMany({
-          data: [
-            {
-              userId: playerA.userId,
-              matchId: payload.matchId,
-              ratingBefore: ratingA.rating,
-              ratingAfter: elo.newRatingA,
-              delta: elo.deltaA,
-            },
-            {
-              userId: playerB.userId,
-              matchId: payload.matchId,
-              ratingBefore: ratingB.rating,
-              ratingAfter: elo.newRatingB,
-              delta: elo.deltaB,
-            },
-          ],
-        }),
-      ]);
-
-      return true;
-    });
+      throw error;
+    }
   }
 
   private async findOrCreateRating(
@@ -139,5 +148,9 @@ export class MatchPersistenceService {
   private getEndedAt(payload: MatchEndedPayload): Date {
     const lastRound = payload.rounds.at(-1);
     return lastRound ? new Date(lastRound.resolvedAt) : new Date();
+  }
+
+  private isUniqueMatchConflict(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
   }
 }

--- a/apps/job-runner/src/persistence/match-persistence.service.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.ts
@@ -1,0 +1,143 @@
+import { MatchStatus, Prisma } from "@chifoumi/db";
+import { computeElo, type Outcome } from "@chifoumi/elo";
+import { Injectable } from "@nestjs/common";
+import type { MatchEndedPayload } from "../match-events/match-ended.types.js";
+import { PrismaService } from "../prisma/prisma.service.js";
+
+const DEFAULT_RATING = 1000;
+const DEFAULT_GAMES_PLAYED = 0;
+
+@Injectable()
+export class MatchPersistenceService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async persistMatchEnded(payload: MatchEndedPayload): Promise<boolean> {
+    return this.prisma.$transaction(async (tx) => {
+      const existing = await tx.match.findUnique({
+        where: { id: payload.matchId },
+        select: { id: true },
+      });
+      if (existing) {
+        return false;
+      }
+
+      const [playerA, playerB] = payload.players;
+      const [ratingA, ratingB] = await Promise.all([
+        this.findOrCreateRating(tx, playerA.userId),
+        this.findOrCreateRating(tx, playerB.userId),
+      ]);
+      const elo = computeElo(
+        ratingA.rating,
+        ratingB.rating,
+        this.toEloOutcome(payload),
+        ratingA.gamesPlayed,
+        ratingB.gamesPlayed,
+      );
+
+      await tx.match.create({
+        data: {
+          id: payload.matchId,
+          playerAId: playerA.userId,
+          playerBId: playerB.userId,
+          winnerId: payload.winner,
+          scoreA: payload.finalScore.a,
+          scoreB: payload.finalScore.b,
+          startedAt: new Date(payload.startedAt),
+          endedAt: this.getEndedAt(payload),
+          status: MatchStatus.ended,
+        },
+      });
+
+      for (const round of payload.rounds) {
+        await tx.round.upsert({
+          where: {
+            matchId_roundNumber: {
+              matchId: payload.matchId,
+              roundNumber: round.roundNumber,
+            },
+          },
+          create: {
+            matchId: payload.matchId,
+            roundNumber: round.roundNumber,
+            moveA: round.moveA,
+            moveB: round.moveB,
+            winner: round.winner,
+            resolvedAt: new Date(round.resolvedAt),
+          },
+          update: {},
+        });
+      }
+
+      await Promise.all([
+        tx.eloRating.update({
+          where: { userId: playerA.userId },
+          data: {
+            rating: elo.newRatingA,
+            gamesPlayed: { increment: 1 },
+          },
+        }),
+        tx.eloRating.update({
+          where: { userId: playerB.userId },
+          data: {
+            rating: elo.newRatingB,
+            gamesPlayed: { increment: 1 },
+          },
+        }),
+        tx.eloHistory.createMany({
+          data: [
+            {
+              userId: playerA.userId,
+              matchId: payload.matchId,
+              ratingBefore: ratingA.rating,
+              ratingAfter: elo.newRatingA,
+              delta: elo.deltaA,
+            },
+            {
+              userId: playerB.userId,
+              matchId: payload.matchId,
+              ratingBefore: ratingB.rating,
+              ratingAfter: elo.newRatingB,
+              delta: elo.deltaB,
+            },
+          ],
+        }),
+      ]);
+
+      return true;
+    });
+  }
+
+  private async findOrCreateRating(
+    tx: Prisma.TransactionClient,
+    userId: string,
+  ): Promise<{ rating: number; gamesPlayed: number }> {
+    return tx.eloRating.upsert({
+      where: { userId },
+      create: {
+        userId,
+        rating: DEFAULT_RATING,
+        gamesPlayed: DEFAULT_GAMES_PLAYED,
+      },
+      update: {},
+      select: {
+        rating: true,
+        gamesPlayed: true,
+      },
+    });
+  }
+
+  private toEloOutcome(payload: MatchEndedPayload): Outcome {
+    if (payload.winner === payload.players[0].userId) {
+      return "A";
+    }
+    if (payload.winner === payload.players[1].userId) {
+      return "B";
+    }
+    return "DRAW";
+  }
+
+  private getEndedAt(payload: MatchEndedPayload): Date {
+    const lastRound = payload.rounds.at(-1);
+    return lastRound ? new Date(lastRound.resolvedAt) : new Date();
+  }
+}

--- a/apps/job-runner/src/prisma/prisma.module.ts
+++ b/apps/job-runner/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from "@nestjs/common";
+import { PrismaService } from "./prisma.service.js";
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/apps/job-runner/src/prisma/prisma.service.ts
+++ b/apps/job-runner/src/prisma/prisma.service.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@chifoumi/db";
+import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  constructor() {
+    const connectionString = process.env.DATABASE_URL;
+    if (!connectionString) {
+      throw new Error("DATABASE_URL is required");
+    }
+    const adapter = new PrismaPg({ connectionString });
+    super({ adapter });
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.SKIP_DB_CONNECT === "true") {
+      return;
+    }
+    await this.$connect();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.$disconnect();
+  }
+}

--- a/apps/job-runner/src/redis/redis-invalidation.service.ts
+++ b/apps/job-runner/src/redis/redis-invalidation.service.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Redis } from "ioredis";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+
+export const LEADERBOARD_INVALIDATE_CHANNEL = "leaderboard:invalidate";
+
+@Injectable()
+export class RedisInvalidationService implements OnModuleInit, OnModuleDestroy {
+  private client: Redis | null = null;
+
+  constructor(@Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig) {}
+
+  onModuleInit(): void {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+    this.client = new Redis(this.config.REDIS_URL);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.client?.quit();
+    this.client = null;
+  }
+
+  async invalidateLeaderboard(): Promise<void> {
+    await this.requireClient().publish(LEADERBOARD_INVALIDATE_CHANNEL, "*");
+  }
+
+  private requireClient(): Redis {
+    if (!this.client) {
+      throw new Error("Redis client is not connected");
+    }
+    return this.client;
+  }
+}

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -6,6 +6,7 @@ import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
 const workerCtor = jest.fn();
 
 jest.unstable_mockModule("bullmq", () => ({
+  UnrecoverableError: class UnrecoverableError extends Error {},
   Worker: workerCtor,
 }));
 
@@ -25,6 +26,18 @@ function createConfig(overrides: Partial<JobRunnerConfig> = {}): JobRunnerConfig
   };
 }
 
+function createMatchPersistence(): { persistMatchEnded: () => Promise<boolean> } {
+  return {
+    persistMatchEnded: jest.fn(async () => true),
+  };
+}
+
+function createRedisInvalidation(): { invalidateLeaderboard: () => Promise<void> } {
+  return {
+    invalidateLeaderboard: jest.fn(async () => undefined),
+  };
+}
+
 describe("WorkerFactory", () => {
   beforeEach(() => {
     workerCtor.mockReset();
@@ -38,7 +51,13 @@ describe("WorkerFactory", () => {
     const config = createConfig({ WORKER_QUEUES: ["match-events"] });
     const metrics = new WorkerMetricsService(config);
     const logger = { log: jest.fn() } as unknown as Logger;
-    const factory = new WorkerFactoryClass(config, metrics, logger);
+    const factory = new WorkerFactoryClass(
+      config,
+      metrics,
+      createMatchPersistence() as never,
+      createRedisInvalidation() as never,
+      logger,
+    );
 
     const workers = factory.createWorkers();
 
@@ -64,7 +83,13 @@ describe("WorkerFactory", () => {
     });
     const metrics = new WorkerMetricsService(config);
     const logger = { log: jest.fn() } as unknown as Logger;
-    const factory = new WorkerFactoryClass(config, metrics, logger);
+    const factory = new WorkerFactoryClass(
+      config,
+      metrics,
+      createMatchPersistence() as never,
+      createRedisInvalidation() as never,
+      logger,
+    );
 
     const workers = factory.createWorkers();
 

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -29,9 +29,9 @@ function createConfig(overrides: Partial<JobRunnerConfig> = {}): JobRunnerConfig
   };
 }
 
-function createMatchPersistence(): { persistMatchEnded: () => Promise<boolean> } {
+function createMatchPersistence(): { persistMatchEnded: () => Promise<"created"> } {
   return {
-    persistMatchEnded: jest.fn(async () => true),
+    persistMatchEnded: jest.fn(async (): Promise<"created"> => "created"),
   };
 }
 

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -3,6 +3,8 @@ import { Worker, type WorkerOptions } from "bullmq";
 import { Logger } from "nestjs-pino";
 import { JOB_RUNNER_CONFIG, type JobRunnerConfig, type WorkerQueueName } from "../config/env.js";
 import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
+import { MatchPersistenceService } from "../persistence/match-persistence.service.js";
+import { RedisInvalidationService } from "../redis/redis-invalidation.service.js";
 import { getProcessorForQueue } from "./worker-processors.js";
 
 export type ManagedWorker = {
@@ -15,6 +17,8 @@ export class WorkerFactory {
   constructor(
     @Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig,
     private readonly metrics: WorkerMetricsService,
+    private readonly matchPersistence: MatchPersistenceService,
+    private readonly redisInvalidation: RedisInvalidationService,
     private readonly logger: Logger,
   ) {}
 
@@ -29,14 +33,35 @@ export class WorkerFactory {
       concurrency: this.config.WORKER_CONCURRENCY,
     };
 
-    const worker = new Worker(queue, getProcessorForQueue(queue), workerOptions);
+    const worker = new Worker(
+      queue,
+      getProcessorForQueue(queue, {
+        matchPersistence: this.matchPersistence,
+        redisInvalidation: this.redisInvalidation,
+      }),
+      workerOptions,
+    );
 
     worker.on("completed", () => {
       this.metrics.recordJobProcessed(queue, "completed");
     });
 
-    worker.on("failed", () => {
+    worker.on("failed", (job, error) => {
       this.metrics.recordJobProcessed(queue, "failed");
+      if (queue === "match-events" && job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
+        this.logger.error(
+          {
+            worker_role: this.config.WORKER_ROLE,
+            queue,
+            job_name: job.name,
+            job_id: job.id,
+            matchId: (job.data as { matchId?: string }).matchId,
+            attempts_made: job.attemptsMade,
+            err: error,
+          },
+          "Match event job failed permanently",
+        );
+      }
     });
 
     worker.on("error", (error) => {

--- a/apps/job-runner/src/workers/worker-processors.ts
+++ b/apps/job-runner/src/workers/worker-processors.ts
@@ -1,14 +1,14 @@
 import type { Job } from "bullmq";
 import type { WorkerQueueName } from "../config/env.js";
+import {
+  createMatchEndedProcessor,
+  type MatchEventsProcessorDependencies,
+} from "../match-events/match-ended.processor.js";
 
 export type WorkerProcessor = (job: Job) => Promise<void>;
+export type ProcessorDependencies = MatchEventsProcessorDependencies;
 
-const STUB_PROCESSORS: Record<WorkerQueueName, WorkerProcessor> = {
-  "match-events": async (job) => {
-    if (job.name !== "match-ended") {
-      throw new Error(`Unsupported job name on match-events: ${job.name}`);
-    }
-  },
+const STUB_PROCESSORS: Record<Exclude<WorkerQueueName, "match-events">, WorkerProcessor> = {
   notifications: async (job) => {
     if (job.name !== "send-mail") {
       throw new Error(`Unsupported job name on notifications: ${job.name}`);
@@ -26,6 +26,13 @@ const STUB_PROCESSORS: Record<WorkerQueueName, WorkerProcessor> = {
   },
 };
 
-export function getProcessorForQueue(queue: WorkerQueueName): WorkerProcessor {
+export function getProcessorForQueue(
+  queue: WorkerQueueName,
+  deps: ProcessorDependencies,
+): WorkerProcessor {
+  if (queue === "match-events") {
+    return createMatchEndedProcessor(deps);
+  }
+
   return STUB_PROCESSORS[queue];
 }

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,122 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+      REDIS_URL: redis://redis:6379
+      API_PORT: 3000
+      BULLMQ_PREFIX: rps
+      JWT_PRIVATE_KEY_PATH: /app/infra/keys/jwt-private.pem
+      JWT_PUBLIC_KEY_PATH: /app/infra/keys/jwt-public.pem
+      CORS_ORIGINS: http://localhost:5173
+    volumes:
+      - ./infra/keys:/app/infra/keys:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    restart: unless-stopped
+
+  game-service-1:
+    build:
+      context: .
+      dockerfile: apps/game-service/Dockerfile
+    ports:
+      - "3101:3001"
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      REDIS_URL: redis://redis:6379
+      GAME_SERVICE_PORT: 3001
+      INSTANCE_ID: game-1
+      BULLMQ_PREFIX: rps
+      MATCHMAKING_WORKER_ENABLED: "true"
+      JWT_PUBLIC_KEY_PATH: /app/infra/keys/jwt-public.pem
+      CORS_ORIGINS: http://localhost:5173
+    volumes:
+      - ./infra/keys:/app/infra/keys:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3001/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    restart: unless-stopped
+
+  game-service-2:
+    build:
+      context: .
+      dockerfile: apps/game-service/Dockerfile
+    ports:
+      - "3102:3001"
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      REDIS_URL: redis://redis:6379
+      GAME_SERVICE_PORT: 3001
+      INSTANCE_ID: game-2
+      BULLMQ_PREFIX: rps
+      MATCHMAKING_WORKER_ENABLED: "true"
+      JWT_PUBLIC_KEY_PATH: /app/infra/keys/jwt-public.pem
+      CORS_ORIGINS: http://localhost:5173
+    volumes:
+      - ./infra/keys:/app/infra/keys:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3001/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    restart: unless-stopped
+
+  job-runner-match:
+    build:
+      context: .
+      dockerfile: apps/job-runner/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+      REDIS_URL: redis://redis:6379
+      WORKER_QUEUES: match-events
+      WORKER_CONCURRENCY: 8
+      WORKER_ROLE: match-processor
+      CRON_ENABLED: "false"
+      BULLMQ_PREFIX: rps
+    restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "tests/*"
   ],
   "scripts": {
     "dev": "pnpm --parallel --filter @chifoumi/api --filter @chifoumi/game-service --filter @chifoumi/job-runner --filter @chifoumi/front dev",
@@ -16,6 +17,7 @@
     "biome:fix": "biome check --write apps packages .github biome.json lefthook.yml",
     "typecheck": "pnpm --filter @chifoumi/db typecheck && pnpm -r typecheck",
     "docs:openapi": "pnpm --filter @chifoumi/api docs:openapi",
+    "test:e2e:smoke": "pnpm --filter @chifoumi/e2e test:smoke",
     "lefthook:install": "lefthook install"
   },
   "devDependencies": {

--- a/packages/elo/package.json
+++ b/packages/elo/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,12 +248,24 @@ importers:
 
   apps/job-runner:
     dependencies:
+      '@chifoumi/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@chifoumi/elo':
+        specifier: workspace:*
+        version: link:../../packages/elo
       '@nestjs/common':
         specifier: ^11.1.21
         version: 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(@nestjs/websockets@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@prisma/adapter-pg':
+        specifier: ^7.8.0
+        version: 7.8.0
+      '@prisma/client':
+        specifier: ^7.8.0
+        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.7.3))(typescript@5.7.3)
       bullmq:
         specifier: ^5.49.2
         version: 5.78.0
@@ -266,6 +278,9 @@ importers:
       nestjs-pino:
         specifier: 4.2.0
         version: 4.2.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@10.4.0)
+      pg:
+        specifier: ^8.16.3
+        version: 8.21.0
       pino-http:
         specifier: 10.4.0
         version: 10.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,30 @@ importers:
         specifier: ~5.7.3
         version: 5.7.3
 
+  tests/e2e:
+    devDependencies:
+      '@jest/globals':
+        specifier: 29.7.0
+        version: 29.7.0
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.12.4
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@24.12.4)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
+      ts-jest:
+        specifier: 29.2.5
+        version: 29.2.5(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.12.4))(typescript@5.7.3)
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
+
 packages:
 
   '@babel/code-frame@7.29.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "tests/*"

--- a/scripts/e2e/start-stack.sh
+++ b/scripts/e2e/start-stack.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+export DATABASE_URL="${DATABASE_URL:-postgresql://app:chifoumi_dev@localhost:5432/chifoumi}"
+export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
+export BULLMQ_PREFIX="${BULLMQ_PREFIX:-rps}"
+export JWT_PRIVATE_KEY_PATH="${JWT_PRIVATE_KEY_PATH:-$ROOT_DIR/infra/keys/jwt-private.pem}"
+export JWT_PUBLIC_KEY_PATH="${JWT_PUBLIC_KEY_PATH:-$ROOT_DIR/infra/keys/jwt-public.pem}"
+export MATCHMAKING_WORKER_ENABLED="${MATCHMAKING_WORKER_ENABLED:-true}"
+export WORKER_QUEUES="${WORKER_QUEUES:-match-events}"
+export WORKER_CONCURRENCY="${WORKER_CONCURRENCY:-8}"
+export CRON_ENABLED="${CRON_ENABLED:-false}"
+
+pnpm --filter @chifoumi/db build
+pnpm --filter @chifoumi/elo build
+pnpm --filter @chifoumi/api build
+pnpm --filter @chifoumi/game-service build
+pnpm --filter @chifoumi/job-runner build
+pnpm --filter @chifoumi/db migrate:deploy
+
+API_PORT=3000 node apps/api/dist/main.js &
+API_PID=$!
+
+GAME_SERVICE_PORT=3101 node apps/game-service/dist/main.js &
+GAME1_PID=$!
+
+GAME_SERVICE_PORT=3102 node apps/game-service/dist/main.js &
+GAME2_PID=$!
+
+node apps/job-runner/dist/main.js &
+JOB_PID=$!
+
+echo "$API_PID" > /tmp/chifoumi-e2e-api.pid
+echo "$GAME1_PID" > /tmp/chifoumi-e2e-game1.pid
+echo "$GAME2_PID" > /tmp/chifoumi-e2e-game2.pid
+echo "$JOB_PID" > /tmp/chifoumi-e2e-job.pid
+
+echo "E2E stack started (api=$API_PID, game1=$GAME1_PID, game2=$GAME2_PID, job=$JOB_PID)"

--- a/scripts/e2e/stop-stack.sh
+++ b/scripts/e2e/stop-stack.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for pid_file in /tmp/chifoumi-e2e-api.pid /tmp/chifoumi-e2e-game1.pid /tmp/chifoumi-e2e-game2.pid /tmp/chifoumi-e2e-job.pid; do
+  if [[ -f "$pid_file" ]]; then
+    kill "$(cat "$pid_file")" 2>/dev/null || true
+    rm -f "$pid_file"
+  fi
+done

--- a/tests/e2e/jest.config.cjs
+++ b/tests/e2e/jest.config.cjs
@@ -1,0 +1,22 @@
+/** @type {import("jest").Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  testEnvironment: "node",
+  maxWorkers: 1,
+  testTimeout: 30_000,
+  roots: ["<rootDir>/src"],
+  testRegex: ".*\\.e2e-spec\\.ts$",
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.json",
+      },
+    ],
+  },
+};

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@chifoumi/e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:smoke": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathPattern=bo3-cross-instance --forceExit"
+  },
+  "devDependencies": {
+    "@jest/globals": "29.7.0",
+    "@types/jest": "29.5.14",
+    "@types/node": "^24.12.4",
+    "jest": "29.7.0",
+    "socket.io-client": "^4.8.3",
+    "ts-jest": "29.2.5",
+    "typescript": "~5.7.3"
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:smoke": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathPattern=bo3-cross-instance --forceExit"
   },
   "devDependencies": {

--- a/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
+++ b/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @e2e US-031 — BO3 smoke test across two Game Service replicas.
+ */
+import {
+  createPlayer,
+  getMe,
+  pollMe,
+  type RegisteredPlayer,
+  waitForHealth,
+} from "./helpers/http.js";
+import {
+  connectAuthenticated,
+  joinQueue,
+  type MatchFoundPayload,
+  playBo3Win,
+  type RoundStartPayload,
+  waitForEvent,
+} from "./helpers/ws.js";
+
+const apiUrl = process.env.E2E_API_URL ?? "http://127.0.0.1:3000";
+const game1Url = process.env.E2E_GAME_1_URL ?? "http://127.0.0.1:3101";
+const game2Url = process.env.E2E_GAME_2_URL ?? "http://127.0.0.1:3102";
+
+describe("US-031 BO3 cross-instance smoke @e2e", () => {
+  let playerA: RegisteredPlayer;
+  let playerB: RegisteredPlayer;
+
+  beforeAll(async () => {
+    await Promise.all([waitForHealth(apiUrl), waitForHealth(game1Url), waitForHealth(game2Url)]);
+
+    playerA = await createPlayer(apiUrl, "a");
+    playerB = await createPlayer(apiUrl, "b");
+  }, 90_000);
+
+  it("plays a full BO3 on different game replicas and persists results", async () => {
+    const { socket: socketA } = await connectAuthenticated(game1Url, playerA.tokens.access);
+    const { socket: socketB } = await connectAuthenticated(game2Url, playerB.tokens.access);
+
+    const baselineA = await getMe(apiUrl, playerA.tokens.access);
+
+    const matchFoundA = waitForEvent<MatchFoundPayload>(socketA, "matchFound");
+    const matchFoundB = waitForEvent<MatchFoundPayload>(socketB, "matchFound");
+    const roundStartA = waitForEvent<RoundStartPayload>(socketA, "roundStart");
+    const roundStartB = waitForEvent<RoundStartPayload>(socketB, "roundStart");
+
+    await joinQueue(socketA);
+    await joinQueue(socketB);
+
+    const payloadA = await matchFoundA;
+    const payloadB = await matchFoundB;
+    const roundStart = await roundStartA;
+    await roundStartB;
+
+    expect(payloadA.matchId).toBe(payloadB.matchId);
+    expect(payloadA.bestOf).toBe(3);
+
+    const { matchEndedA, matchEndedB } = await playBo3Win(
+      socketA,
+      socketB,
+      payloadA.matchId,
+      roundStart,
+    );
+
+    expect(matchEndedA.winner).toBe(playerA.userId);
+    expect(matchEndedB.winner).toBe(playerA.userId);
+    expect(matchEndedA.finalScore).toEqual({ a: 2, b: 0 });
+
+    const profileA = await pollMe(
+      apiUrl,
+      playerA.tokens.access,
+      (profile) => profile.gamesPlayed === 1 && profile.rating > baselineA.rating,
+    );
+    expect(profileA.gamesPlayed).toBe(1);
+
+    const leaderboardResponse = await fetch(`${apiUrl}/leaderboard?limit=10`);
+    expect(leaderboardResponse.ok).toBe(true);
+    const leaderboard = (await leaderboardResponse.json()) as {
+      items: Array<{ userId: string; rating: number }>;
+    };
+    expect(leaderboard.items[0]?.userId).toBe(playerA.userId);
+    expect(leaderboard.items[0]?.rating).toBeGreaterThan(
+      leaderboard.items.find((entry) => entry.userId === playerB.userId)?.rating ?? 0,
+    );
+
+    const historyResponse = await fetch(`${apiUrl}/me/history?limit=10`, {
+      headers: { authorization: `Bearer ${playerB.tokens.access}` },
+    });
+    expect(historyResponse.ok).toBe(true);
+    const history = (await historyResponse.json()) as {
+      items: Array<{ matchId: string; isWinner: boolean }>;
+    };
+    const historyItem = history.items.find((item) => item.matchId === payloadA.matchId);
+    expect(historyItem).toBeDefined();
+    expect(historyItem?.isWinner).toBe(false);
+
+    socketA.disconnect();
+    socketB.disconnect();
+  }, 30_000);
+});

--- a/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
+++ b/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
@@ -46,10 +46,12 @@ describe("US-031 BO3 cross-instance smoke @e2e", () => {
     await joinQueue(socketA);
     await joinQueue(socketB);
 
-    const payloadA = await matchFoundA;
-    const payloadB = await matchFoundB;
-    const roundStart = await roundStartA;
-    await roundStartB;
+    const [payloadA, payloadB, roundStart] = await Promise.all([
+      matchFoundA,
+      matchFoundB,
+      roundStartA,
+      roundStartB,
+    ]);
 
     expect(payloadA.matchId).toBe(payloadB.matchId);
     expect(payloadA.bestOf).toBe(3);

--- a/tests/e2e/src/helpers/http.ts
+++ b/tests/e2e/src/helpers/http.ts
@@ -1,0 +1,103 @@
+export type AuthTokens = {
+  access: string;
+  refresh: string;
+};
+
+export type RegisteredPlayer = {
+  userId: string;
+  email: string;
+  displayName: string;
+  tokens: AuthTokens;
+};
+
+export async function waitForHealth(baseUrl: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/health`);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`health returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+
+  throw new Error(`Service at ${baseUrl} did not become healthy: ${String(lastError)}`);
+}
+
+export async function createPlayer(apiUrl: string, label: string): Promise<RegisteredPlayer> {
+  const suffix = `${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `e2e-${suffix}@example.com`;
+  const displayName = `e2e-${suffix}`;
+
+  const response = await fetch(`${apiUrl}/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email,
+      password: "password1234",
+      displayName,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`register failed (${response.status}): ${body}`);
+  }
+
+  const body = (await response.json()) as {
+    user: { id: string; email: string; displayName: string };
+    tokens: AuthTokens;
+  };
+
+  return {
+    userId: body.user.id,
+    email: body.user.email,
+    displayName: body.user.displayName,
+    tokens: body.tokens,
+  };
+}
+
+export async function getMe(
+  apiUrl: string,
+  accessToken: string,
+): Promise<{ rating: number; gamesPlayed: number }> {
+  const response = await fetch(`${apiUrl}/me`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GET /me failed (${response.status}): ${body}`);
+  }
+
+  return (await response.json()) as { rating: number; gamesPlayed: number };
+}
+
+export async function pollMe(
+  apiUrl: string,
+  accessToken: string,
+  predicate: (profile: { rating: number; gamesPlayed: number }) => boolean,
+  timeoutMs = 5_000,
+): Promise<{ rating: number; gamesPlayed: number }> {
+  const deadline = Date.now() + timeoutMs;
+  let lastProfile: { rating: number; gamesPlayed: number } | null = null;
+
+  while (Date.now() < deadline) {
+    lastProfile = await getMe(apiUrl, accessToken);
+    if (predicate(lastProfile)) {
+      return lastProfile;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `GET /me predicate not satisfied within ${timeoutMs}ms (last=${JSON.stringify(lastProfile)})`,
+  );
+}

--- a/tests/e2e/src/helpers/ws.ts
+++ b/tests/e2e/src/helpers/ws.ts
@@ -33,7 +33,7 @@ export function connectWs(gameUrl: string, accessToken: string): Socket {
   });
 }
 
-export function waitForEvent<T>(socket: Socket, event: string, timeoutMs = 10_000): Promise<T> {
+export function waitForEvent<T>(socket: Socket, event: string, timeoutMs = 20_000): Promise<T> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error(`${event} timeout`)), timeoutMs);
     socket.once(event, (payload: T) => {

--- a/tests/e2e/src/helpers/ws.ts
+++ b/tests/e2e/src/helpers/ws.ts
@@ -1,0 +1,96 @@
+import { io, type Socket } from "socket.io-client";
+
+export type ConnectedPayload = { userId: string; displayName: string };
+export type MatchFoundPayload = {
+  matchId: string;
+  opponent: { userId: string; displayName: string; rating: number };
+  bestOf: number;
+};
+export type RoundStartPayload = { matchId: string; roundNumber: number; deadline: string };
+export type RoundResolvedPayload = {
+  matchId: string;
+  roundNumber: number;
+  yourMove: string;
+  theirMove: string;
+  winner: string;
+  scoreA: number;
+  scoreB: number;
+};
+export type MatchEndedPayload = {
+  matchId: string;
+  winner: string | null;
+  finalScore: { a: number; b: number };
+  eloDelta: { a: number; b: number };
+  reason?: string;
+};
+
+export function connectWs(gameUrl: string, accessToken: string): Socket {
+  return io(`${gameUrl}/game`, {
+    transports: ["websocket"],
+    forceNew: true,
+    reconnection: false,
+    query: { token: accessToken },
+  });
+}
+
+export function waitForEvent<T>(socket: Socket, event: string, timeoutMs = 10_000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${event} timeout`)), timeoutMs);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timeout);
+      resolve(payload);
+    });
+  });
+}
+
+export async function connectAuthenticated(
+  gameUrl: string,
+  accessToken: string,
+): Promise<{ socket: Socket; connected: ConnectedPayload }> {
+  const socket = connectWs(gameUrl, accessToken);
+  const connectedPromise = waitForEvent<ConnectedPayload>(socket, "connected");
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("connect_error", reject);
+  });
+
+  const connected = await connectedPromise;
+  return { socket, connected };
+}
+
+export async function joinQueue(socket: Socket): Promise<void> {
+  socket.emit("joinQueue", {});
+  await waitForEvent(socket, "queueJoined");
+}
+
+export async function playBo3Win(
+  socketA: Socket,
+  socketB: Socket,
+  matchId: string,
+  roundStart: RoundStartPayload,
+): Promise<{ matchEndedA: MatchEndedPayload; matchEndedB: MatchEndedPayload }> {
+  const round1ResolvedA = waitForEvent<RoundResolvedPayload>(socketA, "roundResolved");
+  const round1ResolvedB = waitForEvent<RoundResolvedPayload>(socketB, "roundResolved");
+
+  socketA.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "rock" });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  socketB.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "scissors" });
+  await round1ResolvedA;
+  await round1ResolvedB;
+
+  const round2Start = await waitForEvent<RoundStartPayload>(socketA, "roundStart");
+  await waitForEvent<RoundStartPayload>(socketB, "roundStart");
+
+  const matchEndedA = waitForEvent<MatchEndedPayload>(socketA, "matchEnded");
+  const matchEndedB = waitForEvent<MatchEndedPayload>(socketB, "matchEnded");
+
+  socketA.emit("play", { matchId, roundNumber: round2Start.roundNumber, move: "paper" });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  socketB.emit("play", { matchId, roundNumber: round2Start.roundNumber, move: "rock" });
+
+  return {
+    matchEndedA: await matchEndedA,
+    matchEndedB: await matchEndedB,
+  };
+}

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add `@chifoumi/e2e` smoke test that registers two players, connects them to separate game-service replicas, plays a full 2-0 BO3, and asserts persistence via `/me`, `/leaderboard`, and `/me/history`.
- Run an isolated Docker Compose E2E stack with PostgreSQL, Redis, migrations, API, two game-service replicas, and the match-events job runner.
- Capture and upload Compose logs when the CI smoke test fails.
- Merge US-024 match-events persistence into this branch so rating/history assertions are meaningful in CI.
- Harden WebSocket event synchronization and cleanup to avoid missed events and leaked sockets.

## Test plan
- [x] Local smoke test passes in 6.6s (BO3 scenario: 733ms)
- [x] Workspace typecheck and build pass
- [x] Workspace tests pass
- [x] Game-service WebSocket E2E tests pass (3 suites, 17 tests)
- [x] Docker images build from a clean context
- [ ] CI jobs pass on this PR
