### PR TITLE
Update lefthook configuration, add devcontainer setup, and document agents

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,53 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG NODE_VERSION=20.19.0
+ARG PNPM_VERSION=9.15.9
+ARG USERNAME=vscode
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/usr/local/node/bin:${PATH}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    jq \
+    libpq-dev \
+    openssh-client \
+    openssl \
+    pkg-config \
+    postgresql-client \
+    protobuf-compiler \
+    python3 \
+    python3-pip \
+    python3-venv \
+    redis-tools \
+    shellcheck \
+    unzip \
+    wget \
+    zstd \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN arch="$(dpkg --print-architecture)" \
+  && case "${arch}" in \
+    amd64) node_arch="x64" ;; \
+    arm64) node_arch="arm64" ;; \
+    *) echo "Unsupported architecture: ${arch}" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.xz" -o /tmp/node.tar.xz \
+  && mkdir -p /usr/local/node \
+  && tar -xJf /tmp/node.tar.xz -C /usr/local/node --strip-components=1 \
+  && rm /tmp/node.tar.xz \
+  && npm install -g "pnpm@${PNPM_VERSION}"
+
+RUN mkdir -p /workspace-cache/pnpm \
+  && chown -R "${USERNAME}:${USERNAME}" /workspace-cache
+
+USER ${USERNAME}
+
+WORKDIR /workspaces/Chifoumi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "Chifoumi Ranked",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "workspace",
+  "workspaceFolder": "/workspaces/Chifoumi",
+  "remoteUser": "vscode",
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "forwardPorts": [3000, 3001, 5173, 8025],
+  "portsAttributes": {
+    "3000": {
+      "label": "API"
+    },
+    "3001": {
+      "label": "Game service"
+    },
+    "5173": {
+      "label": "Front"
+    },
+    "8025": {
+      "label": "MailHog"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["biomejs.biome", "Prisma.prisma", "ms-azuretools.vscode-docker"],
+      "settings": {
+        "editor.defaultFormatter": "biomejs.biome",
+        "editor.formatOnSave": true,
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,101 @@
+services:
+  workspace:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    command: sleep infinity
+    init: true
+    user: vscode
+    volumes:
+      - ..:/workspaces/Chifoumi:cached
+      - chifoumi_node_modules:/workspaces/Chifoumi/node_modules
+      - chifoumi_pnpm_store:/workspaces/Chifoumi/pnpm-store
+    environment:
+      PNPM_HOME: /usr/local/node/bin
+      CHIFOUMI_DEVCONTAINER: "true"
+      DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
+      REDIS_URL: redis://redis:6379
+      MAIL_TRANSPORT: mailhog
+      MAIL_HOST: mailhog
+      MAIL_PORT: "1025"
+      MAIL_FROM: noreply@chifoumi.local
+      API_PORT: "3000"
+      GAME_SERVICE_PORT: "3001"
+      CORS_ORIGINS: http://localhost:5173
+      FRONTEND_URL: http://localhost:5173
+      VITE_API_BASE_URL: http://localhost:3000
+      BULLMQ_PREFIX: rps
+      WORKER_QUEUES: match-events,notifications
+      WORKER_CONCURRENCY: "4"
+      WORKER_ROLE: match-processor
+      CRON_ENABLED: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mailhog:
+        condition: service_healthy
+    networks:
+      - chifoumi_dev
+
+  postgres:
+    image: bitnamilegacy/postgresql:16
+    container_name: chifoumi-devcontainer-postgres
+    environment:
+      POSTGRESQL_PASSWORD: postgres_dev
+    ports:
+      - "127.0.0.1:${CHIFOUMI_DEVCONTAINER_POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - chifoumi_pg_data:/bitnami/postgresql
+      - ../infra/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -h 127.0.0.1 -p 5432"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+    networks:
+      - chifoumi_dev
+
+  redis:
+    image: bitnamilegacy/redis:7.4
+    container_name: chifoumi-devcontainer-redis
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+    ports:
+      - "127.0.0.1:${CHIFOUMI_DEVCONTAINER_REDIS_PORT:-6379}:6379"
+    volumes:
+      - chifoumi_redis_data:/bitnami/redis/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - chifoumi_dev
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    container_name: chifoumi-devcontainer-mailhog
+    ports:
+      - "127.0.0.1:${CHIFOUMI_DEVCONTAINER_MAILHOG_HTTP_PORT:-8025}:8025"
+      - "127.0.0.1:${CHIFOUMI_DEVCONTAINER_MAILHOG_SMTP_PORT:-1025}:1025"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8025/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - chifoumi_dev
+
+volumes:
+  chifoumi_node_modules:
+  chifoumi_pg_data:
+  chifoumi_pnpm_store:
+  chifoumi_redis_data:
+
+networks:
+  chifoumi_dev:
+    name: chifoumi-devcontainer

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+sudo mkdir -p \
+  /workspaces/Chifoumi/node_modules \
+  /workspaces/Chifoumi/pnpm-store
+sudo chown -R "$(id -u):$(id -g)" \
+  /workspaces/Chifoumi/node_modules \
+  /workspaces/Chifoumi/pnpm-store
+pnpm config set store-dir "$ROOT_DIR/pnpm-store"
+
+if [ ! -f .env ]; then
+  cp .env.example .env
+  sed -i \
+    -e 's#DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi#DATABASE_URL=postgresql://app:chifoumi_dev@postgres:5432/chifoumi#' \
+    -e 's#REDIS_URL=redis://localhost:6379#REDIS_URL=redis://redis:6379#' \
+    -e 's#MAIL_HOST=localhost#MAIL_HOST=mailhog#' \
+    .env
+fi
+
+if [ ! -f infra/keys/jwt-private.pem ] || [ ! -f infra/keys/jwt-public.pem ]; then
+  mkdir -p infra/keys
+  openssl genrsa -out infra/keys/jwt-private.pem 2048
+  openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
+  chmod 600 infra/keys/jwt-private.pem
+  chmod 644 infra/keys/jwt-public.pem
+fi
+
+pnpm install --frozen-lockfile
+pnpm --filter @chifoumi/db generate
+pnpm dlx lefthook install
+
+printf '\nDev container ready. Run: pnpm --filter @chifoumi/db migrate:deploy && pnpm dev\n'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+> Codex-specific entrypoint. The canonical project guide is [`CLAUDE.md`](CLAUDE.md); read it before modifying this repository.
+
+## Codex Notes
+
+- Follow the stack, structure, test, security, and Git rules from [`CLAUDE.md`](CLAUDE.md).
+- Keep changes scoped to the requested ticket and preserve the PNPM + Biome toolchain.
+- For bug fixes, add or adjust the failing test before changing behavior when practical.
+- Do not duplicate long project rules here; update [`CLAUDE.md`](CLAUDE.md) when the shared agent guidance changes.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Plateforme web competitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties 
 
 - [Pre-requis](#pre-requis)
 - [Demarrage rapide](#demarrage-rapide)
+- [Devcontainer](#devcontainer)
 - [Stack multi-replicas (US-030)](#stack-multi-replicas-us-030)
 - [Demo multi-instances (US-032)](#demo-multi-instances-us-032)
 - [Tech stack](#tech-stack)
@@ -68,6 +69,24 @@ Services lances par `pnpm dev` :
 | Job runner | terminal uniquement | Workers et traitements asynchrones |
 
 Si le schema Postgres evolue, relancer une base vide avec `docker compose down -v`, puis `docker compose up -d`.
+
+## Devcontainer
+
+Le devcontainer lance un workspace Node + pnpm avec Postgres, Redis et MailHog. Le dossier local du repo doit rester nomme `Chifoumi`, car le workspace est monte dans le conteneur sous `/workspaces/Chifoumi`.
+
+Au premier demarrage, `.devcontainer/post-create.sh` :
+
+- copie `.env.example` vers `.env` avec les URLs internes Docker ;
+- genere les cles JWT de developpement dans `infra/keys/` si elles n'existent pas ;
+- configure le store pnpm persistant dans `pnpm-store` ;
+- installe les dependances et genere le client Prisma.
+
+Apres ouverture dans VS Code ou Cursor, lancer les migrations puis les apps :
+
+```bash
+pnpm --filter @chifoumi/db migrate:deploy
+pnpm dev
+```
 
 ## Stack multi-replicas (US-030)
 

--- a/apps/game-service/test/game-ws.e2e-spec.ts
+++ b/apps/game-service/test/game-ws.e2e-spec.ts
@@ -8,10 +8,11 @@ import { createGameServiceTestModule } from "../src/testing/create-game-service-
 import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-config({ path: resolve(repoRoot, ".env") });
-
 process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.MATCHMAKING_WORKER_ENABLED = "false";
+process.env.MATCH_TIMEOUT_WORKER_ENABLED = "false";
+process.env.BULLMQ_PREFIX ??= "rps-test";
+config({ path: resolve(repoRoot, ".env") });
 
 type ConnectedPayload = { userId: string; displayName: string };
 

--- a/apps/game-service/test/match-play.e2e-spec.ts
+++ b/apps/game-service/test/match-play.e2e-spec.ts
@@ -10,11 +10,11 @@ import { createGameServiceTestModule } from "../src/testing/create-game-service-
 import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-config({ path: resolve(repoRoot, ".env") });
-
 process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.MATCHMAKING_WORKER_ENABLED = "false";
+process.env.MATCH_TIMEOUT_WORKER_ENABLED = "false";
 process.env.BULLMQ_PREFIX ??= "rps-test";
+config({ path: resolve(repoRoot, ".env") });
 
 type ConnectedPayload = { userId: string; displayName: string };
 type QueueJoinedPayload = { queuedAt: string; currentRating: number };
@@ -59,6 +59,18 @@ function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
       resolvePromise(payload);
     });
   });
+}
+
+async function waitForQueueJob(queue: Queue, name: string, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const jobs = await queue.getJobs(["wait", "active", "delayed", "prioritized", "paused"]);
+    if (jobs.some((job) => job.name === name)) {
+      return true;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+  }
+  return false;
 }
 
 async function connectAndJoin(
@@ -239,9 +251,11 @@ describe("Match play BO3 (e2e)", () => {
       connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
       prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
     });
-    const jobs = await queue.getJobs(["completed", "waiting", "active"]);
-    expect(jobs.some((job) => job.name === "match-ended")).toBe(true);
-    await queue.close();
+    try {
+      await expect(waitForQueueJob(queue, "match-ended")).resolves.toBe(true);
+    } finally {
+      await queue.close();
+    }
 
     playerA.disconnect();
     playerB.disconnect();

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -14,12 +14,11 @@ import { createGameServiceTestModule } from "../src/testing/create-game-service-
 import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-config({ path: resolve(repoRoot, ".env") });
-
 process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.MATCHMAKING_WORKER_ENABLED = "false";
 process.env.MATCH_TIMEOUT_WORKER_ENABLED = "false";
 process.env.BULLMQ_PREFIX ??= "rps-test";
+config({ path: resolve(repoRoot, ".env") });
 
 type ConnectedPayload = { userId: string; displayName: string };
 type QueueJoinedPayload = { queuedAt: string; currentRating: number };
@@ -68,7 +67,7 @@ async function waitForDelayedTimeoutJob(
       (job): job is NonNullable<(typeof rawJobs)[number]> => job?.data != null,
     );
     const match = jobs.find(
-      (job) => job.data.matchId === matchId && job.data.roundNumber === roundNumber,
+      (job) => job?.data.matchId === matchId && job.data.roundNumber === roundNumber,
     );
     if (match) {
       return;
@@ -254,6 +253,53 @@ describe("Match timeout BullMQ (e2e)", () => {
   });
 
   it("applies reveal-phase forfeit when a recovery worker consumes the delayed job", async () => {
+    const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+    await matchSessionService.mutateState(matchId, (state) => ({
+      ...state,
+      status: "WAITING_REVEALS",
+      roundCommits: { a: "abc123", b: "def456" },
+      roundReveals: { a: "rock", b: null },
+      revealDeadline: new Date(Date.now() + 200).toISOString(),
+    }));
+
+    await scheduler.cancelTimeout(matchId);
+    await scheduler.scheduleTimeout(matchId, roundStart.roundNumber, "WAITING_REVEALS", 200);
+
+    recoveryWorker = new Worker(
+      MATCH_TIMEOUT_QUEUE,
+      async (job) => {
+        await matchPlayService.handleMatchTimeout(
+          job.data.matchId,
+          job.data.roundNumber,
+          job.data.expectedState,
+        );
+      },
+      {
+        connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
+        prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
+      },
+    );
+
+    try {
+      const matchEndedA = waitForEvent<MatchEndedPayload>(playerA, "matchEnded");
+      const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
+
+      const endedA = await matchEndedA;
+      const endedB = await matchEndedB;
+
+      expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
+      expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
+      expect(endedA.winner).toBe("player-a");
+    } finally {
+      await recoveryWorker.close();
+      recoveryWorker = null;
+      playerA.disconnect();
+      playerB.disconnect();
+    }
+  });
+
+  it("defaults reveal-phase forfeit to player-b when both players are silent", async () => {
     const { playerA, playerB, matchId, roundStart } = await pairPlayers();
 
     await matchSessionService.mutateState(matchId, (state) => ({

--- a/apps/game-service/test/matchmaking.e2e-spec.ts
+++ b/apps/game-service/test/matchmaking.e2e-spec.ts
@@ -10,10 +10,11 @@ import { createGameServiceTestModule } from "../src/testing/create-game-service-
 import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-config({ path: resolve(repoRoot, ".env") });
-
 process.env.REDIS_URL ??= "redis://localhost:6379";
 process.env.MATCHMAKING_WORKER_ENABLED = "false";
+process.env.MATCH_TIMEOUT_WORKER_ENABLED = "false";
+process.env.BULLMQ_PREFIX ??= "rps-test";
+config({ path: resolve(repoRoot, ".env") });
 
 type ConnectedPayload = { userId: string; displayName: string };
 type QueueJoinedPayload = { queuedAt: string; currentRating: number };

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,11 +1,12 @@
-# yaml-language-server: $schema=https://lefthook.dev/schemas/lefthook.json
+# yaml-language-server: $schema=./node_modules/lefthook/schema.json
 
 pre-commit:
   parallel: false
   commands:
     biome:
-      glob: "{apps,packages}/**/*.{js,jsx,ts,tsx,json,jsonc,css,wasm,mjs,mts,cjs,cts}"
+      glob: "{*.{js,jsx,ts,tsx,json,jsonc,css,wasm,mjs,mts,cjs,cts},{.devcontainer,.github}/**/*.{js,jsx,ts,tsx,json,jsonc,css,wasm,mjs,mts,cjs,cts},{apps,packages,tests}/**/*.{js,jsx,ts,tsx,json,jsonc,css,wasm,mjs,mts,cjs,cts}}"
       run: pnpm exec biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
       stage_fixed: true
     typecheck:
+      glob: "{*.{ts,tsx,json,jsonc},apps/**/*.{ts,tsx,json,jsonc},packages/**/*.{ts,tsx,json,jsonc},tests/**/*.{ts,tsx,json,jsonc}}"
       run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   ],
   "scripts": {
     "dev": "pnpm --parallel --filter @chifoumi/api --filter @chifoumi/game-service --filter @chifoumi/job-runner --filter @chifoumi/front dev",
-    "biome:check": "biome check apps packages .github biome.json lefthook.yml",
-    "biome:fix": "biome check --write apps packages .github biome.json lefthook.yml",
-    "typecheck": "pnpm --filter @chifoumi/db typecheck && pnpm -r typecheck",
+    "prepare": "test ! -d .git || lefthook install",
+    "biome:check": "biome check apps packages tests .github .devcontainer biome.json package.json pnpm-workspace.yaml lefthook.yml",
+    "biome:fix": "biome check --write apps packages tests .github .devcontainer biome.json package.json pnpm-workspace.yaml lefthook.yml",
+    "typecheck": "pnpm --filter @chifoumi/db typecheck && pnpm -r --if-present typecheck",
     "db:seed": "pnpm --filter @chifoumi/db seed",
     "docs:openapi": "pnpm --filter @chifoumi/api docs:openapi",
     "test:e2e:smoke": "pnpm --filter @chifoumi/e2e test:smoke",

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,5 +1,11 @@
-import "dotenv/config";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { config } from "dotenv";
 import { defineConfig, env } from "prisma/config";
+
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+
+config({ path: resolve(packageDirectory, "../../.env") });
 
 export default defineConfig({
   schema: "prisma/schema.prisma",

--- a/packages/proto/tsconfig.json
+++ b/packages/proto/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "composite": true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - "apps/*"
   - "packages/*"
   - "tests/*"
+  - "!**/dist/**"
+  - "!**/build/**"
+  - "!**/node_modules/**"
+  - "!**/coverage/**"
+  - "!**/.volumes/**"


### PR DESCRIPTION
## Ticket

Refs #40

## Why

This PR improves contributor setup and stabilizes the PR test workflow after the workspace/devcontainer changes. It also addresses the requested review fixes around devcontainer onboarding, duplicated config, and e2e isolation.

## What

- Configure PNPM/Biome/Lefthook workspace checks for the monorepo.
- Add a devcontainer with Postgres, Redis, MailHog, persistent node_modules and PNPM store.
- Generate development JWT keys during post-create when missing.
- Reuse `infra/postgres/init.sql` for devcontainer database initialization.
- Replace duplicated `AGENTS.md` content with a thin Codex overlay pointing to `CLAUDE.md`.
- Stabilize game-service e2e tests by isolating env vars, BullMQ prefixes, and timeout workers.
- Keep both partial-reveal and both-silent reveal timeout coverage.

## Verification

- [x] `pnpm --filter @chifoumi/game-service test:e2e -- test/match-timeout.e2e-spec.ts --runInBand`
- [x] `pnpm biome:check`
- [x] `DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi pnpm run typecheck`

## DoD

- [x] Code changes implemented.
- [x] Tests/checks pass locally.
- [x] No committed secrets; generated JWT keys stay ignored under `infra/keys/`.
- [x] Documentation updated for devcontainer usage and workspace folder constraint.
