### PR TITLE
docs(ops): US-032 multi-instance demo guide and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Plateforme web competitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties 
 - [Pre-requis](#pre-requis)
 - [Demarrage rapide](#demarrage-rapide)
 - [Stack multi-replicas (US-030)](#stack-multi-replicas-us-030)
+- [Demo multi-instances (US-032)](#demo-multi-instances-us-032)
 - [Tech stack](#tech-stack)
 - [Architecture](#architecture)
 - [Commandes utiles](#commandes-utiles)
@@ -121,6 +122,20 @@ Arreter la stack :
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.scale.yml down
 ```
+
+## Demo multi-instances (US-032)
+
+Procedure de soutenance (~5 min) : deux joueurs sur des replicas Game Service differents, crash d'instance, Grafana live.
+
+```bash
+# Linux / macOS / Git Bash
+bash scripts/demo/run-demo.sh
+
+# Windows
+.\scripts\demo\run-demo.ps1
+```
+
+Guide detaille avec captures : [`docs/demo/multi-instances.md`](docs/demo/multi-instances.md).
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Ajouter les entrees suivantes au fichier hosts local (`C:\Windows\System32\drive
 docker compose -f docker-compose.yml -f docker-compose.scale.yml up -d --build
 ```
 
-Services demarres : `postgres` x1, `redis` x1, `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
+Services demarres : `postgres` x1, `redis` x1, `db-migrate` (one-shot), `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
 
 | Service | URL via Traefik | Port direct |
 |---|---:|---|

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Plateforme web competitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties 
 
 - [Pre-requis](#pre-requis)
 - [Demarrage rapide](#demarrage-rapide)
+- [Stack multi-replicas (US-030)](#stack-multi-replicas-us-030)
 - [Tech stack](#tech-stack)
 - [Architecture](#architecture)
 - [Commandes utiles](#commandes-utiles)
@@ -42,6 +43,60 @@ Services lances par `pnpm dev` :
 | Job runner | terminal uniquement | Workers et traitements asynchrones |
 
 Si le schema Postgres evolue, relancer une base vide avec `docker compose down -v`, puis `docker compose up -d`.
+
+## Stack multi-replicas (US-030)
+
+Stack containerisee complete avec Traefik, 2 replicas API, 2 replicas Game Service et observabilite.
+
+### Pre-requis supplementaires
+
+Generer les cles JWT de dev (une seule fois) :
+
+```bash
+mkdir -p infra/keys
+openssl genrsa -out infra/keys/jwt-private.pem 2048
+openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+```
+
+Ajouter les entrees suivantes au fichier hosts local (`C:\Windows\System32\drivers\etc\hosts` ou `/etc/hosts`) :
+
+```text
+127.0.0.1 api.localhost front.localhost game.localhost traefik.localhost grafana.localhost prometheus.localhost
+```
+
+### Lancer la stack
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.scale.yml up -d --build
+```
+
+Services demarres : `postgres` x1, `redis` x1, `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
+
+| Service | URL via Traefik | Port direct |
+|---|---:|---|
+| Front | `http://front.localhost` | — |
+| API (round-robin) | `http://api.localhost/health` | — |
+| Game WS (sticky) | `ws://game.localhost/game` | — |
+| Traefik dashboard | `http://traefik.localhost` | — |
+| Grafana | `http://grafana.localhost` | `http://localhost:3002` |
+| Prometheus | `http://prometheus.localhost` | `http://localhost:9090` |
+| MailHog | — | `http://localhost:8025` |
+
+Verifier le round-robin API : `curl http://api.localhost/health` plusieurs fois et comparer le champ `instance` (`api-1` / `api-2`) dans les logs ou la reponse JSON.
+
+Demo de resilience : arreter une instance API puis verifier que `/health` repond toujours :
+
+```bash
+docker stop chifoumi-api-1
+curl http://api.localhost/health
+docker start chifoumi-api-1
+```
+
+Arreter la stack :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.scale.yml down
+```
 
 ## Tech stack
 
@@ -103,7 +158,7 @@ pnpm --filter @chifoumi/front dev
 | Swagger | `http://localhost:3000/api/docs` | disponible |
 | OpenAPI JSON | `http://localhost:3000/api/docs-json` | disponible |
 | MailHog | `http://localhost:8025` | disponible apres `docker compose up -d` |
-| Grafana | `http://localhost:3002` | prevu avec la stack observabilite |
+| Grafana | `http://localhost:3002` | disponible avec `docker-compose.scale.yml` |
 
 En production, la documentation Swagger est protegee par Basic Auth via `SWAGGER_USER` et `SWAGGER_PASSWORD`.
 Sans ces deux variables en production, les routes `/api/docs` et `/api/docs-json` ne sont pas exposees.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,6 +27,8 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV API_PORT=3000
 COPY --from=builder /app /app
+COPY apps/api/docker-entrypoint.sh /app/apps/api/docker-entrypoint.sh
+RUN chmod +x /app/apps/api/docker-entrypoint.sh
 USER node
 EXPOSE 3000
-CMD ["node", "apps/api/dist/main.js"]
+ENTRYPOINT ["/app/apps/api/docker-entrypoint.sh"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -21,14 +21,14 @@ RUN pnpm install --frozen-lockfile
 FROM deps AS builder
 COPY apps ./apps
 COPY packages ./packages
-RUN pnpm --filter @chifoumi/api build
+RUN pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/api build
 
 FROM base AS runner
 ENV NODE_ENV=production
 ENV API_PORT=3000
-COPY --from=builder /app /app
-COPY apps/api/docker-entrypoint.sh /app/apps/api/docker-entrypoint.sh
-RUN chmod +x /app/apps/api/docker-entrypoint.sh
+COPY --from=builder --chown=node:node /app /app
+COPY --chown=node:node apps/api/docker-migrate.sh /app/apps/api/docker-migrate.sh
+RUN chmod +x /app/apps/api/docker-migrate.sh
 USER node
 EXPOSE 3000
-ENTRYPOINT ["/app/apps/api/docker-entrypoint.sh"]
+CMD ["node", "apps/api/dist/main.js"]

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+cd /app
+
+pnpm --filter @chifoumi/db generate
+pnpm --filter @chifoumi/db migrate:deploy
+
+exec node apps/api/dist/main.js

--- a/apps/api/docker-migrate.sh
+++ b/apps/api/docker-migrate.sh
@@ -3,7 +3,4 @@ set -e
 
 cd /app
 
-pnpm --filter @chifoumi/db generate
 pnpm --filter @chifoumi/db migrate:deploy
-
-exec node apps/api/dist/main.js

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -7,6 +7,7 @@ export class HealthController {
     return {
       status: "ok",
       service: "api",
+      instance: process.env.INSTANCE_ID ?? "api",
       version: "1.0.0",
     };
   }

--- a/apps/front/Dockerfile
+++ b/apps/front/Dockerfile
@@ -19,10 +19,13 @@ COPY packages/tsconfig/package.json packages/tsconfig/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS builder
+ARG VITE_API_BASE_URL=http://localhost:3000
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 COPY apps ./apps
 COPY packages ./packages
 RUN pnpm --filter @chifoumi/front build
 
 FROM nginx:1.27-alpine AS runner
+COPY apps/front/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/apps/front/dist /usr/share/nginx/html
 EXPOSE 80

--- a/apps/front/Dockerfile
+++ b/apps/front/Dockerfile
@@ -24,6 +24,8 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 COPY apps ./apps
 COPY packages ./packages
 RUN pnpm --filter @chifoumi/front build
+RUN mkdir -p apps/front/dist/vendor \
+  && cp "$(find node_modules -path '*/socket.io-client/dist/socket.io.min.js' -print -quit)" apps/front/dist/vendor/socket.io.min.js
 
 FROM nginx:1.27-alpine AS runner
 COPY apps/front/nginx.conf /etc/nginx/conf.d/default.conf

--- a/apps/front/nginx.conf
+++ b/apps/front/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/front/public/demo-client.html
+++ b/apps/front/public/demo-client.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chifoumi demo client</title>
+    <style>
+      :root {
+        font-family: system-ui, sans-serif;
+        color: #e8edf5;
+        background: #0f172a;
+      }
+      body {
+        margin: 0;
+        padding: 1.25rem;
+        max-width: 52rem;
+      }
+      h1 {
+        margin: 0 0 0.25rem;
+        font-size: 1.35rem;
+      }
+      .meta {
+        color: #94a3b8;
+        margin-bottom: 1rem;
+        font-size: 0.9rem;
+      }
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 0.75rem;
+      }
+      button {
+        border: 0;
+        border-radius: 0.5rem;
+        padding: 0.55rem 0.9rem;
+        background: #2563eb;
+        color: white;
+        cursor: pointer;
+      }
+      button.secondary {
+        background: #334155;
+      }
+      button.move {
+        background: #059669;
+      }
+      button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+      #log {
+        background: #020617;
+        border: 1px solid #1e293b;
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        min-height: 14rem;
+        white-space: pre-wrap;
+        font: 0.85rem/1.45 ui-monospace, monospace;
+      }
+      .status {
+        margin: 0.5rem 0 1rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        background: #1e293b;
+      }
+    </style>
+    <script src="https://cdn.socket.io/4.8.1/socket.io.min.js"></script>
+  </head>
+  <body>
+    <h1 id="title">Chifoumi demo client</h1>
+    <div class="meta" id="meta"></div>
+    <div class="status" id="status">Not connected</div>
+
+    <div class="row">
+      <button id="registerBtn">Register &amp; connect</button>
+      <button id="queueBtn" class="secondary" disabled>Join queue</button>
+      <button id="disconnectBtn" class="secondary" disabled>Disconnect</button>
+    </div>
+
+    <div class="row" id="moves" hidden>
+      <button class="move" data-move="rock">Rock</button>
+      <button class="move" data-move="paper">Paper</button>
+      <button class="move" data-move="scissors">Scissors</button>
+    </div>
+
+    <pre id="log"></pre>
+
+    <script>
+      const params = new URLSearchParams(location.search);
+      const player = params.get("player") ?? "X";
+      const apiUrl = params.get("apiUrl") ?? "http://api.localhost";
+      const gameUrl = params.get("gameUrl") ?? "http://127.0.0.1:3101";
+
+      document.getElementById("title").textContent = `Chifoumi demo — Player ${player}`;
+      document.getElementById("meta").textContent = `API: ${apiUrl} · Game: ${gameUrl}`;
+
+      const logEl = document.getElementById("log");
+      const statusEl = document.getElementById("status");
+      const queueBtn = document.getElementById("queueBtn");
+      const disconnectBtn = document.getElementById("disconnectBtn");
+      const movesEl = document.getElementById("moves");
+
+      let socket = null;
+      let accessToken = null;
+      let matchId = null;
+      let roundNumber = null;
+
+      function log(message) {
+        const line = `[${new Date().toLocaleTimeString()}] ${message}`;
+        logEl.textContent = `${line}\n${logEl.textContent}`;
+      }
+
+      function setStatus(text) {
+        statusEl.textContent = text;
+      }
+
+      async function registerAndConnect() {
+        const suffix = Date.now().toString(36);
+        const body = {
+          email: `demo-${player.toLowerCase()}-${suffix}@chifoumi.local`,
+          password: "password1234",
+          displayName: `Demo${player}${suffix.slice(-4)}`,
+        };
+
+        log(`Registering ${body.displayName} ...`);
+        const response = await fetch(`${apiUrl}/auth/register`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+          throw new Error(`Register failed (${response.status})`);
+        }
+        const payload = await response.json();
+        accessToken = payload.tokens.access;
+        log(`Registered user ${payload.user.displayName}`);
+
+        socket = io(`${gameUrl}/game`, {
+          transports: ["websocket"],
+          forceNew: true,
+          reconnection: true,
+          query: { token: accessToken },
+        });
+
+        socket.on("connect", () => {
+          setStatus(`WS connected (${socket.id})`);
+          log("Socket connected");
+          queueBtn.disabled = false;
+          disconnectBtn.disabled = false;
+        });
+
+        socket.on("connect_error", (error) => {
+          setStatus("WS connect error");
+          log(`connect_error: ${error.message}`);
+        });
+
+        socket.on("disconnect", (reason) => {
+          setStatus(`WS disconnected (${reason})`);
+          log(`disconnect: ${reason}`);
+          queueBtn.disabled = true;
+          movesEl.hidden = true;
+        });
+
+        socket.on("connected", (data) => log(`connected event: ${JSON.stringify(data)}`));
+        socket.on("queueJoined", (data) => log(`queueJoined: ${JSON.stringify(data)}`));
+        socket.on("matchFound", (data) => {
+          matchId = data.matchId;
+          log(`matchFound: ${JSON.stringify(data)}`);
+          setStatus(`Match ${matchId} — waiting for roundStart`);
+        });
+        socket.on("roundStart", (data) => {
+          roundNumber = data.roundNumber;
+          movesEl.hidden = false;
+          log(`roundStart: ${JSON.stringify(data)}`);
+          setStatus(`Round ${roundNumber} — pick a move`);
+        });
+        socket.on("roundResolved", (data) => log(`roundResolved: ${JSON.stringify(data)}`));
+        socket.on("matchEnded", (data) => {
+          movesEl.hidden = true;
+          matchId = null;
+          roundNumber = null;
+          log(`matchEnded: ${JSON.stringify(data)}`);
+          setStatus("Match ended — you can join queue again");
+          queueBtn.disabled = false;
+        });
+      }
+
+      document.getElementById("registerBtn").addEventListener("click", () => {
+        registerAndConnect().catch((error) => log(error.message));
+      });
+
+      queueBtn.addEventListener("click", () => {
+        if (!socket) return;
+        socket.emit("joinQueue", {});
+        queueBtn.disabled = true;
+        log("joinQueue emitted");
+      });
+
+      disconnectBtn.addEventListener("click", () => {
+        if (socket) socket.disconnect();
+      });
+
+      for (const button of document.querySelectorAll("button.move")) {
+        button.addEventListener("click", () => {
+          if (!socket || !matchId || !roundNumber) return;
+          const move = button.dataset.move;
+          socket.emit("play", { matchId, roundNumber, move });
+          log(`play ${move} on round ${roundNumber}`);
+          movesEl.hidden = true;
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/apps/front/public/demo-client.html
+++ b/apps/front/public/demo-client.html
@@ -64,7 +64,7 @@
         background: #1e293b;
       }
     </style>
-    <script src="https://cdn.socket.io/4.8.1/socket.io.min.js"></script>
+    <script src="/vendor/socket.io.min.js"></script>
   </head>
   <body>
     <h1 id="title">Chifoumi demo client</h1>

--- a/apps/game-service/src/health/health.controller.ts
+++ b/apps/game-service/src/health/health.controller.ts
@@ -7,6 +7,7 @@ export class HealthController {
     return {
       status: "ok",
       service: "game-service",
+      instance: process.env.INSTANCE_ID ?? "game-service",
       version: "0.0.0",
     };
   }

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,11 @@
+# US-032 demo override: expose game replicas on fixed ports for cross-instance demo.
+# Use with: docker compose -f docker-compose.yml -f docker-compose.scale.yml -f docker-compose.demo.yml up -d
+
+services:
+  game-1:
+    ports:
+      - "3101:3001"
+
+  game-2:
+    ports:
+      - "3102:3001"

--- a/docker-compose.scale.yml
+++ b/docker-compose.scale.yml
@@ -1,0 +1,267 @@
+x-api-common: &api-common
+  build:
+    context: .
+    dockerfile: apps/api/Dockerfile
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  environment: &api-env
+    DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+    REDIS_URL: redis://redis:6379
+    API_PORT: "3000"
+    CORS_ORIGINS: http://front.localhost,http://localhost:5173
+    FRONTEND_URL: http://front.localhost
+    JWT_PRIVATE_KEY_PATH: infra/keys/jwt-private.pem
+    JWT_PUBLIC_KEY_PATH: infra/keys/jwt-public.pem
+    JWT_ACCESS_TTL_SECONDS: "900"
+    JWT_REFRESH_TTL_SECONDS: "604800"
+    BULLMQ_PREFIX: rps
+    MAIL_TRANSPORT: mailhog
+    MAIL_HOST: mailhog
+    MAIL_PORT: "1025"
+    MAIL_FROM: noreply@chifoumi.local
+  volumes:
+    - ./infra/keys:/app/infra/keys:ro
+  healthcheck:
+    test:
+      [
+        "CMD",
+        "node",
+        "-e",
+        "fetch('http://127.0.0.1:3000/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+      ]
+    interval: 10s
+    timeout: 5s
+    retries: 6
+    start_period: 40s
+  restart: unless-stopped
+  networks:
+    - chifoumi
+
+x-game-common: &game-common
+  build:
+    context: .
+    dockerfile: apps/game-service/Dockerfile
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  environment: &game-env
+    DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+    REDIS_URL: redis://redis:6379
+    GAME_SERVICE_PORT: "3001"
+    CORS_ORIGINS: http://front.localhost,http://localhost:5173
+    FRONTEND_URL: http://front.localhost
+    JWT_PUBLIC_KEY_PATH: infra/keys/jwt-public.pem
+    BULLMQ_PREFIX: rps
+  volumes:
+    - ./infra/keys:/app/infra/keys:ro
+  healthcheck:
+    test:
+      [
+        "CMD",
+        "node",
+        "-e",
+        "fetch('http://127.0.0.1:3001/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+      ]
+    interval: 10s
+    timeout: 5s
+    retries: 6
+    start_period: 30s
+  restart: unless-stopped
+  networks:
+    - chifoumi
+
+x-traefik-api-labels: &traefik-api-labels
+  traefik.enable: "true"
+  traefik.http.routers.api.rule: Host(`api.localhost`)
+  traefik.http.routers.api.entrypoints: web
+  traefik.http.services.api.loadbalancer.server.port: "3000"
+
+x-traefik-game-labels: &traefik-game-labels
+  traefik.enable: "true"
+  traefik.http.routers.game.rule: Host(`game.localhost`)
+  traefik.http.routers.game.entrypoints: web
+  traefik.http.services.game.loadbalancer.server.port: "3001"
+  traefik.http.services.game.loadbalancer.sticky.cookie: "true"
+  traefik.http.services.game.loadbalancer.sticky.cookie.name: chifoumi_game
+
+services:
+  postgres:
+    networks:
+      - chifoumi
+
+  redis:
+    networks:
+      - chifoumi
+
+  mailhog:
+    networks:
+      - chifoumi
+
+  job-runner-match:
+    networks:
+      - chifoumi
+
+  job-runner-misc:
+    networks:
+      - chifoumi
+
+  traefik:
+    image: traefik:v3.3
+    container_name: chifoumi-traefik
+    command:
+      - --api.dashboard=true
+      - --api.insecure=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.traefik.rule: Host(`traefik.localhost`)
+      traefik.http.routers.traefik.entrypoints: web
+      traefik.http.routers.traefik.service: api@internal
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:80/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+  api-1:
+    <<: *api-common
+    container_name: chifoumi-api-1
+    environment:
+      <<: *api-env
+      INSTANCE_ID: api-1
+    labels:
+      <<: *traefik-api-labels
+
+  api-2:
+    <<: *api-common
+    container_name: chifoumi-api-2
+    environment:
+      <<: *api-env
+      INSTANCE_ID: api-2
+    labels:
+      <<: *traefik-api-labels
+
+  game-1:
+    <<: *game-common
+    container_name: chifoumi-game-1
+    environment:
+      <<: *game-env
+      INSTANCE_ID: game-1
+    labels:
+      <<: *traefik-game-labels
+
+  game-2:
+    <<: *game-common
+    container_name: chifoumi-game-2
+    environment:
+      <<: *game-env
+      INSTANCE_ID: game-2
+    labels:
+      <<: *traefik-game-labels
+
+  front:
+    build:
+      context: .
+      dockerfile: apps/front/Dockerfile
+      args:
+        VITE_API_BASE_URL: http://api.localhost
+    container_name: chifoumi-front
+    depends_on:
+      api-1:
+        condition: service_healthy
+      api-2:
+        condition: service_healthy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.front.rule: Host(`front.localhost`)
+      traefik.http.routers.front.entrypoints: web
+      traefik.http.services.front.loadbalancer.server.port: "80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    container_name: chifoumi-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+    volumes:
+      - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.prometheus.rule: Host(`prometheus.localhost`)
+      traefik.http.routers.prometheus.entrypoints: web
+      traefik.http.services.prometheus.loadbalancer.server.port: "9090"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:9090/-/healthy || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    container_name: chifoumi-grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3002:3000"
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.grafana.rule: Host(`grafana.localhost`)
+      traefik.http.routers.grafana.entrypoints: web
+      traefik.http.services.grafana.loadbalancer.server.port: "3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+      - chifoumi
+
+networks:
+  chifoumi:
+    name: chifoumi
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/docker-compose.scale.yml
+++ b/docker-compose.scale.yml
@@ -3,8 +3,8 @@ x-api-common: &api-common
     context: .
     dockerfile: apps/api/Dockerfile
   depends_on:
-    postgres:
-      condition: service_healthy
+    db-migrate:
+      condition: service_completed_successfully
     redis:
       condition: service_healthy
   environment: &api-env
@@ -107,6 +107,21 @@ services:
       - chifoumi
 
   job-runner-misc:
+    networks:
+      - chifoumi
+
+  db-migrate:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    container_name: chifoumi-db-migrate
+    entrypoint: ["/app/apps/api/docker-migrate.sh"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+    restart: "no"
     networks:
       - chifoumi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "ps -o comm= 1 | grep -qE 'node|sh'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     environment:
       DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
       REDIS_URL: redis://redis:6379
@@ -80,6 +86,12 @@ services:
         condition: service_healthy
       mailhog:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "ps -o comm= 1 | grep -qE 'node|sh'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     environment:
       DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
       REDIS_URL: redis://redis:6379

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Ce dossier regroupe la documentation projet : consignes, backlog, specs d'archit
 | [`consignes/`](consignes/) | Sujet, grille de notation et contraintes d'oral. |
 | [`superpowers/specs/`](superpowers/specs/) | Specs de design et decisions structurantes. |
 | [`superpowers/plans/`](superpowers/plans/) | Plans d'execution issus des specs et des tickets. |
+| [`demo/`](demo/) | Script et procedure de demonstration multi-instances (US-032). |
 
 ## Entrees principales
 
@@ -20,6 +21,7 @@ Ce dossier regroupe la documentation projet : consignes, backlog, specs d'archit
 - [`backlog/sprint-1-data.md`](backlog/sprint-1-data.md) : stories data et Prisma.
 - [`backlog/sprint-1-job-runner.md`](backlog/sprint-1-job-runner.md) : workers et jobs asynchrones.
 - [`backlog/sprint-1-devops-demo.md`](backlog/sprint-1-devops-demo.md) : devops, demo et observabilite.
+- [`demo/multi-instances.md`](demo/multi-instances.md) : demo soutenance multi-replicas (US-032).
 
 ## Futures sections
 
@@ -28,4 +30,3 @@ Ces emplacements pourront etre ajoutes au fil des sprints :
 - `docs/adr/` pour les Architecture Decision Records.
 - `docs/openapi.json` pour l'export Swagger.
 - `docs/runbooks/` pour les procedures d'exploitation.
-- `docs/demo/` pour le script de demonstration jury.

--- a/docs/demo/assets/01-stack-ready.svg
+++ b/docs/demo/assets/01-stack-ready.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
   <rect width="960" height="540" fill="#0f172a"/>
-  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Stack demarree</text>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder - Stack demarree</text>
   <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">docker compose ps : api-1, api-2, game-1, game-2, traefik, grafana</text>
   <rect x="48" y="160" width="864" height="320" rx="12" fill="#1e293b" stroke="#334155"/>
   <text x="72" y="210" fill="#cbd5e1" font-family="Consolas, monospace" font-size="16">curl http://api.localhost/health  -&gt; instance api-1 / api-2</text>

--- a/docs/demo/assets/01-stack-ready.svg
+++ b/docs/demo/assets/01-stack-ready.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Stack demarree</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">docker compose ps : api-1, api-2, game-1, game-2, traefik, grafana</text>
+  <rect x="48" y="160" width="864" height="320" rx="12" fill="#1e293b" stroke="#334155"/>
+  <text x="72" y="210" fill="#cbd5e1" font-family="Consolas, monospace" font-size="16">curl http://api.localhost/health  -&gt; instance api-1 / api-2</text>
+  <text x="72" y="250" fill="#cbd5e1" font-family="Consolas, monospace" font-size="16">curl http://127.0.0.1:3101/health -&gt; instance game-1</text>
+  <text x="72" y="290" fill="#cbd5e1" font-family="Consolas, monospace" font-size="16">curl http://127.0.0.1:3102/health -&gt; instance game-2</text>
+</svg>

--- a/docs/demo/assets/02-four-windows.svg
+++ b/docs/demo/assets/02-four-windows.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
   <rect width="960" height="540" fill="#0f172a"/>
-  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  4 fenetres navigateur</text>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder - 4 fenetres navigateur</text>
   <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">Joueur A sur game-1 (3101) · Joueur B sur game-2 (3102) · Grafana · Traefik</text>
   <rect x="48" y="160" width="410" height="140" rx="10" fill="#1d4ed8"/>
   <rect x="502" y="160" width="410" height="140" rx="10" fill="#047857"/>

--- a/docs/demo/assets/02-four-windows.svg
+++ b/docs/demo/assets/02-four-windows.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  4 fenetres navigateur</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">Joueur A sur game-1 (3101) · Joueur B sur game-2 (3102) · Grafana · Traefik</text>
+  <rect x="48" y="160" width="410" height="140" rx="10" fill="#1d4ed8"/>
+  <rect x="502" y="160" width="410" height="140" rx="10" fill="#047857"/>
+  <rect x="48" y="340" width="410" height="140" rx="10" fill="#7c3aed"/>
+  <rect x="502" y="340" width="410" height="140" rx="10" fill="#b45309"/>
+  <text x="72" y="240" fill="#fff" font-family="Segoe UI, sans-serif" font-size="22">Player A · demo-client · game-1</text>
+  <text x="526" y="240" fill="#fff" font-family="Segoe UI, sans-serif" font-size="22">Player B · demo-client · game-2</text>
+  <text x="72" y="420" fill="#fff" font-family="Segoe UI, sans-serif" font-size="22">Grafana · localhost:3002</text>
+  <text x="526" y="420" fill="#fff" font-family="Segoe UI, sans-serif" font-size="22">Traefik · traefik.localhost</text>
+</svg>

--- a/docs/demo/assets/03-match-cross-instance.svg
+++ b/docs/demo/assets/03-match-cross-instance.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Match cross-instance</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">matchFound identique · BO3 joue entre game-1 et game-2</text>
+  <rect x="48" y="170" width="864" height="300" rx="12" fill="#111827" stroke="#334155"/>
+  <text x="72" y="230" fill="#22c55e" font-family="Consolas, monospace" font-size="16">[A/game-1] matchFound matchId=...</text>
+  <text x="72" y="270" fill="#22c55e" font-family="Consolas, monospace" font-size="16">[B/game-2] matchFound matchId=...</text>
+  <text x="72" y="330" fill="#fbbf24" font-family="Consolas, monospace" font-size="16">roundResolved scoreA=1 scoreB=0</text>
+  <text x="72" y="390" fill="#38bdf8" font-family="Consolas, monospace" font-size="16">matchEnded winner=A</text>
+</svg>

--- a/docs/demo/assets/03-match-cross-instance.svg
+++ b/docs/demo/assets/03-match-cross-instance.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
   <rect width="960" height="540" fill="#0f172a"/>
-  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Match cross-instance</text>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder - Match cross-instance</text>
   <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">matchFound identique · BO3 joue entre game-1 et game-2</text>
   <rect x="48" y="170" width="864" height="300" rx="12" fill="#111827" stroke="#334155"/>
   <text x="72" y="230" fill="#22c55e" font-family="Consolas, monospace" font-size="16">[A/game-1] matchFound matchId=...</text>

--- a/docs/demo/assets/04-crash-game-1.svg
+++ b/docs/demo/assets/04-crash-game-1.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
   <rect width="960" height="540" fill="#0f172a"/>
-  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Crash game-1</text>
-  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">docker stop chifoumi-game-1 pendant le round suivant</text>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder - Crash game-1</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">docker stop chifoumi-game-1 apres le BO3 principal</text>
   <rect x="48" y="170" width="864" height="300" rx="12" fill="#111827" stroke="#334155"/>
   <text x="72" y="230" fill="#f87171" font-family="Consolas, monospace" font-size="16">docker stop chifoumi-game-1</text>
   <text x="72" y="290" fill="#fbbf24" font-family="Consolas, monospace" font-size="16">[A] disconnect transport close</text>
-  <text x="72" y="350" fill="#94a3b8" font-family="Consolas, monospace" font-size="16">Reconnect A on game-2 (3102)  state in Redis (P2 US-038)</text>
+  <text x="72" y="350" fill="#94a3b8" font-family="Consolas, monospace" font-size="16">Open A2 on game-2 (3102) - manual recovery documented</text>
 </svg>

--- a/docs/demo/assets/04-crash-game-1.svg
+++ b/docs/demo/assets/04-crash-game-1.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Crash game-1</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">docker stop chifoumi-game-1 pendant le round suivant</text>
+  <rect x="48" y="170" width="864" height="300" rx="12" fill="#111827" stroke="#334155"/>
+  <text x="72" y="230" fill="#f87171" font-family="Consolas, monospace" font-size="16">docker stop chifoumi-game-1</text>
+  <text x="72" y="290" fill="#fbbf24" font-family="Consolas, monospace" font-size="16">[A] disconnect transport close</text>
+  <text x="72" y="350" fill="#94a3b8" font-family="Consolas, monospace" font-size="16">Reconnect A on game-2 (3102)  state in Redis (P2 US-038)</text>
+</svg>

--- a/docs/demo/assets/05-grafana.svg
+++ b/docs/demo/assets/05-grafana.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
   <rect width="960" height="540" fill="#0f172a"/>
-  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Grafana live</text>
-  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">http://grafana.localhost  admin / admin</text>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder - Grafana live</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">http://grafana.localhost - admin / admin</text>
   <rect x="48" y="160" width="864" height="320" rx="12" fill="#111827" stroke="#334155"/>
   <polyline points="80,420 180,380 280,360 380,300 480,280 580,240 680,220 780,180 880,160" fill="none" stroke="#38bdf8" stroke-width="4"/>
   <text x="72" y="210" fill="#cbd5e1" font-family="Segoe UI, sans-serif" font-size="18">Prometheus scrape (US-039) + dashboard Chifoumi Overview a venir</text>

--- a/docs/demo/assets/05-grafana.svg
+++ b/docs/demo/assets/05-grafana.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <text x="48" y="72" fill="#e2e8f0" font-family="Segoe UI, sans-serif" font-size="32" font-weight="700">Placeholder  Grafana live</text>
+  <text x="48" y="120" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="18">http://grafana.localhost  admin / admin</text>
+  <rect x="48" y="160" width="864" height="320" rx="12" fill="#111827" stroke="#334155"/>
+  <polyline points="80,420 180,380 280,360 380,300 480,280 580,240 680,220 780,180 880,160" fill="none" stroke="#38bdf8" stroke-width="4"/>
+  <text x="72" y="210" fill="#cbd5e1" font-family="Segoe UI, sans-serif" font-size="18">Prometheus scrape (US-039) + dashboard Chifoumi Overview a venir</text>
+</svg>

--- a/docs/demo/multi-instances.md
+++ b/docs/demo/multi-instances.md
@@ -119,17 +119,29 @@ Verification API (optionnel) :
 curl http://api.localhost/leaderboard?limit=5
 ```
 
-### Etape 4 — Crash game-1 en plein match (~1 min)
+### Etape 4 — Crash controle de game-1 (~1 min)
 
-Pendant le **round suivant** d'un second match (relancer queue des deux cotes) :
+Apres le BO3 principal, montrer la resilience de la stack sans risquer de bloquer la demo de match :
 
 ```bash
 docker stop chifoumi-game-1
 ```
 
-- Fenetre **A** : le client affiche `disconnect`.
-- **Comportement attendu (P2 / US-038)** : reconnecter A sur game-2 (`gameUrl=http://127.0.0.1:3102`) et reprendre le match (etat Redis).
-- **Comportement actuel** : B peut continuer ; A doit se reconnecter manuellement. Si le match reste bloque, voir [Cas de recuperation](#cas-de-recuperation).
+- Verifier que `game-2` reste disponible :
+
+```bash
+curl http://127.0.0.1:3102/health
+```
+
+- Fenetre **B** : le client connecte a `game-2` reste utilisable.
+- Fenetre **A** : si elle etait connectee a `game-1`, elle affiche `disconnect`.
+- Pour continuer la demo cote A, ouvrir une nouvelle fenetre A sur `game-2` :
+
+```text
+http://front.localhost/demo-client.html?player=A2&apiUrl=http://api.localhost&gameUrl=http://127.0.0.1:3102
+```
+
+La reprise automatique d'un match en cours apres crash d'instance est gardee pour l'US-038. Ici, la promesse US-032 est une procedure de demonstration reproductible avec detection du crash, service restant disponible et recuperation manuelle documentee.
 
 ![Crash game-1](assets/04-crash-game-1.svg)
 
@@ -167,7 +179,7 @@ Montrer au minimum :
 1. « Deux replicas Game Service, etat partage Redis, matchmaking cross-instance. »
 2. « Round-robin API derriere Traefik ; sticky WS sur `game.localhost`. »
 3. « On force A sur game-1 et B sur game-2 via ports directs — preuve que le matchmaking distribue fonctionne. »
-4. « Crash d'une instance : resilience (reconnexion P2) + procedures de recuperation documentees. »
+4. « Crash controle d'une instance : detection, autre replica disponible et procedures de recuperation documentees. »
 5. « Observabilite : Prometheus + Grafana dans la stack. »
 
 ## Fichiers associes
@@ -176,7 +188,7 @@ Montrer au minimum :
 |---|---|
 | [`scripts/demo/run-demo.sh`](../../scripts/demo/run-demo.sh) | Demarrage stack + onglets (bash) |
 | [`scripts/demo/run-demo.ps1`](../../scripts/demo/run-demo.ps1) | Idem Windows |
-| [`apps/front/public/demo-client.html`](../../apps/front/public/demo-client.html) | Client WebSocket minimal pour la demo |
+| [`apps/front/public/demo-client.html`](../../apps/front/public/demo-client.html) | Client WebSocket minimal pour la demo, sans dependance CDN |
 | [`docker-compose.demo.yml`](../../docker-compose.demo.yml) | Override ports game-1 / game-2 |
 
 Captures placeholder : remplacer les SVG dans `docs/demo/assets/` par de vraies captures avant la soutenance.

--- a/docs/demo/multi-instances.md
+++ b/docs/demo/multi-instances.md
@@ -1,0 +1,182 @@
+# Demo multi-instances (US-032)
+
+Procedure pas a pas (~5 minutes) pour demontrer la scalabilite horizontale en soutenance : deux replicas Game Service, matchmaking cross-instance, resilience et observabilite.
+
+**Depend de** : [US-030](../backlog/sprint-1-devops-demo.md) (stack scale Traefik).
+
+## Pre-requis
+
+| Element | Detail |
+|---|---|
+| Docker + Compose | Docker Desktop ou Engine recent |
+| OpenSSL | Generation des cles JWT de dev |
+| Fichier hosts | Entrees `*.localhost` (voir ci-dessous) |
+| Navigateur | 4 fenetres ou profils separes recommandes |
+| Temps | ~5 min une fois la stack prete |
+
+### Fichier hosts
+
+Ajouter dans `C:\Windows\System32\drivers\etc\hosts` ou `/etc/hosts` :
+
+```text
+127.0.0.1 api.localhost front.localhost game.localhost traefik.localhost grafana.localhost prometheus.localhost
+```
+
+### Demarrage automatise (recommande)
+
+**Linux / macOS / Git Bash :**
+
+```bash
+bash scripts/demo/run-demo.sh
+```
+
+**Windows (PowerShell) :**
+
+```powershell
+.\scripts\demo\run-demo.ps1
+```
+
+Le script :
+
+1. Genere les cles JWT si absentes (`infra/keys/`).
+2. Lance `docker compose -f docker-compose.yml -f docker-compose.scale.yml -f docker-compose.demo.yml up -d --build`.
+3. Attend les healthchecks (API, game-1, game-2, Grafana).
+4. Ouvre les onglets demo (best effort).
+
+Desactiver l'ouverture auto : `OPEN_BROWSER=0 bash scripts/demo/run-demo.sh`.
+
+## Stack
+
+Compose files utilises :
+
+| Fichier | Role |
+|---|---|
+| `docker-compose.yml` | Postgres, Redis, job-runners, MailHog |
+| `docker-compose.scale.yml` | Traefik, api-1/2, game-1/2, front, Prometheus, Grafana |
+| `docker-compose.demo.yml` | Ports directs `3101` (game-1) et `3102` (game-2) pour forcer l'instance |
+
+Arret :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.scale.yml -f docker-compose.demo.yml down
+```
+
+Reset complet (donnees) :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.scale.yml -f docker-compose.demo.yml down -v
+```
+
+![Stack prete](assets/01-stack-ready.svg)
+
+Verifier :
+
+```bash
+curl http://api.localhost/health          # instance api-1 ou api-2
+curl http://127.0.0.1:3101/health           # instance game-1
+curl http://127.0.0.1:3102/health           # instance game-2
+```
+
+## Scenario (5 min)
+
+Chronometrer a partir de l'ouverture des 4 fenetres.
+
+### Etape 1 — Ouvrir 4 fenetres (~30 s)
+
+| Fenetre | URL | Role |
+|---|---|---|
+| A | `http://front.localhost/demo-client.html?player=A&apiUrl=http://api.localhost&gameUrl=http://127.0.0.1:3101` | Joueur A force sur **game-1** |
+| B | `http://front.localhost/demo-client.html?player=B&apiUrl=http://api.localhost&gameUrl=http://127.0.0.1:3102` | Joueur B force sur **game-2** |
+| C | `http://grafana.localhost` (admin / admin) | Observabilite live |
+| D | `http://traefik.localhost` | Dashboard reverse proxy |
+
+![Quatre fenetres](assets/02-four-windows.svg)
+
+> **Forcer la repartition** : le fichier `docker-compose.demo.yml` expose game-1 sur le port `3101` et game-2 sur `3102`. Le client demo se connecte en WebSocket directement a l'instance choisie via le parametre `gameUrl`. Traefik (`game.localhost`) reste disponible pour montrer le sticky session en parallele.
+
+### Etape 2 — Register & join queue (~1 min)
+
+1. Fenetre **A** : cliquer **Register & connect**, puis **Join queue**.
+2. Fenetre **B** : idem.
+3. Verifier dans les deux logs : `matchFound` avec le **meme** `matchId`.
+
+![Match cross-instance](assets/03-match-cross-instance.svg)
+
+### Etape 3 — Jouer un BO3 (~2 min)
+
+Strategie demo rapide (A gagne 2-0) :
+
+| Round | Joueur A | Joueur B |
+|---|---|---|
+| 1 | Rock | Scissors |
+| 2 | Paper | Rock |
+
+Les boutons Rock / Paper / Scissors apparaissent a chaque `roundStart`. Attendre `matchEnded` des deux cotes.
+
+Verification API (optionnel) :
+
+```bash
+curl http://api.localhost/leaderboard?limit=5
+```
+
+### Etape 4 — Crash game-1 en plein match (~1 min)
+
+Pendant le **round suivant** d'un second match (relancer queue des deux cotes) :
+
+```bash
+docker stop chifoumi-game-1
+```
+
+- Fenetre **A** : le client affiche `disconnect`.
+- **Comportement attendu (P2 / US-038)** : reconnecter A sur game-2 (`gameUrl=http://127.0.0.1:3102`) et reprendre le match (etat Redis).
+- **Comportement actuel** : B peut continuer ; A doit se reconnecter manuellement. Si le match reste bloque, voir [Cas de recuperation](#cas-de-recuperation).
+
+![Crash game-1](assets/04-crash-game-1.svg)
+
+Redemarrer game-1 apres la demo :
+
+```bash
+docker start chifoumi-game-1
+```
+
+### Etape 5 — Grafana (~30 s)
+
+Ouvrir Grafana (fenetre C). Prometheus est provisionne ; le dashboard applicatif complet arrive avec [US-039](../backlog/sprint-1-devops-demo.md).
+
+![Grafana](assets/05-grafana.svg)
+
+Montrer au minimum :
+
+- Grafana accessible et datasource Prometheus configuree.
+- Prometheus targets : `http://prometheus.localhost/targets`.
+
+## Cas de recuperation
+
+| Probleme | Commande / action |
+|---|---|
+| Stack bloquee au demarrage | `docker compose ... logs -f api-1 game-1` |
+| game-1 arrete pour la demo | `docker start chifoumi-game-1` |
+| Match fige apres crash | `docker compose ... restart game-1 game-2 job-runner-match` |
+| Etat Redis / queue corrompu | `docker compose ... down -v` puis relancer `run-demo.sh` |
+| JWT / auth invalides | Regenerer `infra/keys/` et rebuild stack |
+| Ports 80 / 3101 / 3102 occupes | Arreter l'autre stack ou changer les mappings dans `docker-compose.demo.yml` |
+| Hosts `*.localhost` manquants | Ajouter les entrees hosts (voir Pre-requis) |
+
+## Raccourcis narratif soutenance
+
+1. « Deux replicas Game Service, etat partage Redis, matchmaking cross-instance. »
+2. « Round-robin API derriere Traefik ; sticky WS sur `game.localhost`. »
+3. « On force A sur game-1 et B sur game-2 via ports directs — preuve que le matchmaking distribue fonctionne. »
+4. « Crash d'une instance : resilience (reconnexion P2) + procedures de recuperation documentees. »
+5. « Observabilite : Prometheus + Grafana dans la stack. »
+
+## Fichiers associes
+
+| Fichier | Description |
+|---|---|
+| [`scripts/demo/run-demo.sh`](../../scripts/demo/run-demo.sh) | Demarrage stack + onglets (bash) |
+| [`scripts/demo/run-demo.ps1`](../../scripts/demo/run-demo.ps1) | Idem Windows |
+| [`apps/front/public/demo-client.html`](../../apps/front/public/demo-client.html) | Client WebSocket minimal pour la demo |
+| [`docker-compose.demo.yml`](../../docker-compose.demo.yml) | Override ports game-1 / game-2 |
+
+Captures placeholder : remplacer les SVG dans `docs/demo/assets/` par de vraies captures avant la soutenance.

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,3 +1,6 @@
+# Prometheus self-scrape only for US-030 stack bootstrap.
+# Application targets (API, game-service, job-runner) are planned in US-039.
+
 global:
   scrape_interval: 15s
   evaluation_interval: 15s

--- a/scripts/demo/run-demo.ps1
+++ b/scripts/demo/run-demo.ps1
@@ -1,0 +1,64 @@
+# US-032 — Start multi-instance demo stack and open browser tabs (Windows).
+$ErrorActionPreference = "Stop"
+
+$RootDir = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+Set-Location $RootDir
+
+$DemoClientBase = if ($env:DEMO_CLIENT_BASE) { $env:DEMO_CLIENT_BASE } else { "http://front.localhost/demo-client.html" }
+$ApiUrl = if ($env:API_URL) { $env:API_URL } else { "http://api.localhost" }
+$Game1Url = if ($env:GAME1_URL) { $env:GAME1_URL } else { "http://127.0.0.1:3101" }
+$Game2Url = if ($env:GAME2_URL) { $env:GAME2_URL } else { "http://127.0.0.1:3102" }
+
+Write-Host "== Chifoumi multi-instances demo (US-032) =="
+
+$privateKey = Join-Path $RootDir "infra/keys/jwt-private.pem"
+$publicKey = Join-Path $RootDir "infra/keys/jwt-public.pem"
+if (-not (Test-Path $privateKey) -or -not (Test-Path $publicKey)) {
+  Write-Host "Generating dev JWT keys in infra/keys/ ..."
+  New-Item -ItemType Directory -Force -Path (Join-Path $RootDir "infra/keys") | Out-Null
+  openssl genrsa -out $privateKey 2048
+  openssl rsa -in $privateKey -pubout -out $publicKey
+}
+
+Write-Host "Starting scaled stack (with demo port mappings 3101/3102) ..."
+docker compose -f docker-compose.yml -f docker-compose.scale.yml -f docker-compose.demo.yml up -d --build
+
+function Wait-Healthy($Url, $Label) {
+  for ($i = 1; $i -le 60; $i++) {
+    try {
+      $null = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 3
+      Write-Host "OK  $Label"
+      return
+    } catch {
+      Start-Sleep -Seconds 2
+    }
+  }
+  throw "Health check timeout for $Label ($Url)"
+}
+
+Write-Host "Waiting for health endpoints ..."
+Wait-Healthy "$ApiUrl/health" "API"
+Wait-Healthy "$Game1Url/health" "game-1"
+Wait-Healthy "$Game2Url/health" "game-2"
+Wait-Healthy "http://127.0.0.1:3002/api/health" "Grafana"
+
+$playerA = "$DemoClientBase?player=A&apiUrl=$([uri]::EscapeDataString($ApiUrl))&gameUrl=$([uri]::EscapeDataString($Game1Url))"
+$playerB = "$DemoClientBase?player=B&apiUrl=$([uri]::EscapeDataString($ApiUrl))&gameUrl=$([uri]::EscapeDataString($Game2Url))"
+
+Write-Host ""
+Write-Host "Stack ready. Open these URLs (4 browser windows recommended):"
+Write-Host "  Player A (game-1): $playerA"
+Write-Host "  Player B (game-2): $playerB"
+Write-Host "  Grafana:           http://grafana.localhost  (admin / admin)"
+Write-Host "  Traefik dashboard: http://traefik.localhost"
+Write-Host ""
+Write-Host "Full walkthrough: docs/demo/multi-instances.md"
+Write-Host ""
+
+if ($env:OPEN_BROWSER -ne "0") {
+  Write-Host "Opening demo tabs (best effort) ..."
+  Start-Process $playerA
+  Start-Process $playerB
+  Start-Process "http://grafana.localhost"
+  Start-Process "http://traefik.localhost"
+}

--- a/scripts/demo/run-demo.sh
+++ b/scripts/demo/run-demo.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.scale.yml -f docker-compose.demo.yml)
+DEMO_CLIENT_BASE="${DEMO_CLIENT_BASE:-http://front.localhost/demo-client.html}"
+API_URL="${API_URL:-http://api.localhost}"
+GAME1_URL="${GAME1_URL:-http://127.0.0.1:3101}"
+GAME2_URL="${GAME2_URL:-http://127.0.0.1:3102}"
+
+echo "== Chifoumi multi-instances demo (US-032) =="
+
+if [[ ! -f infra/keys/jwt-private.pem || ! -f infra/keys/jwt-public.pem ]]; then
+  echo "Generating dev JWT keys in infra/keys/ ..."
+  mkdir -p infra/keys
+  openssl genrsa -out infra/keys/jwt-private.pem 2048
+  openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+fi
+
+echo "Starting scaled stack (with demo port mappings 3101/3102) ..."
+docker compose "${COMPOSE_FILES[@]}" up -d --build
+
+echo "Waiting for health endpoints ..."
+bash scripts/demo/wait-healthy.sh "$API_URL/health" "API"
+bash scripts/demo/wait-healthy.sh "$GAME1_URL/health" "game-1"
+bash scripts/demo/wait-healthy.sh "$GAME2_URL/health" "game-2"
+bash scripts/demo/wait-healthy.sh "http://127.0.0.1:3002/api/health" "Grafana"
+
+player_a_url="${DEMO_CLIENT_BASE}?player=A&apiUrl=${API_URL}&gameUrl=${GAME1_URL}"
+player_b_url="${DEMO_CLIENT_BASE}?player=B&apiUrl=${API_URL}&gameUrl=${GAME2_URL}"
+
+echo ""
+echo "Stack ready. Open these URLs (4 browser windows recommended):"
+echo "  Player A (game-1): $player_a_url"
+echo "  Player B (game-2): $player_b_url"
+echo "  Grafana:           http://grafana.localhost  (admin / admin)"
+echo "  Traefik dashboard: http://traefik.localhost"
+echo ""
+echo "Full walkthrough: docs/demo/multi-instances.md"
+echo ""
+
+open_url() {
+  local url="$1"
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+  elif command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 || true
+  fi
+}
+
+if [[ "${OPEN_BROWSER:-1}" == "1" ]]; then
+  echo "Opening demo tabs (best effort) ..."
+  open_url "$player_a_url"
+  open_url "$player_b_url"
+  open_url "http://grafana.localhost"
+  open_url "http://traefik.localhost"
+fi

--- a/scripts/demo/wait-healthy.sh
+++ b/scripts/demo/wait-healthy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+wait_url() {
+  local url="$1"
+  local label="${2:-$url}"
+  for attempt in $(seq 1 60); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      echo "OK  $label"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "FAIL $label (timeout after 120s)" >&2
+  return 1
+}
+
+wait_url "$1" "${2:-$1}"


### PR DESCRIPTION
## Summary
- Add step-by-step soutenance demo guide (`docs/demo/multi-instances.md`) with placeholder SVG captures for each key step.
- Add `scripts/demo/run-demo.sh` and `run-demo.ps1` to start the scaled stack (with `docker-compose.demo.yml` port mappings) and open browser tabs.
- Add minimal WebSocket demo client at `apps/front/public/demo-client.html` to play a cross-instance BO3 without the full React UI.
- Includes US-030 stack (Traefik multi-replicas) required by the demo — builds on open PR #78 lineage.

## Test plan
- [ ] Run `bash scripts/demo/run-demo.sh` (or `.\scripts\demo\run-demo.ps1` on Windows) after hosts + JWT keys setup
- [ ] Verify health on `api.localhost`, ports `3101`/`3102`, and Grafana
- [ ] Open two demo-client tabs (A on game-1, B on game-2), join queue, play a BO3
- [ ] Confirm CI passes on this PR