### PR TITLE
feat(auth): US-026 forget-password

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -18,19 +18,22 @@ import { UsersModule } from "./users/users.module.js";
   imports: [
     LoggerModule.forRoot({
       pinoHttp: {
-        redact: ["req.headers.authorization", "req.body.password", "req.body.refreshToken"],
+        redact: [
+          "req.headers.authorization",
+          "req.body.password",
+          "req.body.refreshToken",
+          "req.body.token",
+        ],
       },
     }),
     ThrottlerModule.forRoot(
       process.env.NODE_ENV === "test"
         ? [
             { name: "auth", ttl: 60_000, limit: 1_000_000 },
-            { name: "forgot-password", ttl: 60_000, limit: 1_000_000 },
             { name: "audit", ttl: 60_000, limit: 10 },
           ]
         : [
             { name: "auth", ttl: 60_000, limit: 5 },
-            { name: "forgot-password", ttl: 60_000, limit: 3 },
             { name: "audit", ttl: 60_000, limit: 10 },
           ],
     ),

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,23 +21,19 @@ import { UsersModule } from "./users/users.module.js";
         redact: ["req.headers.authorization", "req.body.password", "req.body.refreshToken"],
       },
     }),
-    ThrottlerModule.forRoot([
-      {
-        name: "auth",
-        ttl: 60_000,
-        limit: 5,
-      },
-      {
-        name: "forgot-password",
-        ttl: 60_000,
-        limit: 3,
-      },
-      {
-        name: "audit",
-        ttl: 60_000,
-        limit: 10,
-      },
-    ]),
+    ThrottlerModule.forRoot(
+      process.env.NODE_ENV === "test"
+        ? [
+            { name: "auth", ttl: 60_000, limit: 1_000_000 },
+            { name: "forgot-password", ttl: 60_000, limit: 1_000_000 },
+            { name: "audit", ttl: 60_000, limit: 10 },
+          ]
+        : [
+            { name: "auth", ttl: 60_000, limit: 5 },
+            { name: "forgot-password", ttl: 60_000, limit: 3 },
+            { name: "audit", ttl: 60_000, limit: 10 },
+          ],
+    ),
     AppConfigModule,
     PrismaModule,
     RedisModule,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -28,6 +28,11 @@ import { UsersModule } from "./users/users.module.js";
         limit: 5,
       },
       {
+        name: "forgot-password",
+        ttl: 60_000,
+        limit: 3,
+      },
+      {
         name: "audit",
         ttl: 60_000,
         limit: 10,

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -16,10 +16,12 @@ import { SWAGGER_BEARER_AUTH } from "../swagger.js";
 import type { SafeUser } from "../users/users.service.js";
 import { AuthService } from "./auth.service.js";
 import { AuthResponseDto } from "./dto/auth-response.dto.js";
+import { ForgotPasswordDto } from "./dto/forgot-password.dto.js";
 import { LoginDto } from "./dto/login.dto.js";
 import { RefreshDto } from "./dto/refresh.dto.js";
 import { RefreshResponseDto } from "./dto/refresh-response.dto.js";
 import { RegisterDto } from "./dto/register.dto.js";
+import { ResetPasswordDto } from "./dto/reset-password.dto.js";
 import { JwtAuthGuard } from "./guards/jwt-auth.guard.js";
 
 type AuthenticatedRequest = {
@@ -183,5 +185,80 @@ export class AuthController {
       jti: req.user.tokenJti,
       expiresAt: req.user.tokenExpiresAt,
     });
+  }
+
+  @Post("forgot-password")
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ "forgot-password": { limit: 3, ttl: 60_000 } })
+  @ApiOperation({
+    summary: "Request a password reset email",
+    description:
+      "Sends a password reset link to the provided email if an account exists. Always responds 200 to prevent account enumeration.",
+  })
+  @ApiBody({
+    type: ForgotPasswordDto,
+    examples: {
+      player: {
+        summary: "Forgot password request",
+        value: { email: "player@example.com" },
+      },
+    },
+  })
+  @ApiOkResponse({ description: "Reset email requested (idempotent, anti-enumeration)" })
+  @ApiBadRequestResponse({
+    description: "Validation error",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["email must be an email"],
+        error: "Bad Request",
+      },
+    },
+  })
+  async forgotPassword(@Body() dto: ForgotPasswordDto): Promise<void> {
+    await this.authService.requestPasswordReset(dto.email);
+  }
+
+  @Post("reset-password")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: "Reset the account password using a reset token",
+    description:
+      "Validates the opaque reset token, updates the password (Argon2id) and revokes all active refresh tokens for the user.",
+  })
+  @ApiBody({
+    type: ResetPasswordDto,
+    examples: {
+      player: {
+        summary: "Reset password",
+        value: {
+          token: "5a7a7a8e-6c4a-4b1a-9f24-9b6f7c2a4e8c",
+          newPassword: "newPassword1234",
+        },
+      },
+    },
+  })
+  @ApiNoContentResponse({ description: "Password updated and refresh tokens revoked" })
+  @ApiBadRequestResponse({
+    description: "Validation error",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["newPassword must be longer than or equal to 10 characters"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: "Invalid, expired or already used reset token",
+    schema: {
+      example: {
+        statusCode: 401,
+        message: "Unauthorized",
+      },
+    },
+  })
+  async resetPassword(@Body() dto: ResetPasswordDto): Promise<void> {
+    await this.authService.resetPassword(dto.token, dto.newPassword);
   }
 }

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -193,7 +193,10 @@ export class AuthController {
 
   @Post("forgot-password")
   @HttpCode(HttpStatus.OK)
-  @Throttle({ "forgot-password": { limit: FORGOT_PASSWORD_THROTTLE_LIMIT, ttl: 60_000 } })
+  // Override the shared "auth" throttler with a stricter limit for this route
+  // only (the throttler key is per-handler), instead of a global throttler that
+  // would rate-limit unrelated endpoints such as GET /me.
+  @Throttle({ auth: { limit: FORGOT_PASSWORD_THROTTLE_LIMIT, ttl: 60_000 } })
   @ApiOperation({
     summary: "Request a password reset email",
     description:
@@ -228,7 +231,7 @@ export class AuthController {
   @ApiOperation({
     summary: "Reset the account password using a reset token",
     description:
-      "Validates the opaque reset token, updates the password (Argon2id) and revokes all active refresh tokens for the user.",
+      "Validates the opaque reset token, updates the password (Argon2id) and revokes all active refresh tokens for the user. Existing access tokens are not blacklisted and stay valid until their short expiry.",
   })
   @ApiBody({
     type: ResetPasswordDto,

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -31,8 +31,12 @@ type AuthenticatedRequest = {
   };
 };
 
+const IS_TEST_ENV = process.env.NODE_ENV === "test";
+const AUTH_THROTTLE_LIMIT = IS_TEST_ENV ? 1_000_000 : 5;
+const FORGOT_PASSWORD_THROTTLE_LIMIT = IS_TEST_ENV ? 1_000_000 : 3;
+
 @ApiTags("auth")
-@Throttle({ auth: { limit: 5, ttl: 60_000 } })
+@Throttle({ auth: { limit: AUTH_THROTTLE_LIMIT, ttl: 60_000 } })
 @Controller("auth")
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
@@ -189,7 +193,7 @@ export class AuthController {
 
   @Post("forgot-password")
   @HttpCode(HttpStatus.OK)
-  @Throttle({ "forgot-password": { limit: 3, ttl: 60_000 } })
+  @Throttle({ "forgot-password": { limit: FORGOT_PASSWORD_THROTTLE_LIMIT, ttl: 60_000 } })
   @ApiOperation({
     summary: "Request a password reset email",
     description:

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -21,6 +21,7 @@ describe("AuthService", () => {
       create: jest.fn<PrismaService["passwordResetToken"]["create"]>(),
       findUnique: jest.fn<PrismaService["passwordResetToken"]["findUnique"]>(),
       updateMany: jest.fn<PrismaService["passwordResetToken"]["updateMany"]>(),
+      delete: jest.fn<PrismaService["passwordResetToken"]["delete"]>(),
     },
     user: {
       update: jest.fn<PrismaService["user"]["update"]>(),
@@ -420,6 +421,15 @@ describe("AuthService", () => {
     await authService.requestPasswordReset("A@B.com");
 
     expect(usersService.findByEmail).toHaveBeenCalledWith("a@b.com");
+    expect(prisma.passwordResetToken.updateMany).toHaveBeenCalledWith({
+      where: { userId: "u1", usedAt: null },
+      data: { usedAt: expect.any(Date) },
+    });
+    const [updateOrder] = prisma.passwordResetToken.updateMany.mock.invocationCallOrder;
+    const [createOrder] = prisma.passwordResetToken.create.mock.invocationCallOrder;
+    expect(updateOrder).toBeDefined();
+    expect(createOrder).toBeDefined();
+    expect(updateOrder ?? 0).toBeLessThan(createOrder ?? 0);
     expect(prisma.passwordResetToken.create).toHaveBeenCalledWith({
       data: {
         userId: "u1",
@@ -438,9 +448,32 @@ describe("AuthService", () => {
 
     await authService.requestPasswordReset("missing@example.com");
 
+    expect(prisma.passwordResetToken.updateMany).not.toHaveBeenCalled();
     expect(prisma.passwordResetToken.create).not.toHaveBeenCalled();
     expect(notificationsQueue.enqueuePasswordResetMail).not.toHaveBeenCalled();
     expect(tokenService.issuePasswordResetToken).not.toHaveBeenCalled();
+  });
+
+  it("requestPasswordReset deletes the persisted token when mail enqueue fails (no orphan)", async () => {
+    usersService.findByEmail.mockResolvedValue({
+      id: "u1",
+      email: "a@b.com",
+    } as Awaited<ReturnType<UsersService["findByEmail"]>>);
+    tokenService.issuePasswordResetToken.mockReturnValue({
+      token: "raw-token",
+      tokenHash: "hashed-token",
+    });
+    prisma.passwordResetToken.create.mockResolvedValue({ id: "prt-new" } as Awaited<
+      ReturnType<PrismaService["passwordResetToken"]["create"]>
+    >);
+    notificationsQueue.enqueuePasswordResetMail.mockRejectedValue(new Error("queue unavailable"));
+    prisma.passwordResetToken.delete.mockResolvedValue(
+      {} as Awaited<ReturnType<PrismaService["passwordResetToken"]["delete"]>>,
+    );
+
+    await expect(authService.requestPasswordReset("a@b.com")).resolves.toBeUndefined();
+
+    expect(prisma.passwordResetToken.delete).toHaveBeenCalledWith({ where: { id: "prt-new" } });
   });
 
   it("resetPassword updates password, marks token used and revokes refresh tokens", async () => {

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -17,6 +17,14 @@ describe("AuthService", () => {
       findUnique: jest.fn<PrismaService["refreshToken"]["findUnique"]>(),
       updateMany: jest.fn<PrismaService["refreshToken"]["updateMany"]>(),
     },
+    passwordResetToken: {
+      create: jest.fn<PrismaService["passwordResetToken"]["create"]>(),
+      findUnique: jest.fn<PrismaService["passwordResetToken"]["findUnique"]>(),
+      updateMany: jest.fn<PrismaService["passwordResetToken"]["updateMany"]>(),
+    },
+    user: {
+      update: jest.fn<PrismaService["user"]["update"]>(),
+    },
   };
   const usersService = {
     findByEmail: jest.fn<UsersService["findByEmail"]>(),
@@ -34,6 +42,8 @@ describe("AuthService", () => {
     issueRefreshToken: jest.fn<TokenService["issueRefreshToken"]>(),
     hashRefreshToken: jest.fn<TokenService["hashRefreshToken"]>(),
     getRefreshExpiresAt: jest.fn<TokenService["getRefreshExpiresAt"]>(),
+    issuePasswordResetToken: jest.fn<TokenService["issuePasswordResetToken"]>(),
+    hashPasswordResetToken: jest.fn<TokenService["hashPasswordResetToken"]>(),
   };
   const redisService = {
     revokeAccessToken: jest.fn<RedisService["revokeAccessToken"]>(),
@@ -44,6 +54,7 @@ describe("AuthService", () => {
   };
   const notificationsQueue = {
     enqueueWelcomeMail: jest.fn<NotificationsQueueService["enqueueWelcomeMail"]>(),
+    enqueuePasswordResetMail: jest.fn<NotificationsQueueService["enqueuePasswordResetMail"]>(),
   };
   let authService: AuthService;
 
@@ -54,12 +65,19 @@ describe("AuthService", () => {
     redisService.setnx.mockResolvedValue(true);
     redisService.del.mockResolvedValue();
     notificationsQueue.enqueueWelcomeMail.mockResolvedValue(undefined);
+    notificationsQueue.enqueuePasswordResetMail.mockResolvedValue(undefined);
 
     (prisma.$transaction as jest.Mock).mockImplementation(async (callback: unknown) =>
       (callback as (tx: never) => Promise<unknown>)({
         refreshToken: {
           updateMany: prisma.refreshToken.updateMany,
           create: prisma.refreshToken.create,
+        },
+        passwordResetToken: {
+          updateMany: prisma.passwordResetToken.updateMany,
+        },
+        user: {
+          update: prisma.user.update,
         },
       } as never),
     );
@@ -384,6 +402,120 @@ describe("AuthService", () => {
         revokedAt: expect.any(Date),
       },
     });
+  });
+
+  it("requestPasswordReset persists hashed token and enqueues mail when email is known", async () => {
+    usersService.findByEmail.mockResolvedValue({
+      id: "u1",
+      email: "a@b.com",
+    } as Awaited<ReturnType<UsersService["findByEmail"]>>);
+    tokenService.issuePasswordResetToken.mockReturnValue({
+      token: "raw-token",
+      tokenHash: "hashed-token",
+    });
+    prisma.passwordResetToken.create.mockResolvedValue(
+      {} as Awaited<ReturnType<PrismaService["passwordResetToken"]["create"]>>,
+    );
+
+    await authService.requestPasswordReset("A@B.com");
+
+    expect(usersService.findByEmail).toHaveBeenCalledWith("a@b.com");
+    expect(prisma.passwordResetToken.create).toHaveBeenCalledWith({
+      data: {
+        userId: "u1",
+        tokenHash: "hashed-token",
+        expiresAt: expect.any(Date),
+      },
+    });
+    expect(notificationsQueue.enqueuePasswordResetMail).toHaveBeenCalledWith({
+      to: "a@b.com",
+      resetUrl: expect.stringContaining("/reset-password?token=raw-token"),
+    });
+  });
+
+  it("requestPasswordReset is silent when email is unknown (anti-enumeration)", async () => {
+    usersService.findByEmail.mockResolvedValue(null);
+
+    await authService.requestPasswordReset("missing@example.com");
+
+    expect(prisma.passwordResetToken.create).not.toHaveBeenCalled();
+    expect(notificationsQueue.enqueuePasswordResetMail).not.toHaveBeenCalled();
+    expect(tokenService.issuePasswordResetToken).not.toHaveBeenCalled();
+  });
+
+  it("resetPassword updates password, marks token used and revokes refresh tokens", async () => {
+    tokenService.hashPasswordResetToken.mockReturnValue("hashed-token");
+    prisma.passwordResetToken.findUnique.mockResolvedValue({
+      id: "prt1",
+      userId: "u1",
+      tokenHash: "hashed-token",
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+    } as Awaited<ReturnType<PrismaService["passwordResetToken"]["findUnique"]>>);
+    prisma.passwordResetToken.updateMany.mockResolvedValue({ count: 1 });
+    passwordService.hash.mockResolvedValue("new-hash");
+
+    await authService.resetPassword("raw-token", "newPassword1234");
+
+    expect(passwordService.hash).toHaveBeenCalledWith("newPassword1234");
+    expect(prisma.passwordResetToken.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "prt1",
+        usedAt: null,
+        expiresAt: { gt: expect.any(Date) },
+      },
+      data: { usedAt: expect.any(Date) },
+    });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { passwordHash: "new-hash" },
+    });
+    expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith({
+      where: { userId: "u1", revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+
+  it("resetPassword rejects unknown token", async () => {
+    tokenService.hashPasswordResetToken.mockReturnValue("missing");
+    prisma.passwordResetToken.findUnique.mockResolvedValue(null);
+
+    await expect(authService.resetPassword("nope", "newPassword1234")).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(passwordService.hash).not.toHaveBeenCalled();
+  });
+
+  it("resetPassword rejects expired token", async () => {
+    tokenService.hashPasswordResetToken.mockReturnValue("hashed-token");
+    prisma.passwordResetToken.findUnique.mockResolvedValue({
+      id: "prt1",
+      userId: "u1",
+      tokenHash: "hashed-token",
+      expiresAt: new Date(Date.now() - 60_000),
+      usedAt: null,
+    } as Awaited<ReturnType<PrismaService["passwordResetToken"]["findUnique"]>>);
+
+    await expect(authService.resetPassword("expired", "newPassword1234")).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(passwordService.hash).not.toHaveBeenCalled();
+  });
+
+  it("resetPassword rejects already used token", async () => {
+    tokenService.hashPasswordResetToken.mockReturnValue("hashed-token");
+    prisma.passwordResetToken.findUnique.mockResolvedValue({
+      id: "prt1",
+      userId: "u1",
+      tokenHash: "hashed-token",
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: new Date(Date.now() - 1_000),
+    } as Awaited<ReturnType<PrismaService["passwordResetToken"]["findUnique"]>>);
+
+    await expect(authService.resetPassword("reused", "newPassword1234")).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(passwordService.hash).not.toHaveBeenCalled();
   });
 
   it("logout rejects already expired access tokens", async () => {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -169,7 +169,14 @@ export class AuthService {
     const { token, tokenHash } = this.tokenService.issuePasswordResetToken();
     const expiresAt = new Date(Date.now() + PASSWORD_RESET_TTL_MS);
 
-    await this.prisma.passwordResetToken.create({
+    // Invalidate any previously issued, still-unused reset token so only the
+    // latest reset link remains valid for a given user.
+    await this.prisma.passwordResetToken.updateMany({
+      where: { userId: user.id, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+
+    const created = await this.prisma.passwordResetToken.create({
       data: {
         userId: user.id,
         tokenHash,
@@ -178,10 +185,19 @@ export class AuthService {
     });
 
     const resetUrl = this.buildPasswordResetUrl(token);
-    await this.notificationsQueue.enqueuePasswordResetMail({
-      to: normalizedEmail,
-      resetUrl,
-    });
+    try {
+      await this.notificationsQueue.enqueuePasswordResetMail({
+        to: normalizedEmail,
+        resetUrl,
+      });
+    } catch {
+      // Compensation: if the mail job cannot be enqueued, drop the token we just
+      // persisted so no unusable orphan reset token is left behind. The error is
+      // swallowed to preserve the anti-enumeration contract (always responds 200).
+      await this.prisma.passwordResetToken
+        .delete({ where: { id: created.id } })
+        .catch(() => undefined);
+    }
   }
 
   async resetPassword(token: string, newPassword: string): Promise<void> {
@@ -221,6 +237,9 @@ export class AuthService {
         data: { passwordHash: newPasswordHash },
       });
 
+      // AC4: only refresh tokens are revoked here. Existing access JWTs are NOT
+      // blacklisted on reset — they remain valid until their short (15 min)
+      // expiry. This is an accepted trade-off documented for the reset flow.
       await tx.refreshToken.updateMany({
         where: { userId: stored.userId, revokedAt: null },
         data: { revokedAt: new Date() },

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -14,6 +14,9 @@ const REFRESH_ROTATION_LOCK_SECONDS = 10;
 const REFRESH_ROTATION_WAIT_ATTEMPTS = 10;
 const REFRESH_ROTATION_WAIT_MS = 25;
 
+const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_FRONTEND_URL = "http://localhost:5173";
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -156,6 +159,75 @@ export class AuthService {
     }
   }
 
+  async requestPasswordReset(email: string): Promise<void> {
+    const normalizedEmail = email.toLowerCase();
+    const user = await this.usersService.findByEmail(normalizedEmail);
+    if (!user) {
+      return;
+    }
+
+    const { token, tokenHash } = this.tokenService.issuePasswordResetToken();
+    const expiresAt = new Date(Date.now() + PASSWORD_RESET_TTL_MS);
+
+    await this.prisma.passwordResetToken.create({
+      data: {
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+      },
+    });
+
+    const resetUrl = this.buildPasswordResetUrl(token);
+    await this.notificationsQueue.enqueuePasswordResetMail({
+      to: normalizedEmail,
+      resetUrl,
+    });
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    const tokenHash = this.tokenService.hashPasswordResetToken(token);
+    const stored = await this.prisma.passwordResetToken.findUnique({
+      where: { tokenHash },
+    });
+
+    if (!stored) {
+      throw new UnauthorizedException();
+    }
+    if (stored.usedAt !== null) {
+      throw new UnauthorizedException();
+    }
+    if (stored.expiresAt.getTime() <= Date.now()) {
+      throw new UnauthorizedException();
+    }
+
+    const newPasswordHash = await this.passwordService.hash(newPassword);
+
+    await this.prisma.$transaction(async (tx) => {
+      const consumed = await tx.passwordResetToken.updateMany({
+        where: {
+          id: stored.id,
+          usedAt: null,
+          expiresAt: { gt: new Date() },
+        },
+        data: { usedAt: new Date() },
+      });
+
+      if (consumed.count === 0) {
+        throw new UnauthorizedException();
+      }
+
+      await tx.user.update({
+        where: { id: stored.userId },
+        data: { passwordHash: newPasswordHash },
+      });
+
+      await tx.refreshToken.updateMany({
+        where: { userId: stored.userId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    });
+  }
+
   async logout(input: { userId: string; jti: string; expiresAt: Date }): Promise<void> {
     const ttlSeconds = Math.ceil((input.expiresAt.getTime() - Date.now()) / 1000);
     if (ttlSeconds <= 0) {
@@ -164,6 +236,11 @@ export class AuthService {
 
     await this.redisService.revokeAccessToken(input.jti, ttlSeconds);
     await this.revokeAllRefreshTokens(input.userId);
+  }
+
+  private buildPasswordResetUrl(token: string): string {
+    const frontendUrl = (process.env.FRONTEND_URL ?? DEFAULT_FRONTEND_URL).replace(/\/+$/, "");
+    return `${frontendUrl}/reset-password?token=${encodeURIComponent(token)}`;
   }
 
   private refreshRotationCacheKey(tokenHash: string): string {

--- a/apps/api/src/auth/dto/forgot-password.dto.ts
+++ b/apps/api/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEmail } from "class-validator";
+
+export class ForgotPasswordDto {
+  @ApiProperty({ format: "email", example: "player@example.com" })
+  @IsEmail()
+  email!: string;
+}

--- a/apps/api/src/auth/dto/reset-password.dto.ts
+++ b/apps/api/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsUUID, Length } from "class-validator";
+
+export class ResetPasswordDto {
+  @ApiProperty({
+    description: "Opaque password reset token received by email",
+    example: "5a7a7a8e-6c4a-4b1a-9f24-9b6f7c2a4e8c",
+  })
+  @IsString()
+  @IsUUID(4)
+  token!: string;
+
+  @ApiProperty({ minLength: 10, maxLength: 128, example: "newPassword1234" })
+  @IsString()
+  @Length(10, 128)
+  newPassword!: string;
+}

--- a/apps/api/src/auth/token.service.ts
+++ b/apps/api/src/auth/token.service.ts
@@ -46,4 +46,13 @@ export class TokenService {
   getRefreshExpiresAt(): Date {
     return new Date(Date.now() + this.jwtConfig.refreshTtlSeconds * 1000);
   }
+
+  hashPasswordResetToken(token: string): string {
+    return createHash("sha256").update(token).digest("hex");
+  }
+
+  issuePasswordResetToken(): { token: string; tokenHash: string } {
+    const token = uuidv4();
+    return { token, tokenHash: this.hashPasswordResetToken(token) };
+  }
 }

--- a/apps/api/src/queues/notifications-queue.service.ts
+++ b/apps/api/src/queues/notifications-queue.service.ts
@@ -49,6 +49,14 @@ export class NotificationsQueueService implements OnModuleInit, OnModuleDestroy 
     });
   }
 
+  async enqueuePasswordResetMail(input: { to: string; resetUrl: string }): Promise<void> {
+    await this.enqueueSendMail({
+      to: input.to,
+      template: "reset-password",
+      data: { resetUrl: input.resetUrl },
+    });
+  }
+
   async enqueueSendMail(payload: SendMailJobData): Promise<void> {
     await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, SEND_MAIL_JOB_OPTIONS);
   }

--- a/apps/api/test/forgot-password-throttle.e2e-spec.ts
+++ b/apps/api/test/forgot-password-throttle.e2e-spec.ts
@@ -1,0 +1,72 @@
+// NB: the side-effect import below MUST stay first — it forces production
+// throttler limits before app.module.ts / auth.controller.ts are evaluated.
+import "./helpers/use-production-throttler.js";
+import { generateKeyPairSync } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type INestApplication, ValidationPipe } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { config } from "dotenv";
+import request from "supertest";
+import { AppModule } from "../src/app.module.js";
+import { AuthService } from "../src/auth/auth.service.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+const jwtKeys = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+process.env.JWT_PRIVATE_KEY = jwtKeys.privateKey;
+process.env.JWT_PUBLIC_KEY = jwtKeys.publicKey;
+process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.SKIP_DB_CONNECT = "true";
+process.env.SKIP_REDIS_CONNECT = "true";
+process.env.FRONTEND_URL ??= "http://localhost:5173";
+
+describe("Forgot-password throttling (e2e, AC7)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    // AuthService is stubbed so throttling is exercised without a database.
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthService)
+      .useValue({ requestPasswordReset: async () => undefined })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+    // Restore the Jest environment so the relaxed throttler limits apply to the
+    // rest of the e2e suite.
+    process.env.NODE_ENV = "test";
+  });
+
+  it("allows 3 requests then returns 429 on the 4th within the window", async () => {
+    const email = "throttle@example.com";
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await request(app.getHttpServer()).post("/auth/forgot-password").send({ email }).expect(200);
+    }
+
+    await request(app.getHttpServer()).post("/auth/forgot-password").send({ email }).expect(429);
+  });
+});

--- a/apps/api/test/helpers/use-production-throttler.ts
+++ b/apps/api/test/helpers/use-production-throttler.ts
@@ -1,0 +1,7 @@
+// Side-effect module: this must be imported BEFORE app.module.ts /
+// auth.controller.ts so that the throttler picks up the production limits
+// (forgot-password: 3/min) instead of the relaxed limits used when
+// NODE_ENV === "test". ES module imports are evaluated in source order, so
+// importing this file first guarantees the environment is set before the Nest
+// module graph is evaluated. The suite restores NODE_ENV to "test" afterwards.
+process.env.NODE_ENV = "production";

--- a/apps/api/test/password-reset.e2e-spec.ts
+++ b/apps/api/test/password-reset.e2e-spec.ts
@@ -1,0 +1,267 @@
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type INestApplication, ValidationPipe } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { config } from "dotenv";
+import request from "supertest";
+import { AppModule } from "../src/app.module.js";
+import { PrismaService } from "../src/prisma/prisma.service.js";
+import { NotificationsQueueService } from "../src/queues/notifications-queue.service.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+const jwtKeys = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+process.env.JWT_PRIVATE_KEY = jwtKeys.privateKey;
+process.env.JWT_PUBLIC_KEY = jwtKeys.publicKey;
+process.env.DATABASE_URL ??= "postgresql://app:chifoumi_dev@localhost:5432/chifoumi";
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.JWT_PRIVATE_KEY_PATH = resolve(
+  repoRoot,
+  process.env.JWT_PRIVATE_KEY_PATH ?? "infra/keys/jwt-private.pem",
+);
+process.env.JWT_PUBLIC_KEY_PATH = resolve(
+  repoRoot,
+  process.env.JWT_PUBLIC_KEY_PATH ?? "infra/keys/jwt-public.pem",
+);
+process.env.FRONTEND_URL ??= "http://localhost:5173";
+
+type EnqueuedMail = {
+  template: string;
+  to: string;
+  data: Record<string, string>;
+};
+
+class NotificationsQueueMock {
+  readonly enqueued: EnqueuedMail[] = [];
+
+  async enqueueWelcomeMail(input: { to: string; displayName: string }): Promise<void> {
+    this.enqueued.push({
+      template: "welcome",
+      to: input.to,
+      data: { displayName: input.displayName },
+    });
+  }
+
+  async enqueuePasswordResetMail(input: { to: string; resetUrl: string }): Promise<void> {
+    this.enqueued.push({
+      template: "reset-password",
+      to: input.to,
+      data: { resetUrl: input.resetUrl },
+    });
+  }
+
+  async enqueueSendMail(payload: {
+    to: string;
+    template: string;
+    data: Record<string, string>;
+  }): Promise<void> {
+    this.enqueued.push(payload);
+  }
+}
+
+describe("Password reset (e2e)", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let queueMock: NotificationsQueueMock;
+
+  beforeAll(async () => {
+    queueMock = new NotificationsQueueMock();
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(NotificationsQueueService)
+      .useValue(queueMock)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    prisma = app.get(PrismaService);
+    await prisma.eloHistory.deleteMany();
+    await prisma.round.deleteMany();
+    await prisma.match.deleteMany();
+    await prisma.passwordResetToken.deleteMany();
+    await prisma.refreshToken.deleteMany();
+    await prisma.eloRating.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  beforeEach(() => {
+    queueMock.enqueued.length = 0;
+  });
+
+  async function registerUser(email: string, password = "password1234"): Promise<string> {
+    const res = await request(app.getHttpServer())
+      .post("/auth/register")
+      .send({
+        email,
+        password,
+        displayName: `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      })
+      .expect(201);
+    return res.body.user.id;
+  }
+
+  it("POST /auth/forgot-password → 200 and enqueues reset mail for known email", async () => {
+    const email = `forgot-${Date.now()}@example.com`;
+    await registerUser(email);
+    queueMock.enqueued.length = 0;
+
+    await request(app.getHttpServer()).post("/auth/forgot-password").send({ email }).expect(200);
+
+    const resetJobs = queueMock.enqueued.filter((job) => job.template === "reset-password");
+    expect(resetJobs).toHaveLength(1);
+    expect(resetJobs[0]?.to).toBe(email);
+    expect(resetJobs[0]?.data.resetUrl).toContain(
+      `${process.env.FRONTEND_URL}/reset-password?token=`,
+    );
+
+    const tokens = await prisma.passwordResetToken.findMany({
+      where: { user: { email } },
+    });
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.tokenHash).not.toMatch(/^[0-9a-f-]{36}$/);
+    const expiresInMs = (tokens[0]?.expiresAt.getTime() ?? 0) - Date.now();
+    expect(expiresInMs).toBeGreaterThan(50 * 60 * 1000);
+    expect(expiresInMs).toBeLessThanOrEqual(60 * 60 * 1000 + 1_000);
+  });
+
+  it("POST /auth/forgot-password → 200 silently when email is unknown (anti-enumeration)", async () => {
+    await request(app.getHttpServer())
+      .post("/auth/forgot-password")
+      .send({ email: `unknown-${Date.now()}@example.com` })
+      .expect(200);
+
+    const resetJobs = queueMock.enqueued.filter((job) => job.template === "reset-password");
+    expect(resetJobs).toHaveLength(0);
+  });
+
+  it("nominal flow: forgot then reset updates password and revokes refresh tokens", async () => {
+    const email = `reset-${Date.now()}@example.com`;
+    const userId = await registerUser(email, "password1234");
+
+    const loginRes = await request(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email, password: "password1234" })
+      .expect(200);
+    const oldRefresh = loginRes.body.tokens.refresh as string;
+
+    queueMock.enqueued.length = 0;
+    await request(app.getHttpServer()).post("/auth/forgot-password").send({ email }).expect(200);
+
+    const resetUrl = queueMock.enqueued.find((job) => job.template === "reset-password")?.data
+      .resetUrl;
+    expect(resetUrl).toBeDefined();
+    const token = new URL(resetUrl ?? "").searchParams.get("token");
+    expect(token).toBeTruthy();
+    if (!token) throw new Error("Missing reset token");
+
+    await request(app.getHttpServer())
+      .post("/auth/reset-password")
+      .send({ token, newPassword: "newPassword4567" })
+      .expect(204);
+
+    const updated = await prisma.user.findUnique({ where: { id: userId } });
+    expect(updated?.passwordHash).toMatch(/^\$argon2id\$/);
+
+    const tokenHash = createHash("sha256").update(token).digest("hex");
+    const storedToken = await prisma.passwordResetToken.findUnique({ where: { tokenHash } });
+    expect(storedToken?.usedAt).not.toBeNull();
+
+    const activeRefreshTokens = await prisma.refreshToken.count({
+      where: { userId, revokedAt: null },
+    });
+    expect(activeRefreshTokens).toBe(0);
+
+    await request(app.getHttpServer())
+      .post("/auth/refresh")
+      .send({ refreshToken: oldRefresh })
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email, password: "password1234" })
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email, password: "newPassword4567" })
+      .expect(200);
+  });
+
+  it("POST /auth/reset-password → 401 when token has already been used", async () => {
+    const email = `reused-${Date.now()}@example.com`;
+    await registerUser(email);
+
+    queueMock.enqueued.length = 0;
+    await request(app.getHttpServer()).post("/auth/forgot-password").send({ email }).expect(200);
+
+    const resetUrl = queueMock.enqueued.find((job) => job.template === "reset-password")?.data
+      .resetUrl;
+    const token = new URL(resetUrl ?? "").searchParams.get("token");
+    if (!token) throw new Error("Missing reset token");
+
+    await request(app.getHttpServer())
+      .post("/auth/reset-password")
+      .send({ token, newPassword: "newPassword4567" })
+      .expect(204);
+
+    await request(app.getHttpServer())
+      .post("/auth/reset-password")
+      .send({ token, newPassword: "anotherPassword99" })
+      .expect(401);
+  });
+
+  it("POST /auth/reset-password → 401 when token has expired", async () => {
+    const email = `expired-${Date.now()}@example.com`;
+    await registerUser(email);
+
+    queueMock.enqueued.length = 0;
+    await request(app.getHttpServer()).post("/auth/forgot-password").send({ email }).expect(200);
+
+    const resetUrl = queueMock.enqueued.find((job) => job.template === "reset-password")?.data
+      .resetUrl;
+    const token = new URL(resetUrl ?? "").searchParams.get("token");
+    if (!token) throw new Error("Missing reset token");
+
+    const tokenHash = createHash("sha256").update(token).digest("hex");
+    await prisma.passwordResetToken.update({
+      where: { tokenHash },
+      data: { expiresAt: new Date("2020-01-01") },
+    });
+
+    await request(app.getHttpServer())
+      .post("/auth/reset-password")
+      .send({ token, newPassword: "newPassword4567" })
+      .expect(401);
+  });
+
+  it("POST /auth/reset-password → 401 for unknown token", async () => {
+    await request(app.getHttpServer())
+      .post("/auth/reset-password")
+      .send({
+        token: "00000000-0000-4000-8000-000000000000",
+        newPassword: "newPassword4567",
+      })
+      .expect(401);
+  });
+});

--- a/apps/api/test/swagger.e2e-spec.ts
+++ b/apps/api/test/swagger.e2e-spec.ts
@@ -85,6 +85,8 @@ describe("Swagger docs (e2e)", () => {
         "/auth/login",
         "/auth/refresh",
         "/auth/logout",
+        "/auth/forgot-password",
+        "/auth/reset-password",
         "/me",
         "/me/history",
         "/users/{id}/profile",

--- a/apps/job-runner/src/notifications/template.service.spec.ts
+++ b/apps/job-runner/src/notifications/template.service.spec.ts
@@ -14,6 +14,18 @@ describe("TemplateService", () => {
     expect(rendered.text).not.toContain("__DISPLAY_NAME__");
   });
 
+  it("renders reset-password template with interpolated resetUrl", () => {
+    const rendered = service.render("reset-password", {
+      resetUrl: "https://example.com/reset-password?token=abc",
+    });
+
+    expect(rendered.subject).toBe("Réinitialisation de votre mot de passe Chifoumi");
+    expect(rendered.html).toContain("https://example.com/reset-password?token=abc");
+    expect(rendered.text).toContain("https://example.com/reset-password?token=abc");
+    expect(rendered.html).not.toContain("__RESET_URL__");
+    expect(rendered.text).not.toContain("__RESET_URL__");
+  });
+
   it("throws a clear error when template is unknown", () => {
     expect(() => service.render("missing-template", {})).toThrow(
       "Unknown mail template: missing-template",

--- a/apps/job-runner/src/notifications/template.service.ts
+++ b/apps/job-runner/src/notifications/template.service.ts
@@ -11,6 +11,7 @@ export type RenderedMail = {
 
 const TEMPLATE_SUBJECTS: Record<string, string> = {
   welcome: "Bienvenue sur Chifoumi",
+  "reset-password": "Réinitialisation de votre mot de passe Chifoumi",
 };
 
 @Injectable()

--- a/apps/job-runner/src/notifications/templates/reset-password.html
+++ b/apps/job-runner/src/notifications/templates/reset-password.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Réinitialisation de votre mot de passe Chifoumi</title>
+  </head>
+  <body>
+    <h1>Réinitialisation de votre mot de passe</h1>
+    <p>
+      Vous avez demandé la réinitialisation du mot de passe de votre compte Chifoumi. Cliquez sur le
+      lien ci-dessous pour choisir un nouveau mot de passe :
+    </p>
+    <p>
+      <a href="__RESET_URL__">Réinitialiser mon mot de passe</a>
+    </p>
+    <p>
+      Ce lien est valable pendant 1 heure. Si vous n'êtes pas à l'origine de cette demande, vous
+      pouvez ignorer ce message en toute sécurité : aucun changement n'a été effectué sur votre
+      compte.
+    </p>
+    <p>À très vite sur le terrain.</p>
+  </body>
+</html>

--- a/apps/job-runner/src/notifications/templates/reset-password.txt
+++ b/apps/job-runner/src/notifications/templates/reset-password.txt
@@ -1,0 +1,12 @@
+Réinitialisation de votre mot de passe
+
+Vous avez demandé la réinitialisation du mot de passe de votre compte Chifoumi.
+Cliquez sur le lien ci-dessous pour choisir un nouveau mot de passe :
+
+__RESET_URL__
+
+Ce lien est valable pendant 1 heure. Si vous n'êtes pas à l'origine de cette demande,
+vous pouvez ignorer ce message en toute sécurité : aucun changement n'a été effectué
+sur votre compte.
+
+À très vite sur le terrain.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -310,6 +310,112 @@
         "tags": ["auth"]
       }
     },
+    "/auth/forgot-password": {
+      "post": {
+        "description": "Sends a password reset link to the provided email if an account exists. Always responds 200 to prevent account enumeration.",
+        "operationId": "AuthController_forgotPassword",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForgotPasswordDto"
+              },
+              "examples": {
+                "player": {
+                  "summary": "Forgot password request",
+                  "value": {
+                    "email": "player@example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Reset email requested (idempotent, anti-enumeration)"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": ["email must be an email"],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Request a password reset email",
+        "tags": ["auth"]
+      }
+    },
+    "/auth/reset-password": {
+      "post": {
+        "description": "Validates the opaque reset token, updates the password (Argon2id) and revokes all active refresh tokens for the user. Existing access tokens are not blacklisted and stay valid until their short expiry.",
+        "operationId": "AuthController_resetPassword",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordDto"
+              },
+              "examples": {
+                "player": {
+                  "summary": "Reset password",
+                  "value": {
+                    "token": "5a7a7a8e-6c4a-4b1a-9f24-9b6f7c2a4e8c",
+                    "newPassword": "newPassword1234"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Password updated and refresh tokens revoked"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 400,
+                    "message": ["newPassword must be longer than or equal to 10 characters"],
+                    "error": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid, expired or already used reset token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "statusCode": 401,
+                    "message": "Unauthorized"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Reset the account password using a reset token",
+        "tags": ["auth"]
+      }
+    },
     "/me": {
       "get": {
         "description": "Returns private profile data for the current player, including email and ELO stats.",
@@ -480,6 +586,62 @@
         },
         "summary": "Get global top players by rating",
         "tags": ["leaderboard"]
+      }
+    },
+    "/matches/{id}/audit": {
+      "get": {
+        "description": "Returns commits, reveals, nonces and server-side hash verification so anyone can replay a finished match and detect cheating.",
+        "operationId": "MatchesController_getAudit",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Match id",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Audit trail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchAuditResponseDto"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "MATCH_NOT_ENDED",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "error": "MATCH_NOT_ENDED"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MATCH_NOT_FOUND",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "error": "MATCH_NOT_FOUND"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Public commit-reveal audit trail for an ended match",
+        "tags": ["matches"]
       }
     },
     "/.well-known/jwks.json": {
@@ -661,6 +823,34 @@
         },
         "required": ["tokens"]
       },
+      "ForgotPasswordDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "player@example.com"
+          }
+        },
+        "required": ["email"]
+      },
+      "ResetPasswordDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Opaque password reset token received by email",
+            "example": "5a7a7a8e-6c4a-4b1a-9f24-9b6f7c2a4e8c"
+          },
+          "newPassword": {
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 128,
+            "example": "newPassword1234"
+          }
+        },
+        "required": ["token", "newPassword"]
+      },
       "MeProfileDto": {
         "type": "object",
         "properties": {
@@ -804,6 +994,125 @@
           }
         },
         "required": ["items"]
+      },
+      "RoundHashCheckDto": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string",
+            "enum": ["match", "mismatch"],
+            "example": "match"
+          },
+          "b": {
+            "type": "string",
+            "enum": ["match", "mismatch"],
+            "example": "match"
+          }
+        },
+        "required": ["a", "b"]
+      },
+      "MatchAuditRoundDto": {
+        "type": "object",
+        "properties": {
+          "roundNumber": {
+            "type": "number",
+            "example": 1
+          },
+          "commitA": {
+            "type": "object",
+            "nullable": true,
+            "example": "a1b2c3..."
+          },
+          "commitB": {
+            "type": "object",
+            "nullable": true,
+            "example": "d4e5f6..."
+          },
+          "moveA": {
+            "type": "string",
+            "enum": ["rock", "paper", "scissors"],
+            "nullable": true,
+            "example": "rock"
+          },
+          "moveB": {
+            "type": "string",
+            "enum": ["rock", "paper", "scissors"],
+            "nullable": true,
+            "example": "paper"
+          },
+          "nonceA": {
+            "type": "object",
+            "nullable": true,
+            "example": "deadbeef..."
+          },
+          "nonceB": {
+            "type": "object",
+            "nullable": true,
+            "example": "cafebabe..."
+          },
+          "hashCheck": {
+            "$ref": "#/components/schemas/RoundHashCheckDto"
+          }
+        },
+        "required": [
+          "roundNumber",
+          "commitA",
+          "commitB",
+          "moveA",
+          "moveB",
+          "nonceA",
+          "nonceB",
+          "hashCheck"
+        ]
+      },
+      "MatchAuditFinalScoreDto": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "number",
+            "example": 2
+          },
+          "b": {
+            "type": "number",
+            "example": 1
+          }
+        },
+        "required": ["a", "b"]
+      },
+      "MatchAuditResponseDto": {
+        "type": "object",
+        "properties": {
+          "matchId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "players": {
+            "description": "Player A and player B user ids",
+            "example": [
+              "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1",
+              "8c7c06a3-40ea-5a3e-9b69-ac9691e3a8b2"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rounds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MatchAuditRoundDto"
+            }
+          },
+          "finalScore": {
+            "$ref": "#/components/schemas/MatchAuditFinalScoreDto"
+          },
+          "winner": {
+            "type": "object",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "required": ["matchId", "players", "rounds", "finalScore", "winner"]
       }
     }
   }

--- a/packages/db/prisma/migrations/20260609120000_add_password_reset_tokens/migration.sql
+++ b/packages/db/prisma/migrations/20260609120000_add_password_reset_tokens/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "password_reset_tokens" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "password_reset_tokens_token_hash_key" ON "password_reset_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_user_id_idx" ON "password_reset_tokens"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,12 +40,26 @@ model User {
 
   eloRating       EloRating?
   refreshTokens   RefreshToken[]
+  passwordResetTokens PasswordResetToken[]
   matchesAsPlayerA Match[]      @relation("PlayerA")
   matchesAsPlayerB Match[]      @relation("PlayerB")
   matchesWon       Match[]      @relation("Winner")
   eloHistory       EloHistory[]
 
   @@map("users")
+}
+
+model PasswordResetToken {
+  id        String    @id @default(uuid()) @db.Uuid
+  userId    String    @map("user_id") @db.Uuid
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash String    @unique @map("token_hash")
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@map("password_reset_tokens")
 }
 
 model RefreshToken {


### PR DESCRIPTION
## Summary
- Implement password reset flow (US-026): `POST /auth/forgot-password` and `POST /auth/reset-password` endpoints, with opaque UUID v4 tokens persisted as SHA-256 hashes in a new `password_reset_tokens` table (1h expiry, `used_at` marker).
- Anti-enumeration: `/auth/forgot-password` always returns 200, even for unknown emails. When the email exists, a `notifications.send-mail` job is enqueued with the `reset-password` template and the `${FRONTEND_URL}/reset-password?token=…` URL.
- On successful reset: password rehashed with Argon2id, the reset token is marked `used_at`, and **all active refresh tokens of the user are revoked** (forces re-login on every device).
- Reuse, expiry, or unknown token on `/auth/reset-password` → 401.
- Per-route throttling via `@nestjs/throttler`: 3 req/min/IP on `/auth/forgot-password` (limits are bumped automatically when `NODE_ENV=test` so the e2e suite is not blocked).
- New email templates `reset-password.html` / `reset-password.txt` shipped with the job-runner.
- Full integration coverage: nominal flow, unknown email (silent), expired token, reused token, anti-enumeration, plus unit tests on `AuthService` and `TemplateService`.

## Test plan
- [ ] `pnpm --filter @chifoumi/db migrate:deploy` applies the new `password_reset_tokens` migration cleanly
- [ ] `pnpm --filter @chifoumi/api test` — all unit tests green (incl. new password reset cases)
- [ ] `pnpm --filter @chifoumi/job-runner test` — template service renders `reset-password` correctly
- [ ] `pnpm --filter @chifoumi/api test:e2e` — full e2e suite passes (auth, leaderboard, me-history, password-reset, swagger)
- [ ] `pnpm biome check` and `pnpm -r typecheck` still green
- [ ] Manual smoke: `POST /auth/forgot-password` for a known email → mail visible in MailHog with the reset link
- [ ] Manual smoke: follow the link, `POST /auth/reset-password`, then log in with the new password → 200; refresh with the old refresh token → 401

## Acceptance criteria covered
- AC1–AC2: anti-enumeration 200 + conditional job publish
- AC3: opaque UUID v4, hashed at rest, 1h expiry
- AC4: Argon2id rehash + token used + refresh tokens revoked + 204
- AC5: 401 on expired / reused / unknown token
- AC6: reset URL points to `${FRONTEND_URL}/reset-password?token=…`
- AC7: throttler 3 req/min/IP on `/auth/forgot-password`
- AC8: nominal, unknown email, expired token, reused token, anti-enumeration all tested

Closes #27