### PR TITLE
fix(ci): repair US-031 workflow merge artifacts (#32)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U app -d chifoumi"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -59,19 +59,6 @@ jobs:
           - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: app
-          POSTGRES_PASSWORD: chifoumi_dev
-          POSTGRES_DB: chifoumi
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U app -d chifoumi"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -89,9 +76,6 @@ jobs:
         run: |
           pnpm --filter @chifoumi/db build
           pnpm --filter @chifoumi/elo build
-
-      - name: Apply database migrations
-        run: pnpm --filter @chifoumi/db migrate:deploy
 
       - name: Apply database migrations
         run: pnpm --filter @chifoumi/db migrate:deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -128,6 +128,7 @@ jobs:
           mkdir -p infra/keys
           openssl genrsa -out infra/keys/jwt-private.pem 2048
           openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+          chmod a+r infra/keys/jwt-private.pem infra/keys/jwt-public.pem
 
       - name: Start E2E stack
         run: bash scripts/e2e/start-stack.sh

--- a/scripts/e2e/start-stack.sh
+++ b/scripts/e2e/start-stack.sh
@@ -4,5 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+if [ -d infra/keys ]; then
+  chmod a+r infra/keys/*.pem 2>/dev/null || true
+fi
+
 docker compose --project-name chifoumi-e2e -f docker-compose.e2e.yml up \
   --build --detach --wait --wait-timeout 180

--- a/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
+++ b/tests/e2e/src/bo3-cross-instance.e2e-spec.ts
@@ -77,6 +77,7 @@ describe("US-031 BO3 cross-instance smoke @e2e", () => {
         apiUrl,
         playerA.tokens.access,
         (profile) => profile.gamesPlayed === 1 && profile.rating > baselineA.rating,
+        15_000,
       );
       expect(profileA.gamesPlayed).toBe(1);
 
@@ -104,5 +105,5 @@ describe("US-031 BO3 cross-instance smoke @e2e", () => {
       socketA?.disconnect();
       socketB?.disconnect();
     }
-  }, 30_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- PR #79 was merged with a broken \.github/workflows/pr.yml\ (duplicate \postgres\ service key and duplicated migrate step), which invalidates the workflow on GitHub Actions.
- This follow-up removes the merge artifacts and increases E2E smoke persistence timeouts for CI stability.

## Test plan
- [ ] CI \lint\, \	ypecheck\, \	est\, \uild\, and \e2e\ jobs pass
- [ ] Workflow file validates (no duplicate service keys)

Closes #32

Made with [Cursor](https://cursor.com)