### PR TITLE
fix(game-service): wire commit-reveal BullMQ timeout handlers (#37)

### DIFF
--- a/apps/game-service/src/match-session/match-session.types.ts
+++ b/apps/game-service/src/match-session/match-session.types.ts
@@ -4,7 +4,12 @@ export const ROUND_DEADLINE_MS = 5_000;
 export const MAX_ROUNDS = 5;
 export const WINS_TO_END = 2;
 
-export type MatchStatus = "WAITING_PLAYS" | "RESOLVING" | "ENDED";
+export type MatchStatus =
+  | "WAITING_PLAYS"
+  | "WAITING_COMMITS"
+  | "WAITING_REVEALS"
+  | "RESOLVING"
+  | "ENDED";
 
 export type Move = "rock" | "paper" | "scissors";
 
@@ -17,6 +22,16 @@ export type MatchPlayer = {
 export type MatchEndReason = "BEST_OF_3" | "FORFEIT_TIMEOUT" | "MAX_ROUNDS_DRAW";
 
 export type RoundPlays = {
+  a: Move | null;
+  b: Move | null;
+};
+
+export type RoundCommits = {
+  a: string | null;
+  b: string | null;
+};
+
+export type RoundReveals = {
   a: Move | null;
   b: Move | null;
 };
@@ -39,6 +54,9 @@ export type MatchState = {
   startedAt: string;
   roundDeadline: string;
   roundPlays: RoundPlays;
+  roundCommits?: RoundCommits;
+  roundReveals?: RoundReveals;
+  revealDeadline?: string;
   rounds?: ResolvedRound[];
   winnerId?: string;
   endReason?: MatchEndReason;
@@ -114,5 +132,13 @@ export function playerIndex(state: MatchState, userId: string): 0 | 1 | null {
 }
 
 export function emptyRoundPlays(): RoundPlays {
+  return { a: null, b: null };
+}
+
+export function emptyRoundCommits(): RoundCommits {
+  return { a: null, b: null };
+}
+
+export function emptyRoundReveals(): RoundReveals {
   return { a: null, b: null };
 }

--- a/apps/game-service/src/match-session/match-state-machine.spec.ts
+++ b/apps/game-service/src/match-session/match-state-machine.spec.ts
@@ -115,6 +115,45 @@ describe("match state machine", () => {
     });
   });
 
+  it("ends the match by forfeit on waiting-commit timeout", () => {
+    const waitingCommits: MatchState = {
+      ...baseState,
+      status: "WAITING_COMMITS",
+      roundCommits: { a: "abc123", b: null },
+    };
+    const next = transitionMatchState(waitingCommits, {
+      type: "TIMEOUT",
+      silentPlayer: "B",
+      now: new Date("2026-06-09T10:00:06.000Z"),
+    });
+
+    expect(next).toMatchObject({
+      status: "ENDED",
+      winnerId: "a",
+      endReason: "FORFEIT_TIMEOUT",
+    });
+  });
+
+  it("ends the match by forfeit on waiting-reveal timeout", () => {
+    const waitingReveals: MatchState = {
+      ...baseState,
+      status: "WAITING_REVEALS",
+      roundReveals: { a: "rock", b: null },
+      revealDeadline: "2026-06-09T10:00:10.000Z",
+    };
+    const next = transitionMatchState(waitingReveals, {
+      type: "TIMEOUT",
+      silentPlayer: "B",
+      now: new Date("2026-06-09T10:00:10.000Z"),
+    });
+
+    expect(next).toMatchObject({
+      status: "ENDED",
+      winnerId: "a",
+      endReason: "FORFEIT_TIMEOUT",
+    });
+  });
+
   it("rejects invalid transitions", () => {
     expect(() =>
       transitionMatchState(baseState, {

--- a/apps/game-service/src/match-session/match-state-machine.ts
+++ b/apps/game-service/src/match-session/match-state-machine.ts
@@ -40,7 +40,11 @@ export function transitionMatchState(state: MatchState, event: MatchStateMachine
   }
 
   if (event.type === "TIMEOUT") {
-    if (state.status !== "WAITING_PLAYS") {
+    if (
+      state.status !== "WAITING_PLAYS" &&
+      state.status !== "WAITING_COMMITS" &&
+      state.status !== "WAITING_REVEALS"
+    ) {
       throw new InvalidMatchTransitionError(state.status, event.type);
     }
     const winnerIndex = event.silentPlayer === "A" ? 1 : 0;

--- a/apps/game-service/src/match/match-play.service.spec.ts
+++ b/apps/game-service/src/match/match-play.service.spec.ts
@@ -15,6 +15,10 @@ describe("MatchPlayService", () => {
   let eventBus: MatchEventBus;
   let service: MatchPlayService;
   let publishedJobs: unknown[];
+  let matchTimeoutScheduler: {
+    scheduleTimeout: jest.Mock;
+    cancelTimeout: jest.Mock;
+  };
 
   beforeEach(async () => {
     client = new Redis(`redis://match-play-test/${Date.now()}-${Math.random()}`);
@@ -31,10 +35,10 @@ describe("MatchPlayService", () => {
       }),
     } as unknown as MatchEndedPublisher;
 
-    const matchTimeoutScheduler = {
+    matchTimeoutScheduler = {
       scheduleTimeout: jest.fn(async () => "job-1"),
       cancelTimeout: jest.fn(async () => undefined),
-    } as unknown as MatchTimeoutSchedulerService;
+    };
 
     const logger = { warn: jest.fn(), debug: jest.fn() } as unknown as Logger;
 
@@ -42,7 +46,7 @@ describe("MatchPlayService", () => {
       matchSessionService,
       eventBus,
       matchEndedPublisher,
-      matchTimeoutScheduler,
+      matchTimeoutScheduler as unknown as MatchTimeoutSchedulerService,
       logger,
     );
 
@@ -164,5 +168,83 @@ describe("MatchPlayService", () => {
     expect(state?.status).toBe("WAITING_PLAYS");
     expect(state?.currentRound).toBe(2);
     expect(state?.scoreA).toBe(1);
+  });
+
+  it("forfeits the match when commit phase times out", async () => {
+    await matchSessionService.mutateState("match-1", (state) => ({
+      ...state,
+      status: "WAITING_COMMITS",
+      roundCommits: { a: "abc123", b: null },
+    }));
+
+    await service.handleMatchTimeout("match-1", 1, "WAITING_COMMITS");
+
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("ENDED");
+    expect(state?.winnerId).toBe("a");
+    expect(state?.endReason).toBe("FORFEIT_TIMEOUT");
+  });
+
+  it("does not mutate state when commit timeout fires after phase advanced", async () => {
+    await matchSessionService.mutateState("match-1", (state) => ({
+      ...state,
+      status: "WAITING_REVEALS",
+      roundCommits: { a: "abc123", b: "def456" },
+      roundReveals: { a: null, b: null },
+      revealDeadline: "2026-06-09T10:00:10.000Z",
+    }));
+
+    await service.handleMatchTimeout("match-1", 1, "WAITING_COMMITS");
+
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("WAITING_REVEALS");
+  });
+
+  it("forfeits the match when reveal phase times out", async () => {
+    await matchSessionService.mutateState("match-1", (state) => ({
+      ...state,
+      status: "WAITING_REVEALS",
+      roundCommits: { a: "abc123", b: "def456" },
+      roundReveals: { a: "rock", b: null },
+      revealDeadline: "2026-06-09T10:00:10.000Z",
+    }));
+
+    await service.handleMatchTimeout("match-1", 1, "WAITING_REVEALS");
+
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("ENDED");
+    expect(state?.winnerId).toBe("a");
+    expect(state?.endReason).toBe("FORFEIT_TIMEOUT");
+  });
+
+  it("schedules commit phase timeout with expected state", async () => {
+    await service.onCommitPhaseStarted({
+      matchId: "match-1",
+      currentRound: 1,
+      roundDeadline: "2026-06-09T10:00:05.000Z",
+    } as Parameters<MatchPlayService["onCommitPhaseStarted"]>[0]);
+
+    expect(matchTimeoutScheduler.scheduleTimeout).toHaveBeenCalledWith(
+      "match-1",
+      1,
+      "WAITING_COMMITS",
+      expect.any(Number),
+    );
+  });
+
+  it("schedules reveal timeout when reveal phase starts", async () => {
+    await service.onRevealPhaseStarted({
+      matchId: "match-1",
+      currentRound: 1,
+      revealDeadline: "2026-06-09T10:00:10.000Z",
+      roundDeadline: "2026-06-09T10:00:05.000Z",
+    } as Parameters<MatchPlayService["onRevealPhaseStarted"]>[0]);
+
+    expect(matchTimeoutScheduler.scheduleTimeout).toHaveBeenCalledWith(
+      "match-1",
+      1,
+      "WAITING_REVEALS",
+      expect.any(Number),
+    );
   });
 });

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -6,7 +6,9 @@ import {
   MatchSessionService,
 } from "../match-session/match-session.service.js";
 import {
+  emptyRoundCommits,
   emptyRoundPlays,
+  emptyRoundReveals,
   type MatchState,
   type Move,
   playerIndex,
@@ -51,7 +53,26 @@ export class MatchPlayService {
   ) {}
 
   async onMatchStarted(state: MatchState): Promise<void> {
-    await this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
+    await this.schedulePhaseTimeout(
+      state.matchId,
+      state.currentRound,
+      this.timeoutStateForStatus(state.status),
+      state.roundDeadline,
+    );
+  }
+
+  async onCommitPhaseStarted(state: MatchState): Promise<void> {
+    await this.schedulePhaseTimeout(
+      state.matchId,
+      state.currentRound,
+      "WAITING_COMMITS",
+      state.roundDeadline,
+    );
+  }
+
+  async onRevealPhaseStarted(state: MatchState): Promise<void> {
+    const deadline = state.revealDeadline ?? state.roundDeadline;
+    await this.schedulePhaseTimeout(state.matchId, state.currentRound, "WAITING_REVEALS", deadline);
   }
 
   async submitPlay(input: PlayInput): Promise<void> {
@@ -158,50 +179,119 @@ export class MatchPlayService {
       return;
     }
 
-    // Commit-reveal phases are handled once US-035 lands on develop.
-    this.logger.debug({ matchId, roundNumber, expectedState }, "unsupported timeout state");
+    if (expectedState === "WAITING_COMMITS") {
+      await this.handleCommitPhaseTimeout(matchId, roundNumber);
+      return;
+    }
+
+    if (expectedState === "WAITING_REVEALS") {
+      await this.handleRevealPhaseTimeout(matchId, roundNumber);
+    }
   }
 
   async handleRoundTimeout(matchId: string, roundNumber: number): Promise<void> {
-    const nextState = await this.matchSessionService.mutateState(matchId, (state) => {
-      if (state.status !== "WAITING_PLAYS" || state.currentRound !== roundNumber) {
-        return state;
-      }
-
-      const silentPlayer =
-        state.roundPlays.a === null && state.roundPlays.b !== null
-          ? "A"
-          : state.roundPlays.b === null && state.roundPlays.a !== null
-            ? "B"
-            : "A";
-      const winnerLabel = silentPlayer === "A" ? "b" : "a";
-
-      const resolvedAt = new Date();
-      return transitionMatchState(
-        {
-          ...state,
-          rounds: [
-            ...(state.rounds ?? []),
-            {
-              roundNumber,
-              moveA: state.roundPlays.a,
-              moveB: state.roundPlays.b,
-              winner: winnerLabel,
-              resolvedAt: resolvedAt.toISOString(),
-            },
-          ],
-        },
-        {
-          type: "TIMEOUT",
-          silentPlayer,
-          now: resolvedAt,
-        },
-      );
-    });
+    const nextState = await this.applyPhaseTimeout(
+      matchId,
+      roundNumber,
+      "WAITING_PLAYS",
+      () => "A",
+    );
 
     if (nextState.status === "ENDED") {
       await this.finalizeMatch(nextState);
     }
+  }
+
+  async handleCommitPhaseTimeout(matchId: string, roundNumber: number): Promise<void> {
+    const nextState = await this.applyPhaseTimeout(
+      matchId,
+      roundNumber,
+      "WAITING_COMMITS",
+      (state) => {
+        const commits = state.roundCommits ?? emptyRoundCommits();
+        return this.resolveSilentPlayer(commits.a, commits.b);
+      },
+    );
+
+    if (nextState.status === "ENDED") {
+      await this.finalizeMatch(nextState);
+    }
+  }
+
+  async handleRevealPhaseTimeout(matchId: string, roundNumber: number): Promise<void> {
+    const nextState = await this.applyPhaseTimeout(
+      matchId,
+      roundNumber,
+      "WAITING_REVEALS",
+      (state) => {
+        const reveals = state.roundReveals ?? emptyRoundReveals();
+        return this.resolveSilentPlayer(reveals.a, reveals.b);
+      },
+    );
+
+    if (nextState.status === "ENDED") {
+      await this.finalizeMatch(nextState);
+    }
+  }
+
+  private async applyPhaseTimeout(
+    matchId: string,
+    roundNumber: number,
+    expectedStatus: MatchTimeoutExpectedState,
+    resolveSilentPlayer: (state: MatchState) => "A" | "B",
+  ): Promise<MatchState> {
+    return this.matchSessionService.mutateState(matchId, (state) => {
+      if (state.status !== expectedStatus || state.currentRound !== roundNumber) {
+        return state;
+      }
+
+      const silentPlayer =
+        expectedStatus === "WAITING_PLAYS"
+          ? this.resolveSilentPlayer(state.roundPlays.a, state.roundPlays.b)
+          : resolveSilentPlayer(state);
+
+      const resolvedAt = new Date();
+      const winnerLabel = silentPlayer === "A" ? "b" : "a";
+
+      if (expectedStatus === "WAITING_PLAYS") {
+        return transitionMatchState(
+          {
+            ...state,
+            rounds: [
+              ...(state.rounds ?? []),
+              {
+                roundNumber,
+                moveA: state.roundPlays.a,
+                moveB: state.roundPlays.b,
+                winner: winnerLabel,
+                resolvedAt: resolvedAt.toISOString(),
+              },
+            ],
+          },
+          {
+            type: "TIMEOUT",
+            silentPlayer,
+            now: resolvedAt,
+          },
+        );
+      }
+
+      return transitionMatchState(state, {
+        type: "TIMEOUT",
+        silentPlayer,
+        now: resolvedAt,
+      });
+    });
+  }
+
+  private resolveSilentPlayer(slotA: string | Move | null, slotB: string | Move | null): "A" | "B" {
+    if (slotA === null && slotB !== null) {
+      return "A";
+    }
+    if (slotB === null && slotA !== null) {
+      return "B";
+    }
+    return "A";
   }
 
   private async afterRoundResolved(state: MatchState, resolution: RoundResolution): Promise<void> {
@@ -243,8 +333,23 @@ export class MatchPlayService {
       return;
     }
 
-    await this.scheduleRoundTimeout(state.matchId, state.currentRound, state.roundDeadline);
+    await this.schedulePhaseTimeout(
+      state.matchId,
+      state.currentRound,
+      this.timeoutStateForStatus(state.status),
+      state.roundDeadline,
+    );
     await this.matchSessionService.broadcastRoundStart(state);
+  }
+
+  private timeoutStateForStatus(status: MatchState["status"]): MatchTimeoutExpectedState {
+    if (status === "WAITING_COMMITS") {
+      return "WAITING_COMMITS";
+    }
+    if (status === "WAITING_REVEALS") {
+      return "WAITING_REVEALS";
+    }
+    return "WAITING_PLAYS";
   }
 
   private async finalizeMatch(state: MatchState): Promise<void> {
@@ -271,9 +376,10 @@ export class MatchPlayService {
     await this.matchEndedPublisher.publishMatchEnded(state);
   }
 
-  private async scheduleRoundTimeout(
+  private async schedulePhaseTimeout(
     matchId: string,
     roundNumber: number,
+    expectedState: MatchTimeoutExpectedState,
     deadlineIso: string,
   ): Promise<void> {
     const delayMs = Math.max(0, new Date(deadlineIso).getTime() - Date.now());
@@ -281,11 +387,14 @@ export class MatchPlayService {
       await this.matchTimeoutScheduler.scheduleTimeout(
         matchId,
         roundNumber,
-        "WAITING_PLAYS",
+        expectedState,
         delayMs,
       );
     } catch (error) {
-      this.logger.warn({ matchId, roundNumber, error }, "failed to schedule round timeout");
+      this.logger.warn(
+        { matchId, roundNumber, expectedState, error },
+        "failed to schedule timeout",
+      );
     }
   }
 

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -10,6 +10,7 @@ import { JWT_CONFIG } from "../src/config/jwt.config.js";
 import { MatchPlayService } from "../src/match/match-play.service.js";
 import { MATCH_TIMEOUT_QUEUE, matchTimeoutJobKey } from "../src/match/match-timeout.constants.js";
 import { MatchTimeoutSchedulerService } from "../src/match/match-timeout-scheduler.service.js";
+import { MatchSessionService } from "../src/match-session/match-session.service.js";
 import { MatchmakingWorkerService } from "../src/matchmaking/matchmaking-worker.service.js";
 import { RedisService } from "../src/redis/redis.service.js";
 import { issueTestAccessToken, testJwtKeys } from "../src/testing/issue-test-access-token.js";
@@ -110,6 +111,7 @@ describe("Match timeout BullMQ (e2e)", () => {
   let worker: MatchmakingWorkerService;
   let scheduler: MatchTimeoutSchedulerService;
   let matchPlayService: MatchPlayService;
+  let matchSessionService: MatchSessionService;
   let recoveryWorker: Worker | null = null;
 
   beforeAll(async () => {
@@ -128,6 +130,7 @@ describe("Match timeout BullMQ (e2e)", () => {
     worker = app.get(MatchmakingWorkerService);
     scheduler = app.get(MatchTimeoutSchedulerService);
     matchPlayService = app.get(MatchPlayService);
+    matchSessionService = app.get(MatchSessionService);
   });
 
   afterAll(async () => {
@@ -244,6 +247,53 @@ describe("Match timeout BullMQ (e2e)", () => {
       expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
       expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
       expect(endedA.winner).toBeTruthy();
+    } finally {
+      await recoveryWorker.close();
+      recoveryWorker = null;
+      playerA.disconnect();
+      playerB.disconnect();
+    }
+  });
+
+  it("applies reveal-phase forfeit when a recovery worker consumes the delayed job", async () => {
+    const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+    await matchSessionService.mutateState(matchId, (state) => ({
+      ...state,
+      status: "WAITING_REVEALS",
+      roundCommits: { a: "abc123", b: "def456" },
+      roundReveals: { a: null, b: null },
+      revealDeadline: new Date(Date.now() + 200).toISOString(),
+    }));
+
+    await scheduler.cancelTimeout(matchId);
+    await scheduler.scheduleTimeout(matchId, roundStart.roundNumber, "WAITING_REVEALS", 200);
+
+    recoveryWorker = new Worker(
+      MATCH_TIMEOUT_QUEUE,
+      async (job) => {
+        await matchPlayService.handleMatchTimeout(
+          job.data.matchId,
+          job.data.roundNumber,
+          job.data.expectedState,
+        );
+      },
+      {
+        connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
+        prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
+      },
+    );
+
+    try {
+      const matchEndedA = waitForEvent<MatchEndedPayload>(playerA, "matchEnded");
+      const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
+
+      const endedA = await matchEndedA;
+      const endedB = await matchEndedB;
+
+      expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
+      expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
+      expect(endedA.winner).toBe("player-a");
     } finally {
       await recoveryWorker.close();
       recoveryWorker = null;


### PR DESCRIPTION
## Summary

- Implement BullMQ timeout handling for \WAITING_COMMITS\ and \WAITING_REVEALS\ phases (US-036 AC1-AC4 gap from PR #85)
- Extend match state types and state machine to support commit/reveal timeout forfeit
- Add \onCommitPhaseStarted\ / \onRevealPhaseStarted\ hooks for US-035 gateway wiring
- Add unit tests and reveal-phase recovery e2e test

Closes #37

## Why

PR #85 delivered BullMQ timeouts for the P0 \WAITING_PLAYS\ flow but left commit/reveal phases as a debug no-op. This patch completes the timeout worker contract so US-035 can plug in without reworking the scheduler.

## Test plan

- [x] \pnpm --filter @chifoumi/game-service test\ green (62 tests)
- [x] \pnpm --filter @chifoumi/game-service typecheck\ green
- [x] Unit: commit/reveal timeout forfeit + no-op when phase advanced
- [x] Unit: phase scheduling uses correct \expectedState\`n- [ ] E2E reveal timeout recovery (requires Redis in CI)

Made with [Cursor](https://cursor.com)