### PR TITLE
feat(game-service): replace match timers with BullMQ delayed jobs (#37)

### DIFF
--- a/apps/game-service/src/match/match-play.service.spec.ts
+++ b/apps/game-service/src/match/match-play.service.spec.ts
@@ -6,6 +6,7 @@ import { MatchSessionService } from "../match-session/match-session.service.js";
 import { RedisService } from "../redis/redis.service.js";
 import { MatchEndedPublisher } from "./match-ended-publisher.service.js";
 import { MatchPlayService, PlayValidationError } from "./match-play.service.js";
+import { MatchTimeoutSchedulerService } from "./match-timeout-scheduler.service.js";
 
 describe("MatchPlayService", () => {
   let client: InstanceType<typeof Redis>;
@@ -30,9 +31,20 @@ describe("MatchPlayService", () => {
       }),
     } as unknown as MatchEndedPublisher;
 
-    const logger = { warn: jest.fn() } as unknown as Logger;
+    const matchTimeoutScheduler = {
+      scheduleTimeout: jest.fn(async () => "job-1"),
+      cancelTimeout: jest.fn(async () => undefined),
+    } as unknown as MatchTimeoutSchedulerService;
 
-    service = new MatchPlayService(matchSessionService, eventBus, matchEndedPublisher, logger);
+    const logger = { warn: jest.fn(), debug: jest.fn() } as unknown as Logger;
+
+    service = new MatchPlayService(
+      matchSessionService,
+      eventBus,
+      matchEndedPublisher,
+      matchTimeoutScheduler,
+      logger,
+    );
 
     await matchSessionService.create({
       matchId: "match-1",
@@ -140,5 +152,17 @@ describe("MatchPlayService", () => {
     expect(state?.scoreA).toBe(0);
     expect(state?.scoreB).toBe(0);
     expect(state?.currentRound).toBe(2);
+  });
+
+  it("does not mutate state when timeout fires after the round advanced", async () => {
+    await service.submitPlay({ userId: "a", matchId: "match-1", roundNumber: 1, move: "rock" });
+    await service.submitPlay({ userId: "b", matchId: "match-1", roundNumber: 1, move: "scissors" });
+
+    await service.handleMatchTimeout("match-1", 1, "WAITING_PLAYS");
+
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("WAITING_PLAYS");
+    expect(state?.currentRound).toBe(2);
+    expect(state?.scoreA).toBe(1);
   });
 });

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -243,8 +243,8 @@ export class MatchPlayService {
       return;
     }
 
-    await this.matchSessionService.broadcastRoundStart(state);
     await this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
+    await this.matchSessionService.broadcastRoundStart(state);
   }
 
   private async finalizeMatch(state: MatchState): Promise<void> {

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, type OnModuleDestroy } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Logger } from "nestjs-pino";
 import { MatchEventBus } from "../match-session/match-event-bus.js";
 import {
@@ -15,6 +15,8 @@ import {
 import { transitionMatchState } from "../match-session/match-state-machine.js";
 import { isValidMove, resolveRound as resolveRps } from "../rps/resolve.js";
 import { MatchEndedPublisher } from "./match-ended-publisher.service.js";
+import type { MatchTimeoutExpectedState } from "./match-timeout.types.js";
+import { MatchTimeoutSchedulerService } from "./match-timeout-scheduler.service.js";
 
 export type PlayInput = {
   userId: string;
@@ -32,11 +34,6 @@ export class PlayValidationError extends Error {
   }
 }
 
-type ActiveTimer = {
-  timeout: ReturnType<typeof setTimeout>;
-  roundNumber: number;
-};
-
 type RoundResolution = {
   moveA: Move;
   moveB: Move;
@@ -44,22 +41,14 @@ type RoundResolution = {
 };
 
 @Injectable()
-export class MatchPlayService implements OnModuleDestroy {
-  private readonly timers = new Map<string, ActiveTimer>();
-
+export class MatchPlayService {
   constructor(
     private readonly matchSessionService: MatchSessionService,
     private readonly eventBus: MatchEventBus,
     private readonly matchEndedPublisher: MatchEndedPublisher,
+    private readonly matchTimeoutScheduler: MatchTimeoutSchedulerService,
     private readonly logger: Logger,
   ) {}
-
-  onModuleDestroy(): void {
-    for (const timer of this.timers.values()) {
-      clearTimeout(timer.timeout);
-    }
-    this.timers.clear();
-  }
 
   async onMatchStarted(state: MatchState): Promise<void> {
     this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
@@ -157,6 +146,20 @@ export class MatchPlayService implements OnModuleDestroy {
     }
 
     return { state: nextState, resolution };
+  }
+
+  async handleMatchTimeout(
+    matchId: string,
+    roundNumber: number,
+    expectedState: MatchTimeoutExpectedState,
+  ): Promise<void> {
+    if (expectedState === "WAITING_PLAYS") {
+      await this.handleRoundTimeout(matchId, roundNumber);
+      return;
+    }
+
+    // Commit-reveal phases are handled once US-035 lands on develop.
+    this.logger.debug({ matchId, roundNumber, expectedState }, "unsupported timeout state");
   }
 
   async handleRoundTimeout(matchId: string, roundNumber: number): Promise<void> {
@@ -269,23 +272,17 @@ export class MatchPlayService implements OnModuleDestroy {
   }
 
   private scheduleRoundTimeout(matchId: string, roundNumber: number, deadlineIso: string): void {
-    this.clearTimer(matchId);
-
     const delayMs = Math.max(0, new Date(deadlineIso).getTime() - Date.now());
-    const timeout = setTimeout(() => {
-      void this.handleRoundTimeout(matchId, roundNumber).catch((error) => {
-        this.logger.warn({ matchId, roundNumber, error }, "round timeout handling failed");
+    void this.matchTimeoutScheduler
+      .scheduleTimeout(matchId, roundNumber, "WAITING_PLAYS", delayMs)
+      .catch((error) => {
+        this.logger.warn({ matchId, roundNumber, error }, "failed to schedule round timeout");
       });
-    }, delayMs);
-
-    this.timers.set(matchId, { timeout, roundNumber });
   }
 
   private clearTimer(matchId: string): void {
-    const active = this.timers.get(matchId);
-    if (active) {
-      clearTimeout(active.timeout);
-      this.timers.delete(matchId);
-    }
+    void this.matchTimeoutScheduler.cancelTimeout(matchId).catch((error) => {
+      this.logger.warn({ matchId, error }, "failed to cancel round timeout");
+    });
   }
 }

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -51,7 +51,7 @@ export class MatchPlayService {
   ) {}
 
   async onMatchStarted(state: MatchState): Promise<void> {
-    this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
+    await this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
   }
 
   async submitPlay(input: PlayInput): Promise<void> {
@@ -244,11 +244,11 @@ export class MatchPlayService {
     }
 
     await this.matchSessionService.broadcastRoundStart(state);
-    this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
+    await this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
   }
 
   private async finalizeMatch(state: MatchState): Promise<void> {
-    this.clearTimer(state.matchId);
+    await this.clearTimer(state.matchId);
 
     const payload = {
       matchId: state.matchId,
@@ -271,18 +271,29 @@ export class MatchPlayService {
     await this.matchEndedPublisher.publishMatchEnded(state);
   }
 
-  private scheduleRoundTimeout(matchId: string, roundNumber: number, deadlineIso: string): void {
+  private async scheduleRoundTimeout(
+    matchId: string,
+    roundNumber: number,
+    deadlineIso: string,
+  ): Promise<void> {
     const delayMs = Math.max(0, new Date(deadlineIso).getTime() - Date.now());
-    void this.matchTimeoutScheduler
-      .scheduleTimeout(matchId, roundNumber, "WAITING_PLAYS", delayMs)
-      .catch((error) => {
-        this.logger.warn({ matchId, roundNumber, error }, "failed to schedule round timeout");
-      });
+    try {
+      await this.matchTimeoutScheduler.scheduleTimeout(
+        matchId,
+        roundNumber,
+        "WAITING_PLAYS",
+        delayMs,
+      );
+    } catch (error) {
+      this.logger.warn({ matchId, roundNumber, error }, "failed to schedule round timeout");
+    }
   }
 
-  private clearTimer(matchId: string): void {
-    void this.matchTimeoutScheduler.cancelTimeout(matchId).catch((error) => {
+  private async clearTimer(matchId: string): Promise<void> {
+    try {
+      await this.matchTimeoutScheduler.cancelTimeout(matchId);
+    } catch (error) {
       this.logger.warn({ matchId, error }, "failed to cancel round timeout");
-    });
+    }
   }
 }

--- a/apps/game-service/src/match/match-timeout-scheduler.service.spec.ts
+++ b/apps/game-service/src/match/match-timeout-scheduler.service.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Queue } from "bullmq";
+import Redis from "ioredis-mock";
+import { RedisService } from "../redis/redis.service.js";
+import { MATCH_TIMEOUT_JOB_NAME, matchTimeoutJobKey } from "./match-timeout.constants.js";
+import { MatchTimeoutSchedulerService } from "./match-timeout-scheduler.service.js";
+
+describe("MatchTimeoutSchedulerService", () => {
+  let client: InstanceType<typeof Redis>;
+  let redisService: RedisService;
+  let service: MatchTimeoutSchedulerService;
+  let queueAdd: jest.Mock;
+  let queueGetJob: jest.Mock;
+  let queueClose: jest.Mock;
+
+  beforeEach(async () => {
+    client = new Redis(`redis://match-timeout-test/${Date.now()}-${Math.random()}`);
+    redisService = new RedisService({ url: "redis://localhost:6379" });
+    Object.assign(redisService, { client });
+
+    queueAdd = jest.fn(async () => ({ id: "job-123", remove: jest.fn(async () => undefined) }));
+    queueGetJob = jest.fn(async () => ({ remove: jest.fn(async () => undefined) }));
+    queueClose = jest.fn(async () => undefined);
+
+    service = new MatchTimeoutSchedulerService({ url: "redis://localhost:6379" }, redisService);
+    Object.assign(service, {
+      queue: {
+        add: queueAdd,
+        getJob: queueGetJob,
+        close: queueClose,
+      } as unknown as Queue,
+    });
+  });
+
+  it("schedules a delayed job and stores its id in Redis", async () => {
+    const jobId = await service.scheduleTimeout("match-1", 1, "WAITING_PLAYS", 5000);
+
+    expect(jobId).toBe("job-123");
+    expect(await client.get(matchTimeoutJobKey("match-1"))).toBe("job-123");
+    expect(queueAdd).toHaveBeenCalledWith(
+      MATCH_TIMEOUT_JOB_NAME,
+      {
+        matchId: "match-1",
+        roundNumber: 1,
+        expectedState: "WAITING_PLAYS",
+      },
+      expect.objectContaining({ delay: 5000 }),
+    );
+  });
+
+  it("cancels a pending job before rescheduling for a new state", async () => {
+    const remove = jest.fn<() => Promise<void>>(async () => undefined);
+    queueGetJob.mockResolvedValue({ remove } as never);
+
+    await service.scheduleTimeout("match-1", 1, "WAITING_PLAYS", 5000);
+    await service.scheduleTimeout("match-1", 1, "WAITING_COMMITS", 5000);
+
+    expect(remove).toHaveBeenCalled();
+    expect(queueAdd).toHaveBeenCalledTimes(2);
+    expect(queueAdd.mock.calls[1]?.[1]).toMatchObject({
+      expectedState: "WAITING_COMMITS",
+    });
+  });
+
+  it("removes the pending job on cancelTimeout", async () => {
+    const remove = jest.fn<() => Promise<void>>(async () => undefined);
+    queueGetJob.mockResolvedValue({ remove } as never);
+
+    await service.scheduleTimeout("match-1", 1, "WAITING_PLAYS", 5000);
+    await service.cancelTimeout("match-1");
+
+    expect(remove).toHaveBeenCalled();
+    expect(await client.get(matchTimeoutJobKey("match-1"))).toBeNull();
+  });
+});

--- a/apps/game-service/src/match/match-timeout-scheduler.service.ts
+++ b/apps/game-service/src/match/match-timeout-scheduler.service.ts
@@ -1,0 +1,93 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  MATCH_TIMEOUT_JOB_NAME,
+  MATCH_TIMEOUT_JOB_TTL_SECONDS,
+  MATCH_TIMEOUT_QUEUE,
+  matchTimeoutJobKey,
+} from "./match-timeout.constants.js";
+import type { MatchTimeoutExpectedState } from "./match-timeout.types.js";
+
+@Injectable()
+export class MatchTimeoutSchedulerService implements OnModuleInit, OnModuleDestroy {
+  private queue: Queue | null = null;
+
+  constructor(
+    @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
+    private readonly redisService: RedisService,
+  ) {}
+
+  onModuleInit(): void {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    const prefix = process.env.BULLMQ_PREFIX ?? "rps";
+    this.queue = new Queue(MATCH_TIMEOUT_QUEUE, {
+      connection: { url: this.redisConfig.url },
+      prefix,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.queue?.close();
+    this.queue = null;
+  }
+
+  async scheduleTimeout(
+    matchId: string,
+    roundNumber: number,
+    expectedState: MatchTimeoutExpectedState,
+    delayMs: number,
+  ): Promise<string | null> {
+    await this.cancelTimeout(matchId);
+
+    if (!this.queue) {
+      return null;
+    }
+
+    const job = await this.queue.add(
+      MATCH_TIMEOUT_JOB_NAME,
+      { matchId, roundNumber, expectedState },
+      {
+        delay: Math.max(0, delayMs),
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+    );
+
+    if (!job.id) {
+      return null;
+    }
+
+    await this.redisService.setex(
+      matchTimeoutJobKey(matchId),
+      MATCH_TIMEOUT_JOB_TTL_SECONDS,
+      job.id,
+    );
+
+    return job.id;
+  }
+
+  async cancelTimeout(matchId: string): Promise<void> {
+    const jobId = await this.redisService.get(matchTimeoutJobKey(matchId));
+    if (!jobId) {
+      return;
+    }
+
+    if (this.queue) {
+      const job = await this.queue.getJob(jobId);
+      if (job) {
+        try {
+          await job.remove();
+        } catch {
+          // Job may already be active or completed.
+        }
+      }
+    }
+
+    await this.redisService.del(matchTimeoutJobKey(matchId));
+  }
+}

--- a/apps/game-service/src/match/match-timeout-worker.service.spec.ts
+++ b/apps/game-service/src/match/match-timeout-worker.service.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { Job } from "bullmq";
+import { Logger } from "nestjs-pino";
+import { MatchPlayService } from "./match-play.service.js";
+import type { MatchTimeoutJobPayload } from "./match-timeout.types.js";
+import { MatchTimeoutWorkerService } from "./match-timeout-worker.service.js";
+
+describe("MatchTimeoutWorkerService", () => {
+  let matchPlayService: MatchPlayService;
+  let service: MatchTimeoutWorkerService;
+
+  beforeEach(() => {
+    matchPlayService = {
+      handleMatchTimeout: jest.fn(async () => undefined),
+    } as unknown as MatchPlayService;
+
+    const logger = { warn: jest.fn() } as unknown as Logger;
+    service = new MatchTimeoutWorkerService(
+      { url: "redis://localhost:6379" },
+      matchPlayService,
+      logger,
+    );
+  });
+
+  it("delegates timeout jobs to MatchPlayService", async () => {
+    const job = {
+      id: "job-1",
+      data: {
+        matchId: "match-1",
+        roundNumber: 2,
+        expectedState: "WAITING_PLAYS",
+      },
+    } as Job<MatchTimeoutJobPayload>;
+
+    await service.processJob(job);
+
+    expect(matchPlayService.handleMatchTimeout).toHaveBeenCalledWith("match-1", 2, "WAITING_PLAYS");
+  });
+});

--- a/apps/game-service/src/match/match-timeout-worker.service.ts
+++ b/apps/game-service/src/match/match-timeout-worker.service.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { type Job, Worker } from "bullmq";
+import { Logger } from "nestjs-pino";
+import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
+import { MatchPlayService } from "./match-play.service.js";
+import { MATCH_TIMEOUT_QUEUE } from "./match-timeout.constants.js";
+import type { MatchTimeoutJobPayload } from "./match-timeout.types.js";
+
+@Injectable()
+export class MatchTimeoutWorkerService implements OnModuleInit, OnModuleDestroy {
+  private worker: Worker<MatchTimeoutJobPayload> | null = null;
+
+  constructor(
+    @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
+    private readonly matchPlayService: MatchPlayService,
+    private readonly logger: Logger,
+  ) {}
+
+  onModuleInit(): void {
+    if (
+      process.env.SKIP_REDIS_CONNECT === "true" ||
+      process.env.MATCH_TIMEOUT_WORKER_ENABLED === "false"
+    ) {
+      return;
+    }
+
+    const prefix = process.env.BULLMQ_PREFIX ?? "rps";
+    this.worker = new Worker<MatchTimeoutJobPayload>(
+      MATCH_TIMEOUT_QUEUE,
+      async (job) => this.processJob(job),
+      {
+        connection: { url: this.redisConfig.url },
+        prefix,
+      },
+    );
+
+    this.worker.on("failed", (job, error) => {
+      this.logger.warn(
+        { jobId: job?.id, matchId: job?.data.matchId, error },
+        "match timeout job failed",
+      );
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.worker?.close();
+    this.worker = null;
+  }
+
+  async processJob(job: Job<MatchTimeoutJobPayload>): Promise<void> {
+    const { matchId, roundNumber, expectedState } = job.data;
+    await this.matchPlayService.handleMatchTimeout(matchId, roundNumber, expectedState);
+  }
+}

--- a/apps/game-service/src/match/match-timeout.constants.ts
+++ b/apps/game-service/src/match/match-timeout.constants.ts
@@ -1,0 +1,11 @@
+import { MATCH_SESSION_TTL_SECONDS } from "../match-session/match-session.types.js";
+
+export const MATCH_TIMEOUT_QUEUE = "match-timeouts";
+
+export const MATCH_TIMEOUT_JOB_NAME = "round-timeout";
+
+export const MATCH_TIMEOUT_JOB_TTL_SECONDS = MATCH_SESSION_TTL_SECONDS;
+
+export function matchTimeoutJobKey(matchId: string): string {
+  return `match:${matchId}:timeoutJob`;
+}

--- a/apps/game-service/src/match/match-timeout.types.ts
+++ b/apps/game-service/src/match/match-timeout.types.ts
@@ -1,0 +1,7 @@
+export type MatchTimeoutExpectedState = "WAITING_PLAYS" | "WAITING_COMMITS" | "WAITING_REVEALS";
+
+export type MatchTimeoutJobPayload = {
+  matchId: string;
+  roundNumber: number;
+  expectedState: MatchTimeoutExpectedState;
+};

--- a/apps/game-service/src/match/match.module.ts
+++ b/apps/game-service/src/match/match.module.ts
@@ -4,10 +4,18 @@ import { RedisModule } from "../redis/redis.module.js";
 import { MatchEndedPublisher } from "./match-ended-publisher.service.js";
 import { MatchEventsRelayService } from "./match-events-relay.service.js";
 import { MatchPlayService } from "./match-play.service.js";
+import { MatchTimeoutSchedulerService } from "./match-timeout-scheduler.service.js";
+import { MatchTimeoutWorkerService } from "./match-timeout-worker.service.js";
 
 @Module({
   imports: [RedisModule, MatchSessionModule],
-  providers: [MatchPlayService, MatchEventsRelayService, MatchEndedPublisher],
-  exports: [MatchPlayService, MatchEventsRelayService],
+  providers: [
+    MatchPlayService,
+    MatchEventsRelayService,
+    MatchEndedPublisher,
+    MatchTimeoutSchedulerService,
+    MatchTimeoutWorkerService,
+  ],
+  exports: [MatchPlayService, MatchEventsRelayService, MatchTimeoutSchedulerService],
 })
 export class MatchModule {}

--- a/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
@@ -198,8 +198,8 @@ export class MatchmakingWorkerService implements OnModuleInit, OnModuleDestroy {
     this.metricsService.observeMatchDuration(playerA.queuedAt, now);
     this.metricsService.observeMatchDuration(playerB.queuedAt, now);
 
-    await this.matchSessionService.broadcastInitialEvents(matchState);
     await this.matchPlayService.onMatchStarted(matchState);
+    await this.matchSessionService.broadcastInitialEvents(matchState);
 
     this.logger.log(
       { matchId, playerA: playerA.userId, playerB: playerB.userId },

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -8,7 +8,7 @@ import { io, type Socket } from "socket.io-client";
 import { AppModule } from "../src/app.module.js";
 import { JWT_CONFIG } from "../src/config/jwt.config.js";
 import { MatchPlayService } from "../src/match/match-play.service.js";
-import { MATCH_TIMEOUT_QUEUE } from "../src/match/match-timeout.constants.js";
+import { MATCH_TIMEOUT_QUEUE, matchTimeoutJobKey } from "../src/match/match-timeout.constants.js";
 import { MatchTimeoutSchedulerService } from "../src/match/match-timeout-scheduler.service.js";
 import { MatchmakingWorkerService } from "../src/matchmaking/matchmaking-worker.service.js";
 import { RedisService } from "../src/redis/redis.service.js";
@@ -56,6 +56,28 @@ function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
       resolvePromise(payload);
     });
   });
+}
+
+async function waitForDelayedTimeoutJob(
+  queue: Queue,
+  matchId: string,
+  roundNumber: number,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const jobs = await queue.getJobs(["delayed"]);
+    const match = jobs.find(
+      (job) => job.data.matchId === matchId && job.data.roundNumber === roundNumber,
+    );
+    if (match) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(
+    `timed out waiting for delayed timeout job (match=${matchId}, round=${roundNumber})`,
+  );
 }
 
 async function connectAndJoin(
@@ -172,8 +194,10 @@ describe("Match timeout BullMQ (e2e)", () => {
       playerB.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "scissors" });
       await waitForEvent(playerA, "roundResolved");
       await waitForEvent(playerB, "roundResolved");
-      await waitForEvent<RoundStartPayload>(playerA, "roundStart");
-      await waitForEvent<RoundStartPayload>(playerB, "roundStart");
+      await waitForDelayedTimeoutJob(queue, matchId, 2);
+
+      const timeoutJobId = await redisService.get(matchTimeoutJobKey(matchId));
+      expect(timeoutJobId).toBeTruthy();
 
       const delayedJobs = await queue.getJobs(["delayed"]);
       expect(delayedJobs).toHaveLength(1);

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -1,0 +1,218 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { Queue, Worker } from "bullmq";
+import { config } from "dotenv";
+import { io, type Socket } from "socket.io-client";
+import { AppModule } from "../src/app.module.js";
+import { JWT_CONFIG } from "../src/config/jwt.config.js";
+import { MatchPlayService } from "../src/match/match-play.service.js";
+import { MATCH_TIMEOUT_QUEUE } from "../src/match/match-timeout.constants.js";
+import { MatchTimeoutSchedulerService } from "../src/match/match-timeout-scheduler.service.js";
+import { MatchmakingWorkerService } from "../src/matchmaking/matchmaking-worker.service.js";
+import { RedisService } from "../src/redis/redis.service.js";
+import { issueTestAccessToken, testJwtKeys } from "../src/testing/issue-test-access-token.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+process.env.JWT_PUBLIC_KEY = testJwtKeys.publicKey;
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.MATCHMAKING_WORKER_ENABLED = "false";
+process.env.MATCH_TIMEOUT_WORKER_ENABLED = "false";
+process.env.BULLMQ_PREFIX ??= "rps-test";
+
+type ConnectedPayload = { userId: string; displayName: string };
+type QueueJoinedPayload = { queuedAt: string; currentRating: number };
+type MatchFoundPayload = {
+  matchId: string;
+  opponent: { userId: string; displayName: string; rating: number };
+  bestOf: number;
+};
+type RoundStartPayload = { matchId: string; roundNumber: number; deadline: string };
+type MatchEndedPayload = {
+  matchId: string;
+  winner: string | null;
+  finalScore: { a: number; b: number };
+  eloDelta: { a: number; b: number };
+  reason?: string;
+};
+
+function connectClient(port: number, token: string): Socket {
+  return io(`http://127.0.0.1:${port}/game`, {
+    transports: ["websocket"],
+    forceNew: true,
+    reconnection: false,
+    query: { token },
+  });
+}
+
+function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${event} timeout`)), 10_000);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timeout);
+      resolvePromise(payload);
+    });
+  });
+}
+
+async function connectAndJoin(
+  port: number,
+  input: { userId: string; displayName: string },
+): Promise<{ socket: Socket; queueJoined: QueueJoinedPayload }> {
+  const token = await issueTestAccessToken({
+    userId: input.userId,
+    displayName: input.displayName,
+  });
+  const socket = connectClient(port, token);
+  const connectedPromise = waitForEvent<ConnectedPayload>(socket, "connected");
+
+  await new Promise<void>((resolvePromise, reject) => {
+    socket.once("connect", () => resolvePromise());
+    socket.once("connect_error", reject);
+  });
+
+  await connectedPromise;
+  socket.emit("joinQueue", {});
+  const queueJoined = await waitForEvent<QueueJoinedPayload>(socket, "queueJoined");
+
+  return { socket, queueJoined };
+}
+
+describe("Match timeout BullMQ (e2e)", () => {
+  let app: INestApplication;
+  let port: number;
+  let redisService: RedisService;
+  let worker: MatchmakingWorkerService;
+  let scheduler: MatchTimeoutSchedulerService;
+  let matchPlayService: MatchPlayService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(JWT_CONFIG)
+      .useValue({ publicKey: testJwtKeys.publicKey })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0, "127.0.0.1");
+    port = app.getHttpServer().address().port as number;
+    redisService = app.get(RedisService);
+    worker = app.get(MatchmakingWorkerService);
+    scheduler = app.get(MatchTimeoutSchedulerService);
+    matchPlayService = app.get(MatchPlayService);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  beforeEach(async () => {
+    const client = redisService.getClient();
+    const keys = await client.keys("*");
+    if (keys.length > 0) {
+      await client.del(...keys);
+    }
+  });
+
+  async function pairPlayers(): Promise<{
+    playerA: Socket;
+    playerB: Socket;
+    matchId: string;
+    roundStart: RoundStartPayload;
+  }> {
+    await redisService.setex("user:rating:player-a", 60, "1000");
+    await redisService.setex("user:rating:player-b", 60, "1040");
+
+    const joinedA = await connectAndJoin(port, { userId: "player-a", displayName: "Ace" });
+    const joinedB = await connectAndJoin(port, { userId: "player-b", displayName: "Bob" });
+
+    const matchFoundA = waitForEvent<MatchFoundPayload>(joinedA.socket, "matchFound");
+    const matchFoundB = waitForEvent<MatchFoundPayload>(joinedB.socket, "matchFound");
+    const roundStartA = waitForEvent<RoundStartPayload>(joinedA.socket, "roundStart");
+    const roundStartB = waitForEvent<RoundStartPayload>(joinedB.socket, "roundStart");
+
+    await worker.tick();
+
+    const payloadA = await matchFoundA;
+    await matchFoundB;
+    const roundStart = await roundStartA;
+    await roundStartB;
+
+    return {
+      playerA: joinedA.socket,
+      playerB: joinedB.socket,
+      matchId: payloadA.matchId,
+      roundStart,
+    };
+  }
+
+  it("cancels the pending timeout when both players submit before the deadline", async () => {
+    const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+    const queue = new Queue(MATCH_TIMEOUT_QUEUE, {
+      connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
+      prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
+    });
+
+    playerA.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "rock" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    playerB.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "scissors" });
+    await waitForEvent(playerA, "roundResolved");
+    await waitForEvent(playerB, "roundResolved");
+
+    const delayedJobs = await queue.getJobs(["delayed"]);
+    expect(delayedJobs).toHaveLength(1);
+    expect(delayedJobs[0]?.data).toMatchObject({
+      matchId,
+      roundNumber: 2,
+      expectedState: "WAITING_PLAYS",
+    });
+
+    await queue.close();
+    playerA.disconnect();
+    playerB.disconnect();
+  });
+
+  it("applies forfeit when another instance consumes the delayed timeout job", async () => {
+    const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+    await scheduler.cancelTimeout(matchId);
+    await scheduler.scheduleTimeout(matchId, roundStart.roundNumber, "WAITING_PLAYS", 200);
+
+    const recoveryWorker = new Worker(
+      MATCH_TIMEOUT_QUEUE,
+      async (job) => {
+        await matchPlayService.handleMatchTimeout(
+          job.data.matchId,
+          job.data.roundNumber,
+          job.data.expectedState,
+        );
+      },
+      {
+        connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
+        prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
+      },
+    );
+
+    const matchEndedA = waitForEvent<MatchEndedPayload>(playerA, "matchEnded");
+    const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
+
+    const endedA = await matchEndedA;
+    const endedB = await matchEndedB;
+
+    expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
+    expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
+    expect(endedA.winner).toBeTruthy();
+
+    await recoveryWorker.close();
+    playerA.disconnect();
+    playerB.disconnect();
+  });
+});

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -88,6 +88,7 @@ describe("Match timeout BullMQ (e2e)", () => {
   let worker: MatchmakingWorkerService;
   let scheduler: MatchTimeoutSchedulerService;
   let matchPlayService: MatchPlayService;
+  let recoveryWorker: Worker | null = null;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -108,6 +109,10 @@ describe("Match timeout BullMQ (e2e)", () => {
   });
 
   afterAll(async () => {
+    if (recoveryWorker) {
+      await recoveryWorker.close();
+      recoveryWorker = null;
+    }
     if (app) {
       await app.close();
     }
@@ -161,23 +166,27 @@ describe("Match timeout BullMQ (e2e)", () => {
       prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
     });
 
-    playerA.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "rock" });
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    playerB.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "scissors" });
-    await waitForEvent(playerA, "roundResolved");
-    await waitForEvent(playerB, "roundResolved");
+    try {
+      playerA.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "rock" });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      playerB.emit("play", { matchId, roundNumber: roundStart.roundNumber, move: "scissors" });
+      await waitForEvent(playerA, "roundResolved");
+      await waitForEvent(playerB, "roundResolved");
+      await waitForEvent<RoundStartPayload>(playerA, "roundStart");
+      await waitForEvent<RoundStartPayload>(playerB, "roundStart");
 
-    const delayedJobs = await queue.getJobs(["delayed"]);
-    expect(delayedJobs).toHaveLength(1);
-    expect(delayedJobs[0]?.data).toMatchObject({
-      matchId,
-      roundNumber: 2,
-      expectedState: "WAITING_PLAYS",
-    });
-
-    await queue.close();
-    playerA.disconnect();
-    playerB.disconnect();
+      const delayedJobs = await queue.getJobs(["delayed"]);
+      expect(delayedJobs).toHaveLength(1);
+      expect(delayedJobs[0]?.data).toMatchObject({
+        matchId,
+        roundNumber: 2,
+        expectedState: "WAITING_PLAYS",
+      });
+    } finally {
+      await queue.close();
+      playerA.disconnect();
+      playerB.disconnect();
+    }
   });
 
   it("applies forfeit when another instance consumes the delayed timeout job", async () => {
@@ -186,7 +195,7 @@ describe("Match timeout BullMQ (e2e)", () => {
     await scheduler.cancelTimeout(matchId);
     await scheduler.scheduleTimeout(matchId, roundStart.roundNumber, "WAITING_PLAYS", 200);
 
-    const recoveryWorker = new Worker(
+    recoveryWorker = new Worker(
       MATCH_TIMEOUT_QUEUE,
       async (job) => {
         await matchPlayService.handleMatchTimeout(
@@ -201,18 +210,21 @@ describe("Match timeout BullMQ (e2e)", () => {
       },
     );
 
-    const matchEndedA = waitForEvent<MatchEndedPayload>(playerA, "matchEnded");
-    const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
+    try {
+      const matchEndedA = waitForEvent<MatchEndedPayload>(playerA, "matchEnded");
+      const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
 
-    const endedA = await matchEndedA;
-    const endedB = await matchEndedB;
+      const endedA = await matchEndedA;
+      const endedB = await matchEndedB;
 
-    expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
-    expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
-    expect(endedA.winner).toBeTruthy();
-
-    await recoveryWorker.close();
-    playerA.disconnect();
-    playerB.disconnect();
+      expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
+      expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
+      expect(endedA.winner).toBeTruthy();
+    } finally {
+      await recoveryWorker.close();
+      recoveryWorker = null;
+      playerA.disconnect();
+      playerB.disconnect();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replace in-memory \setTimeout\ round timers with BullMQ \match-timeouts\ delayed jobs stored in Redis
- Add \MatchTimeoutSchedulerService\ (schedule/cancel) and \MatchTimeoutWorkerService\ (consume on any game-service instance)
- \MatchPlayService\ now delegates timeout handling through the scheduler; state checks + Redis lock keep processing idempotent

Closes #37

## Why

In-memory timers are lost when a game-service instance crashes or restarts during a match, leaving rounds stuck. BullMQ delayed jobs survive restarts and can be consumed by any replica, which is required for the multi-instance demo.

## Test plan

- [x] Unit tests for scheduler (schedule, cancel, reschedule)
- [x] Unit tests for worker delegation and timeout no-op when round already advanced
- [x] E2E: timeout job cancellation when both players submit
- [x] E2E: forfeit applied when a recovery worker consumes the delayed job (simulated crash)
- [x] \pnpm --filter @chifoumi/game-service test\ green
- [x] \pnpm --filter @chifoumi/game-service typecheck\ green

## Notes

- Commit/reveal phases (\WAITING_COMMITS\ / \WAITING_REVEALS\) are typed and schedulable; handler wiring lands with US-035.
- Disable the local consumer with \MATCH_TIMEOUT_WORKER_ENABLED=false\ (used in E2E crash simulation).

Made with [Cursor](https://cursor.com)