### PR TITLE
feat(game-service): resume WS matches after disconnect via Redis (#39)

### DIFF
--- a/apps/game-service/src/game.gateway.ts
+++ b/apps/game-service/src/game.gateway.ts
@@ -12,7 +12,7 @@ import { WsAuthService } from "./auth/ws-auth.service.js";
 import { resolveCorsOrigins } from "./cors.js";
 import { scrubTokenFromUrl } from "./logging/scrub-token.js";
 import { MatchEventsRelayService } from "./match/match-events-relay.service.js";
-import { MatchmakingService } from "./matchmaking/matchmaking.service.js";
+import { MatchReconnectService } from "./match/match-reconnect.service.js";
 import { MatchmakingEventsService } from "./matchmaking/matchmaking-events.service.js";
 import { RedisService } from "./redis/redis.service.js";
 
@@ -40,9 +40,9 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   constructor(
     private readonly wsAuthService: WsAuthService,
     private readonly redisService: RedisService,
-    private readonly matchmakingService: MatchmakingService,
     private readonly matchmakingEventsService: MatchmakingEventsService,
     private readonly matchEventsRelayService: MatchEventsRelayService,
+    private readonly matchReconnectService: MatchReconnectService,
     private readonly logger: Logger,
   ) {}
 
@@ -78,6 +78,11 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     await this.redisService.setUserSocket(userId, client.id);
     client.emit("connected", { userId, displayName });
 
+    const resumed = await this.matchReconnectService.handleReconnect(userId);
+    if (resumed) {
+      client.emit("matchResumed", resumed);
+    }
+
     const requestUrl = client.request.url ?? "";
     this.logger.log(
       { userId, socketId: client.id, url: scrubTokenFromUrl(requestUrl) },
@@ -89,8 +94,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     const userId = client.data.userId as string | undefined;
     if (userId) {
       try {
-        await this.matchmakingService.leaveQueue(userId);
-        await this.redisService.removeUserSocket(userId, client.id);
+        await this.matchReconnectService.handleDisconnect(userId, client.id);
       } catch {
         // Redis may already be closed during app shutdown in e2e tests.
       }

--- a/apps/game-service/src/match-session/match-session.types.ts
+++ b/apps/game-service/src/match-session/match-session.types.ts
@@ -19,7 +19,13 @@ export type MatchPlayer = {
   rating: number;
 };
 
-export type MatchEndReason = "BEST_OF_3" | "FORFEIT_TIMEOUT" | "MAX_ROUNDS_DRAW";
+export type MatchEndReason =
+  | "BEST_OF_3"
+  | "FORFEIT_TIMEOUT"
+  | "DISCONNECT_FORFEIT"
+  | "MAX_ROUNDS_DRAW";
+
+export type MatchResumedCurrentState = "WAITING_PLAYS" | "WAITING_COMMITS" | "WAITING_REVEALS";
 
 export type RoundPlays = {
   a: Move | null;
@@ -94,6 +100,15 @@ export type MatchEndedPayload = {
   finalScore: { a: number; b: number };
   eloDelta: { a: number; b: number };
   reason?: MatchEndReason;
+};
+
+export type MatchResumedPayload = {
+  matchId: string;
+  currentRound: number;
+  scoreA: number;
+  scoreB: number;
+  currentState: MatchResumedCurrentState;
+  deadline: string;
 };
 
 export type MatchSessionEventPayloads = {

--- a/apps/game-service/src/match/match-disconnect-scheduler.service.spec.ts
+++ b/apps/game-service/src/match/match-disconnect-scheduler.service.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { Queue } from "bullmq";
+import Redis from "ioredis-mock";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  MATCH_DISCONNECT_FORFEIT_FAILED_JOBS_RETAINED,
+  MATCH_DISCONNECT_FORFEIT_JOB_ATTEMPTS,
+  MATCH_DISCONNECT_FORFEIT_JOB_BACKOFF_MS,
+  MATCH_DISCONNECT_FORFEIT_JOB_NAME,
+  matchDisconnectForfeitJobKey,
+} from "./match-disconnect.constants.js";
+import { MatchDisconnectSchedulerService } from "./match-disconnect-scheduler.service.js";
+
+describe("MatchDisconnectSchedulerService", () => {
+  let client: InstanceType<typeof Redis>;
+  let redisService: RedisService;
+  let service: MatchDisconnectSchedulerService;
+  let queueAdd: jest.Mock;
+  let queueGetJob: jest.Mock;
+
+  beforeEach(async () => {
+    client = new Redis(`redis://match-disconnect-test/${Date.now()}-${Math.random()}`);
+    redisService = new RedisService({ url: "redis://localhost:6379" });
+    Object.assign(redisService, { client });
+
+    queueAdd = jest.fn(async () => ({ id: "job-123", remove: jest.fn(async () => undefined) }));
+    queueGetJob = jest.fn(async () => ({ remove: jest.fn(async () => undefined) }));
+
+    service = new MatchDisconnectSchedulerService({ url: "redis://localhost:6379" }, redisService);
+    Object.assign(service, {
+      queue: {
+        add: queueAdd,
+        getJob: queueGetJob,
+        close: jest.fn(async () => undefined),
+      } as unknown as Queue,
+    });
+  });
+
+  it("schedules a delayed forfeit job with retry/backoff and retained failures", async () => {
+    const jobId = await service.scheduleForfeit("player-a", "match-1", 10_000);
+
+    expect(jobId).toBe("job-123");
+    expect(await client.get(matchDisconnectForfeitJobKey("player-a"))).toBe("job-123");
+    expect(queueAdd).toHaveBeenCalledWith(
+      MATCH_DISCONNECT_FORFEIT_JOB_NAME,
+      { userId: "player-a", matchId: "match-1" },
+      expect.objectContaining({
+        delay: 10_000,
+        attempts: MATCH_DISCONNECT_FORFEIT_JOB_ATTEMPTS,
+        backoff: {
+          type: "exponential",
+          delay: MATCH_DISCONNECT_FORFEIT_JOB_BACKOFF_MS,
+        },
+        removeOnComplete: true,
+        removeOnFail: MATCH_DISCONNECT_FORFEIT_FAILED_JOBS_RETAINED,
+      }),
+    );
+  });
+
+  it("cancels a pending forfeit job before rescheduling", async () => {
+    const remove = jest.fn<() => Promise<void>>(async () => undefined);
+    queueGetJob.mockResolvedValue({ remove } as never);
+
+    await service.scheduleForfeit("player-a", "match-1");
+    await service.scheduleForfeit("player-a", "match-1");
+
+    expect(remove).toHaveBeenCalled();
+    expect(queueAdd).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/game-service/src/match/match-disconnect-scheduler.service.ts
+++ b/apps/game-service/src/match/match-disconnect-scheduler.service.ts
@@ -3,6 +3,9 @@ import { Queue } from "bullmq";
 import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
 import { RedisService } from "../redis/redis.service.js";
 import {
+  MATCH_DISCONNECT_FORFEIT_FAILED_JOBS_RETAINED,
+  MATCH_DISCONNECT_FORFEIT_JOB_ATTEMPTS,
+  MATCH_DISCONNECT_FORFEIT_JOB_BACKOFF_MS,
   MATCH_DISCONNECT_FORFEIT_JOB_NAME,
   MATCH_DISCONNECT_FORFEIT_JOB_TTL_SECONDS,
   MATCH_DISCONNECT_FORFEIT_QUEUE,
@@ -52,8 +55,13 @@ export class MatchDisconnectSchedulerService implements OnModuleInit, OnModuleDe
       { userId, matchId },
       {
         delay: Math.max(0, delayMs),
+        attempts: MATCH_DISCONNECT_FORFEIT_JOB_ATTEMPTS,
+        backoff: {
+          type: "exponential",
+          delay: MATCH_DISCONNECT_FORFEIT_JOB_BACKOFF_MS,
+        },
         removeOnComplete: true,
-        removeOnFail: true,
+        removeOnFail: MATCH_DISCONNECT_FORFEIT_FAILED_JOBS_RETAINED,
       },
     );
 

--- a/apps/game-service/src/match/match-disconnect-scheduler.service.ts
+++ b/apps/game-service/src/match/match-disconnect-scheduler.service.ts
@@ -1,0 +1,96 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
+import { RedisService } from "../redis/redis.service.js";
+import {
+  MATCH_DISCONNECT_FORFEIT_JOB_NAME,
+  MATCH_DISCONNECT_FORFEIT_JOB_TTL_SECONDS,
+  MATCH_DISCONNECT_FORFEIT_QUEUE,
+  MATCH_DISCONNECT_FORFEIT_WINDOW_MS,
+  matchDisconnectForfeitJobKey,
+} from "./match-disconnect.constants.js";
+
+@Injectable()
+export class MatchDisconnectSchedulerService implements OnModuleInit, OnModuleDestroy {
+  private queue: Queue | null = null;
+
+  constructor(
+    @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
+    private readonly redisService: RedisService,
+  ) {}
+
+  onModuleInit(): void {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    const prefix = process.env.BULLMQ_PREFIX ?? "rps";
+    this.queue = new Queue(MATCH_DISCONNECT_FORFEIT_QUEUE, {
+      connection: { url: this.redisConfig.url },
+      prefix,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.queue?.close();
+    this.queue = null;
+  }
+
+  async scheduleForfeit(
+    userId: string,
+    matchId: string,
+    delayMs = MATCH_DISCONNECT_FORFEIT_WINDOW_MS,
+  ): Promise<string | null> {
+    await this.cancelForfeit(userId);
+
+    if (!this.queue) {
+      return null;
+    }
+
+    const job = await this.queue.add(
+      MATCH_DISCONNECT_FORFEIT_JOB_NAME,
+      { userId, matchId },
+      {
+        delay: Math.max(0, delayMs),
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+    );
+
+    if (!job.id) {
+      return null;
+    }
+
+    await this.redisService.setex(
+      matchDisconnectForfeitJobKey(userId),
+      MATCH_DISCONNECT_FORFEIT_JOB_TTL_SECONDS,
+      job.id,
+    );
+
+    return job.id;
+  }
+
+  async cancelForfeit(userId: string): Promise<void> {
+    const jobId = await this.redisService.get(matchDisconnectForfeitJobKey(userId));
+    if (!jobId) {
+      return;
+    }
+
+    if (this.queue) {
+      const job = await this.queue.getJob(jobId);
+      if (job) {
+        try {
+          await job.remove();
+        } catch {
+          // Job may already be active or completed.
+        }
+      }
+    }
+
+    await this.redisService.del(matchDisconnectForfeitJobKey(userId));
+  }
+
+  async cancelForfeitForPlayers(userIds: string[]): Promise<void> {
+    await Promise.all(userIds.map((userId) => this.cancelForfeit(userId)));
+  }
+}

--- a/apps/game-service/src/match/match-disconnect-worker.service.ts
+++ b/apps/game-service/src/match/match-disconnect-worker.service.ts
@@ -1,0 +1,61 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { type Job, Worker } from "bullmq";
+import { Logger } from "nestjs-pino";
+import { REDIS_CONFIG, type RedisConfig } from "../config/redis.config.js";
+import { MATCH_DISCONNECT_FORFEIT_QUEUE } from "./match-disconnect.constants.js";
+import type { MatchDisconnectForfeitJobPayload } from "./match-disconnect.types.js";
+import { MatchPlayService } from "./match-play.service.js";
+import { MatchReconnectMetricsService } from "./match-reconnect-metrics.service.js";
+
+@Injectable()
+export class MatchDisconnectWorkerService implements OnModuleInit, OnModuleDestroy {
+  private worker: Worker<MatchDisconnectForfeitJobPayload> | null = null;
+
+  constructor(
+    @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
+    private readonly matchPlayService: MatchPlayService,
+    private readonly matchReconnectMetrics: MatchReconnectMetricsService,
+    private readonly logger: Logger,
+  ) {}
+
+  onModuleInit(): void {
+    if (
+      process.env.SKIP_REDIS_CONNECT === "true" ||
+      process.env.MATCH_DISCONNECT_WORKER_ENABLED === "false"
+    ) {
+      return;
+    }
+
+    const prefix = process.env.BULLMQ_PREFIX ?? "rps";
+    this.worker = new Worker<MatchDisconnectForfeitJobPayload>(
+      MATCH_DISCONNECT_FORFEIT_QUEUE,
+      async (job) => this.processJob(job),
+      {
+        connection: { url: this.redisConfig.url },
+        prefix,
+      },
+    );
+
+    this.worker.on("failed", (job, error) => {
+      this.logger.warn(
+        { jobId: job?.id, userId: job?.data.userId, matchId: job?.data.matchId, error },
+        "match disconnect forfeit job failed",
+      );
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.worker?.close();
+    this.worker = null;
+  }
+
+  async processJob(job: Job<MatchDisconnectForfeitJobPayload>): Promise<void> {
+    const forfeited = await this.matchPlayService.handleDisconnectForfeit(
+      job.data.userId,
+      job.data.matchId,
+    );
+    if (forfeited) {
+      this.matchReconnectMetrics.recordForfeited();
+    }
+  }
+}

--- a/apps/game-service/src/match/match-disconnect.constants.ts
+++ b/apps/game-service/src/match/match-disconnect.constants.ts
@@ -6,6 +6,12 @@ export const MATCH_DISCONNECT_FORFEIT_WINDOW_MS = 10_000;
 
 export const MATCH_DISCONNECT_FORFEIT_JOB_TTL_SECONDS = 60;
 
+export const MATCH_DISCONNECT_FORFEIT_JOB_ATTEMPTS = 5;
+
+export const MATCH_DISCONNECT_FORFEIT_JOB_BACKOFF_MS = 200;
+
+export const MATCH_DISCONNECT_FORFEIT_FAILED_JOBS_RETAINED = 100;
+
 export function matchDisconnectForfeitJobKey(userId: string): string {
   return `match:disconnectForfeit:${userId}`;
 }

--- a/apps/game-service/src/match/match-disconnect.constants.ts
+++ b/apps/game-service/src/match/match-disconnect.constants.ts
@@ -1,0 +1,11 @@
+export const MATCH_DISCONNECT_FORFEIT_QUEUE = "match-disconnect-forfeits";
+
+export const MATCH_DISCONNECT_FORFEIT_JOB_NAME = "match-disconnect-forfeit";
+
+export const MATCH_DISCONNECT_FORFEIT_WINDOW_MS = 10_000;
+
+export const MATCH_DISCONNECT_FORFEIT_JOB_TTL_SECONDS = 60;
+
+export function matchDisconnectForfeitJobKey(userId: string): string {
+  return `match:disconnectForfeit:${userId}`;
+}

--- a/apps/game-service/src/match/match-disconnect.types.ts
+++ b/apps/game-service/src/match/match-disconnect.types.ts
@@ -1,0 +1,4 @@
+export type MatchDisconnectForfeitJobPayload = {
+  userId: string;
+  matchId: string;
+};

--- a/apps/game-service/src/match/match-play.service.spec.ts
+++ b/apps/game-service/src/match/match-play.service.spec.ts
@@ -52,6 +52,7 @@ describe("MatchPlayService", () => {
       matchEndedPublisher,
       matchTimeoutScheduler as unknown as MatchTimeoutSchedulerService,
       matchDisconnectScheduler as unknown as import("./match-disconnect-scheduler.service.js").MatchDisconnectSchedulerService,
+      redisService,
       logger,
     );
 
@@ -251,5 +252,25 @@ describe("MatchPlayService", () => {
       "WAITING_REVEALS",
       expect.any(Number),
     );
+  });
+
+  it("forfeits the match when a disconnected player does not reconnect", async () => {
+    const forfeited = await service.handleDisconnectForfeit("a", "match-1");
+
+    expect(forfeited).toBe(true);
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("ENDED");
+    expect(state?.winnerId).toBe("b");
+    expect(state?.endReason).toBe("DISCONNECT_FORFEIT");
+  });
+
+  it("skips disconnect forfeit when the player has an active socket", async () => {
+    await redisService.setUserSocket("a", "socket-a");
+
+    const forfeited = await service.handleDisconnectForfeit("a", "match-1");
+
+    expect(forfeited).toBe(false);
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("WAITING_PLAYS");
   });
 });

--- a/apps/game-service/src/match/match-play.service.spec.ts
+++ b/apps/game-service/src/match/match-play.service.spec.ts
@@ -40,6 +40,10 @@ describe("MatchPlayService", () => {
       cancelTimeout: jest.fn(async () => undefined),
     };
 
+    const matchDisconnectScheduler = {
+      cancelForfeitForPlayers: jest.fn(async () => undefined),
+    };
+
     const logger = { warn: jest.fn(), debug: jest.fn() } as unknown as Logger;
 
     service = new MatchPlayService(
@@ -47,6 +51,7 @@ describe("MatchPlayService", () => {
       eventBus,
       matchEndedPublisher,
       matchTimeoutScheduler as unknown as MatchTimeoutSchedulerService,
+      matchDisconnectScheduler as unknown as import("./match-disconnect-scheduler.service.js").MatchDisconnectSchedulerService,
       logger,
     );
 

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -16,6 +16,7 @@ import {
 } from "../match-session/match-session.types.js";
 import { transitionMatchState } from "../match-session/match-state-machine.js";
 import { isValidMove, resolveRound as resolveRps } from "../rps/resolve.js";
+import { MatchDisconnectSchedulerService } from "./match-disconnect-scheduler.service.js";
 import { MatchEndedPublisher } from "./match-ended-publisher.service.js";
 import type { MatchTimeoutExpectedState } from "./match-timeout.types.js";
 import { MatchTimeoutSchedulerService } from "./match-timeout-scheduler.service.js";
@@ -49,6 +50,7 @@ export class MatchPlayService {
     private readonly eventBus: MatchEventBus,
     private readonly matchEndedPublisher: MatchEndedPublisher,
     private readonly matchTimeoutScheduler: MatchTimeoutSchedulerService,
+    private readonly matchDisconnectScheduler: MatchDisconnectSchedulerService,
     private readonly logger: Logger,
   ) {}
 
@@ -234,6 +236,37 @@ export class MatchPlayService {
     }
   }
 
+  async handleDisconnectForfeit(userId: string, matchId: string): Promise<boolean> {
+    let forfeited = false;
+
+    const nextState = await this.matchSessionService.mutateState(matchId, (state) => {
+      if (state.status === "ENDED") {
+        return state;
+      }
+
+      const index = playerIndex(state, userId);
+      if (index === null) {
+        return state;
+      }
+
+      const winnerIndex = index === 0 ? 1 : 0;
+      forfeited = true;
+      return {
+        ...state,
+        status: "ENDED",
+        winnerId: state.players[winnerIndex].userId,
+        endReason: "DISCONNECT_FORFEIT",
+      };
+    });
+
+    if (!forfeited || nextState.status !== "ENDED") {
+      return false;
+    }
+
+    await this.finalizeMatch(nextState);
+    return true;
+  }
+
   private async applyPhaseTimeout(
     matchId: string,
     roundNumber: number,
@@ -354,6 +387,9 @@ export class MatchPlayService {
 
   private async finalizeMatch(state: MatchState): Promise<void> {
     await this.clearTimer(state.matchId);
+    await this.matchDisconnectScheduler.cancelForfeitForPlayers(
+      state.players.map((player) => player.userId),
+    );
 
     const payload = {
       matchId: state.matchId,

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -15,6 +15,7 @@ import {
   type RoundResolvedPayload,
 } from "../match-session/match-session.types.js";
 import { transitionMatchState } from "../match-session/match-state-machine.js";
+import { RedisService } from "../redis/redis.service.js";
 import { isValidMove, resolveRound as resolveRps } from "../rps/resolve.js";
 import { MatchDisconnectSchedulerService } from "./match-disconnect-scheduler.service.js";
 import { MatchEndedPublisher } from "./match-ended-publisher.service.js";
@@ -51,6 +52,7 @@ export class MatchPlayService {
     private readonly matchEndedPublisher: MatchEndedPublisher,
     private readonly matchTimeoutScheduler: MatchTimeoutSchedulerService,
     private readonly matchDisconnectScheduler: MatchDisconnectSchedulerService,
+    private readonly redisService: RedisService,
     private readonly logger: Logger,
   ) {}
 
@@ -237,6 +239,11 @@ export class MatchPlayService {
   }
 
   async handleDisconnectForfeit(userId: string, matchId: string): Promise<boolean> {
+    const activeSocket = await this.redisService.getUserSocket(userId);
+    if (activeSocket) {
+      return false;
+    }
+
     let forfeited = false;
 
     const nextState = await this.matchSessionService.mutateState(matchId, (state) => {

--- a/apps/game-service/src/match/match-reconnect-metrics.service.ts
+++ b/apps/game-service/src/match/match-reconnect-metrics.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@nestjs/common";
+import { Counter, Registry } from "prom-client";
+
+export type MatchReconnectOutcome = "resumed" | "forfeited";
+
+@Injectable()
+export class MatchReconnectMetricsService {
+  readonly registry = new Registry();
+  readonly reconnectTotal: Counter<string>;
+
+  constructor() {
+    this.reconnectTotal = new Counter({
+      name: "match_reconnect_total",
+      help: "Match reconnect attempts by outcome",
+      labelNames: ["outcome"],
+      registers: [this.registry],
+    });
+  }
+
+  recordResumed(): void {
+    this.reconnectTotal.inc({ outcome: "resumed" });
+  }
+
+  recordForfeited(): void {
+    this.reconnectTotal.inc({ outcome: "forfeited" });
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/apps/game-service/src/match/match-reconnect.service.spec.ts
+++ b/apps/game-service/src/match/match-reconnect.service.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import Redis from "ioredis-mock";
+import { MatchSessionService } from "../match-session/match-session.service.js";
+import { MatchmakingService } from "../matchmaking/matchmaking.service.js";
+import { RedisService } from "../redis/redis.service.js";
+import { MatchDisconnectSchedulerService } from "./match-disconnect-scheduler.service.js";
+import { MatchReconnectService } from "./match-reconnect.service.js";
+import { MatchReconnectMetricsService } from "./match-reconnect-metrics.service.js";
+
+describe("MatchReconnectService", () => {
+  let client: InstanceType<typeof Redis>;
+  let redisService: RedisService;
+  let matchSessionService: MatchSessionService;
+  let matchmakingService: MatchmakingService;
+  let disconnectScheduler: {
+    scheduleForfeit: jest.Mock;
+    cancelForfeit: jest.Mock;
+  };
+  let metrics: MatchReconnectMetricsService;
+  let service: MatchReconnectService;
+
+  beforeEach(async () => {
+    client = new Redis(`redis://match-reconnect-test/${Date.now()}-${Math.random()}`);
+    redisService = new RedisService({ url: "redis://localhost:6379" });
+    Object.assign(redisService, { client });
+
+    matchSessionService = new MatchSessionService(redisService, {
+      broadcastToMatch: jest.fn(async () => undefined),
+    } as never);
+
+    matchmakingService = new MatchmakingService(redisService, {
+      getRating: jest.fn(async () => 1000),
+    } as never);
+
+    disconnectScheduler = {
+      scheduleForfeit: jest.fn(async () => "job-1"),
+      cancelForfeit: jest.fn(async () => undefined),
+    };
+
+    metrics = new MatchReconnectMetricsService();
+    service = new MatchReconnectService(
+      matchmakingService,
+      matchSessionService,
+      disconnectScheduler as unknown as MatchDisconnectSchedulerService,
+      metrics,
+      redisService,
+    );
+
+    await matchSessionService.create({
+      matchId: "match-1",
+      players: [
+        { userId: "player-a", displayName: "Ace", rating: 1000 },
+        { userId: "player-b", displayName: "Bob", rating: 1020 },
+      ],
+      now: new Date("2026-06-09T10:00:00.000Z"),
+    });
+  });
+
+  it("schedules a disconnect forfeit instead of leaving the queue when in match", async () => {
+    await redisService.setUserSocket("player-a", "socket-a");
+
+    await service.handleDisconnect("player-a", "socket-a");
+
+    expect(disconnectScheduler.scheduleForfeit).toHaveBeenCalledWith("player-a", "match-1");
+    expect(await redisService.getUserSocket("player-a")).toBeNull();
+    expect(await matchmakingService.isInMatch("player-a")).toBe(true);
+  });
+
+  it("removes the player from the queue on disconnect when not in match", async () => {
+    await matchmakingService.joinQueue("queue-user", "Queue");
+    await redisService.setUserSocket("queue-user", "socket-q");
+
+    await service.handleDisconnect("queue-user", "socket-q");
+
+    expect(disconnectScheduler.scheduleForfeit).not.toHaveBeenCalled();
+    expect(await matchmakingService.isInQueue("queue-user")).toBe(false);
+    expect(await redisService.getUserSocket("queue-user")).toBeNull();
+  });
+
+  it("emits matchResumed payload and cancels pending forfeit on reconnect", async () => {
+    const resumed = await service.handleReconnect("player-a");
+
+    expect(resumed).toEqual({
+      matchId: "match-1",
+      currentRound: 1,
+      scoreA: 0,
+      scoreB: 0,
+      currentState: "WAITING_PLAYS",
+      deadline: "2026-06-09T10:00:05.000Z",
+    });
+    expect(disconnectScheduler.cancelForfeit).toHaveBeenCalledWith("player-a");
+  });
+
+  it("returns null when the player has no active match", async () => {
+    await expect(service.handleReconnect("unknown-user")).resolves.toBeNull();
+  });
+});

--- a/apps/game-service/src/match/match-reconnect.service.spec.ts
+++ b/apps/game-service/src/match/match-reconnect.service.spec.ts
@@ -66,6 +66,16 @@ describe("MatchReconnectService", () => {
     expect(await matchmakingService.isInMatch("player-a")).toBe(true);
   });
 
+  it("does not schedule forfeit when a stale socket disconnects after reconnect", async () => {
+    await redisService.setUserSocket("player-a", "socket-a");
+    await redisService.setUserSocket("player-a", "socket-b");
+
+    await service.handleDisconnect("player-a", "socket-a");
+
+    expect(disconnectScheduler.scheduleForfeit).not.toHaveBeenCalled();
+    expect(await redisService.getUserSocket("player-a")).toBe("socket-b");
+  });
+
   it("removes the player from the queue on disconnect when not in match", async () => {
     await matchmakingService.joinQueue("queue-user", "Queue");
     await redisService.setUserSocket("queue-user", "socket-q");

--- a/apps/game-service/src/match/match-reconnect.service.ts
+++ b/apps/game-service/src/match/match-reconnect.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from "@nestjs/common";
+import { MatchSessionService } from "../match-session/match-session.service.js";
+import {
+  type MatchResumedCurrentState,
+  type MatchResumedPayload,
+  type MatchState,
+} from "../match-session/match-session.types.js";
+import { MatchmakingService } from "../matchmaking/matchmaking.service.js";
+import { RedisService } from "../redis/redis.service.js";
+import { MatchDisconnectSchedulerService } from "./match-disconnect-scheduler.service.js";
+import { MatchReconnectMetricsService } from "./match-reconnect-metrics.service.js";
+
+@Injectable()
+export class MatchReconnectService {
+  constructor(
+    private readonly matchmakingService: MatchmakingService,
+    private readonly matchSessionService: MatchSessionService,
+    private readonly matchDisconnectScheduler: MatchDisconnectSchedulerService,
+    private readonly matchReconnectMetrics: MatchReconnectMetricsService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async handleDisconnect(userId: string, socketId: string): Promise<void> {
+    if (await this.matchmakingService.isInMatch(userId)) {
+      const matchId = await this.matchmakingService.getMatchIdForUser(userId);
+      if (matchId) {
+        await this.redisService.removeUserSocket(userId, socketId);
+        await this.matchDisconnectScheduler.scheduleForfeit(userId, matchId);
+      }
+      return;
+    }
+
+    await this.matchmakingService.leaveQueue(userId);
+    await this.redisService.removeUserSocket(userId, socketId);
+  }
+
+  async handleReconnect(userId: string): Promise<MatchResumedPayload | null> {
+    const matchId = await this.matchmakingService.getMatchIdForUser(userId);
+    if (!matchId) {
+      return null;
+    }
+
+    const state = await this.matchSessionService.loadState(matchId);
+    if (!state || state.status === "ENDED") {
+      return null;
+    }
+
+    const resumed = buildMatchResumedPayload(state);
+    if (!resumed) {
+      return null;
+    }
+
+    await this.matchDisconnectScheduler.cancelForfeit(userId);
+    this.matchReconnectMetrics.recordResumed();
+    return resumed;
+  }
+}
+
+function buildMatchResumedPayload(state: MatchState): MatchResumedPayload | null {
+  const currentState = toResumedCurrentState(state);
+  if (!currentState) {
+    return null;
+  }
+
+  const deadline =
+    currentState === "WAITING_REVEALS" && state.revealDeadline
+      ? state.revealDeadline
+      : state.roundDeadline;
+
+  return {
+    matchId: state.matchId,
+    currentRound: state.currentRound,
+    scoreA: state.scoreA,
+    scoreB: state.scoreB,
+    currentState,
+    deadline,
+  };
+}
+
+function toResumedCurrentState(state: MatchState): MatchResumedCurrentState | null {
+  if (state.status === "WAITING_PLAYS") {
+    return "WAITING_PLAYS";
+  }
+  if (state.status === "WAITING_COMMITS") {
+    return "WAITING_COMMITS";
+  }
+  if (state.status === "WAITING_REVEALS") {
+    return "WAITING_REVEALS";
+  }
+  if (state.status === "RESOLVING") {
+    return "WAITING_PLAYS";
+  }
+  return null;
+}

--- a/apps/game-service/src/match/match-reconnect.service.ts
+++ b/apps/game-service/src/match/match-reconnect.service.ts
@@ -24,8 +24,10 @@ export class MatchReconnectService {
     if (await this.matchmakingService.isInMatch(userId)) {
       const matchId = await this.matchmakingService.getMatchIdForUser(userId);
       if (matchId) {
-        await this.redisService.removeUserSocket(userId, socketId);
-        await this.matchDisconnectScheduler.scheduleForfeit(userId, matchId);
+        const removedActiveSocket = await this.redisService.removeUserSocket(userId, socketId);
+        if (removedActiveSocket) {
+          await this.matchDisconnectScheduler.scheduleForfeit(userId, matchId);
+        }
       }
       return;
     }

--- a/apps/game-service/src/match/match.module.ts
+++ b/apps/game-service/src/match/match.module.ts
@@ -1,21 +1,37 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { MatchSessionModule } from "../match-session/match-session.module.js";
+import { MatchmakingModule } from "../matchmaking/matchmaking.module.js";
 import { RedisModule } from "../redis/redis.module.js";
+import { MatchDisconnectSchedulerService } from "./match-disconnect-scheduler.service.js";
+import { MatchDisconnectWorkerService } from "./match-disconnect-worker.service.js";
 import { MatchEndedPublisher } from "./match-ended-publisher.service.js";
 import { MatchEventsRelayService } from "./match-events-relay.service.js";
 import { MatchPlayService } from "./match-play.service.js";
+import { MatchReconnectService } from "./match-reconnect.service.js";
+import { MatchReconnectMetricsService } from "./match-reconnect-metrics.service.js";
 import { MatchTimeoutSchedulerService } from "./match-timeout-scheduler.service.js";
 import { MatchTimeoutWorkerService } from "./match-timeout-worker.service.js";
 
 @Module({
-  imports: [RedisModule, MatchSessionModule],
+  imports: [RedisModule, MatchSessionModule, forwardRef(() => MatchmakingModule)],
   providers: [
     MatchPlayService,
     MatchEventsRelayService,
     MatchEndedPublisher,
     MatchTimeoutSchedulerService,
     MatchTimeoutWorkerService,
+    MatchDisconnectSchedulerService,
+    MatchDisconnectWorkerService,
+    MatchReconnectService,
+    MatchReconnectMetricsService,
   ],
-  exports: [MatchPlayService, MatchEventsRelayService, MatchTimeoutSchedulerService],
+  exports: [
+    MatchPlayService,
+    MatchEventsRelayService,
+    MatchTimeoutSchedulerService,
+    MatchDisconnectSchedulerService,
+    MatchReconnectService,
+    MatchReconnectMetricsService,
+  ],
 })
 export class MatchModule {}

--- a/apps/game-service/src/matchmaking/matchmaking.module.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { MatchModule } from "../match/match.module.js";
 import { MatchSessionModule } from "../match-session/match-session.module.js";
 import { MetricsController } from "../metrics/metrics.controller.js";
@@ -11,7 +11,7 @@ import { MatchmakingWorkerService } from "./matchmaking-worker.service.js";
 import { RatingService } from "./rating.service.js";
 
 @Module({
-  imports: [RedisModule, MatchSessionModule, MatchModule],
+  imports: [RedisModule, MatchSessionModule, forwardRef(() => MatchModule)],
   controllers: [MetricsController],
   providers: [
     RatingService,

--- a/apps/game-service/src/metrics/metrics.controller.ts
+++ b/apps/game-service/src/metrics/metrics.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Header } from "@nestjs/common";
 import { GrpcMetricsService } from "../grpc/grpc-metrics.service.js";
+import { MatchReconnectMetricsService } from "../match/match-reconnect-metrics.service.js";
 import { MatchmakingMetricsService } from "../matchmaking/matchmaking-metrics.service.js";
 
 @Controller("metrics")
@@ -7,15 +8,17 @@ export class MetricsController {
   constructor(
     private readonly matchmakingMetricsService: MatchmakingMetricsService,
     private readonly grpcMetricsService: GrpcMetricsService,
+    private readonly matchReconnectMetricsService: MatchReconnectMetricsService,
   ) {}
 
   @Get()
   @Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
   async getMetrics(): Promise<string> {
-    const [matchmakingMetrics, grpcMetrics] = await Promise.all([
+    const [matchmakingMetrics, grpcMetrics, reconnectMetrics] = await Promise.all([
       this.matchmakingMetricsService.getMetrics(),
       this.grpcMetricsService.getMetrics(),
+      this.matchReconnectMetricsService.getMetrics(),
     ]);
-    return `${matchmakingMetrics}\n${grpcMetrics}`;
+    return `${matchmakingMetrics}\n${grpcMetrics}\n${reconnectMetrics}`;
   }
 }

--- a/apps/game-service/src/redis/redis.service.spec.ts
+++ b/apps/game-service/src/redis/redis.service.spec.ts
@@ -21,7 +21,7 @@ describe("RedisService", () => {
   it("removes a user socket only when the stored socket id matches", async () => {
     await service.setUserSocket("user-1", "socket-a");
 
-    await service.removeUserSocket("user-1", "socket-a");
+    expect(await service.removeUserSocket("user-1", "socket-a")).toBe(true);
 
     expect(await service.getUserSocket("user-1")).toBeNull();
   });
@@ -30,7 +30,7 @@ describe("RedisService", () => {
     await service.setUserSocket("user-1", "socket-a");
     await service.setUserSocket("user-1", "socket-b");
 
-    await service.removeUserSocket("user-1", "socket-a");
+    expect(await service.removeUserSocket("user-1", "socket-a")).toBe(false);
 
     expect(await service.getUserSocket("user-1")).toBe("socket-b");
   });

--- a/apps/game-service/src/redis/redis.service.ts
+++ b/apps/game-service/src/redis/redis.service.ts
@@ -165,9 +165,15 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     );
   }
 
-  async removeUserSocket(userId: string, socketId: string): Promise<void> {
+  async removeUserSocket(userId: string, socketId: string): Promise<boolean> {
     const key = `ws:user:${userId}:socket`;
-    await this.requireClient().eval(REMOVE_USER_SOCKET_IF_MATCH_SCRIPT, 1, key, socketId);
+    const removed = await this.requireClient().eval(
+      REMOVE_USER_SOCKET_IF_MATCH_SCRIPT,
+      1,
+      key,
+      socketId,
+    );
+    return removed === 1;
   }
 
   async getUserSocket(userId: string): Promise<string | null> {

--- a/apps/game-service/test/match-reconnect.e2e-spec.ts
+++ b/apps/game-service/test/match-reconnect.e2e-spec.ts
@@ -1,0 +1,276 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { INestApplication } from "@nestjs/common";
+import { Worker } from "bullmq";
+import { config } from "dotenv";
+import { io, type Socket } from "socket.io-client";
+import {
+  MATCH_DISCONNECT_FORFEIT_QUEUE,
+  matchDisconnectForfeitJobKey,
+} from "../src/match/match-disconnect.constants.js";
+import { MatchDisconnectSchedulerService } from "../src/match/match-disconnect-scheduler.service.js";
+import { MatchPlayService } from "../src/match/match-play.service.js";
+import { MatchmakingWorkerService } from "../src/matchmaking/matchmaking-worker.service.js";
+import { RedisService } from "../src/redis/redis.service.js";
+import { createGameServiceTestModule } from "../src/testing/create-game-service-test-module.js";
+import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+config({ path: resolve(repoRoot, ".env") });
+
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.MATCHMAKING_WORKER_ENABLED = "false";
+process.env.MATCH_DISCONNECT_WORKER_ENABLED = "false";
+process.env.BULLMQ_PREFIX ??= "rps-test";
+
+type ConnectedPayload = { userId: string; displayName: string };
+type QueueJoinedPayload = { queuedAt: string; currentRating: number };
+type MatchFoundPayload = {
+  matchId: string;
+  opponent: { userId: string; displayName: string; rating: number };
+  bestOf: number;
+};
+type RoundStartPayload = { matchId: string; roundNumber: number; deadline: string };
+type MatchResumedPayload = {
+  matchId: string;
+  currentRound: number;
+  scoreA: number;
+  scoreB: number;
+  currentState: string;
+  deadline: string;
+};
+type MatchEndedPayload = {
+  matchId: string;
+  winner: string | null;
+  finalScore: { a: number; b: number };
+  eloDelta: { a: number; b: number };
+  reason?: string;
+};
+
+function connectClient(port: number, token: string): Socket {
+  return io(`http://127.0.0.1:${port}/game`, {
+    transports: ["websocket"],
+    forceNew: true,
+    reconnection: false,
+    query: { token },
+  });
+}
+
+function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${event} timeout`)), 10_000);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timeout);
+      resolvePromise(payload);
+    });
+  });
+}
+
+async function connectAndJoin(
+  port: number,
+  input: { userId: string; displayName: string },
+): Promise<{ socket: Socket; queueJoined: QueueJoinedPayload }> {
+  const token = await issueTestAccessToken({
+    userId: input.userId,
+    displayName: input.displayName,
+  });
+  const socket = connectClient(port, token);
+  const connectedPromise = waitForEvent<ConnectedPayload>(socket, "connected");
+
+  await new Promise<void>((resolvePromise, reject) => {
+    socket.once("connect", () => resolvePromise());
+    socket.once("connect_error", reject);
+  });
+
+  await connectedPromise;
+  socket.emit("joinQueue", {});
+  const queueJoined = await waitForEvent<QueueJoinedPayload>(socket, "queueJoined");
+
+  return { socket, queueJoined };
+}
+
+describe("Match reconnect WS (e2e)", () => {
+  let app: INestApplication;
+  let port: number;
+  let redisService: RedisService;
+  let worker: MatchmakingWorkerService;
+  let disconnectScheduler: MatchDisconnectSchedulerService;
+  let matchPlayService: MatchPlayService;
+  let recoveryWorker: Worker | null = null;
+
+  beforeAll(async () => {
+    const moduleRef = await createGameServiceTestModule().compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0, "127.0.0.1");
+    port = app.getHttpServer().address().port as number;
+    redisService = app.get(RedisService);
+    worker = app.get(MatchmakingWorkerService);
+    disconnectScheduler = app.get(MatchDisconnectSchedulerService);
+    matchPlayService = app.get(MatchPlayService);
+  });
+
+  afterAll(async () => {
+    if (recoveryWorker) {
+      await recoveryWorker.close();
+      recoveryWorker = null;
+    }
+    if (app) {
+      await app.close();
+    }
+  });
+
+  beforeEach(async () => {
+    const client = redisService.getClient();
+    const keys = await client.keys("*");
+    if (keys.length > 0) {
+      await client.del(...keys);
+    }
+  });
+
+  async function pairPlayers(): Promise<{
+    playerA: Socket;
+    playerB: Socket;
+    matchId: string;
+    roundStart: RoundStartPayload;
+  }> {
+    await redisService.setex("user:rating:player-a", 60, "1000");
+    await redisService.setex("user:rating:player-b", 60, "1040");
+
+    const joinedA = await connectAndJoin(port, { userId: "player-a", displayName: "Ace" });
+    const joinedB = await connectAndJoin(port, { userId: "player-b", displayName: "Bob" });
+
+    const matchFoundA = waitForEvent<MatchFoundPayload>(joinedA.socket, "matchFound");
+    const matchFoundB = waitForEvent<MatchFoundPayload>(joinedB.socket, "matchFound");
+    const roundStartA = waitForEvent<RoundStartPayload>(joinedA.socket, "roundStart");
+    const roundStartB = waitForEvent<RoundStartPayload>(joinedB.socket, "roundStart");
+
+    await worker.tick();
+
+    const payloadA = await matchFoundA;
+    await matchFoundB;
+    const roundStart = await roundStartA;
+    await roundStartB;
+
+    return {
+      playerA: joinedA.socket,
+      playerB: joinedB.socket,
+      matchId: payloadA.matchId,
+      roundStart,
+    };
+  }
+
+  it("resumes an active match when the player reconnects on the same instance", async () => {
+    const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+    playerA.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(await redisService.get(matchDisconnectForfeitJobKey("player-a"))).toBeTruthy();
+
+    const token = await issueTestAccessToken({ userId: "player-a", displayName: "Ace" });
+    const reconnected = connectClient(port, token);
+    const connected = waitForEvent<ConnectedPayload>(reconnected, "connected");
+    const resumed = waitForEvent<MatchResumedPayload>(reconnected, "matchResumed");
+
+    await new Promise<void>((resolvePromise, reject) => {
+      reconnected.once("connect", () => resolvePromise());
+      reconnected.once("connect_error", reject);
+    });
+
+    await connected;
+    const payload = await resumed;
+
+    expect(payload).toEqual({
+      matchId,
+      currentRound: roundStart.roundNumber,
+      scoreA: 0,
+      scoreB: 0,
+      currentState: "WAITING_PLAYS",
+      deadline: roundStart.deadline,
+    });
+    expect(await redisService.get(matchDisconnectForfeitJobKey("player-a"))).toBeNull();
+
+    reconnected.disconnect();
+    playerB.disconnect();
+  });
+
+  it("resumes an active match when the player reconnects on another instance", async () => {
+    const moduleRef = await createGameServiceTestModule().compile();
+    const secondApp = moduleRef.createNestApplication();
+    await secondApp.init();
+    await secondApp.listen(0, "127.0.0.1");
+    const secondPort = secondApp.getHttpServer().address().port as number;
+
+    try {
+      const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+      playerA.disconnect();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const token = await issueTestAccessToken({ userId: "player-a", displayName: "Ace" });
+      const reconnected = connectClient(secondPort, token);
+      const connected = waitForEvent<ConnectedPayload>(reconnected, "connected");
+      const resumed = waitForEvent<MatchResumedPayload>(reconnected, "matchResumed");
+
+      await new Promise<void>((resolvePromise, reject) => {
+        reconnected.once("connect", () => resolvePromise());
+        reconnected.once("connect_error", reject);
+      });
+
+      await connected;
+      const payload = await resumed;
+
+      expect(payload.matchId).toBe(matchId);
+      expect(payload.currentState).toBe("WAITING_PLAYS");
+      expect(payload.deadline).toBe(roundStart.deadline);
+
+      reconnected.disconnect();
+      playerB.disconnect();
+    } finally {
+      await secondApp.close();
+    }
+  });
+
+  it("forfeits the disconnected player after the reconnect window expires", async () => {
+    const { playerA, playerB, matchId } = await pairPlayers();
+
+    playerA.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await disconnectScheduler.cancelForfeit("player-a");
+    await disconnectScheduler.scheduleForfeit("player-a", matchId, 200);
+
+    recoveryWorker = new Worker(
+      MATCH_DISCONNECT_FORFEIT_QUEUE,
+      async (job) => {
+        await matchPlayService.handleDisconnectForfeit(job.data.userId, job.data.matchId);
+      },
+      {
+        connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
+        prefix: process.env.BULLMQ_PREFIX ?? "rps-test",
+      },
+    );
+
+    try {
+      const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
+      const ended = await matchEndedB;
+
+      expect(ended.reason).toBe("DISCONNECT_FORFEIT");
+      expect(ended.winner).toBe("player-b");
+    } finally {
+      await recoveryWorker.close();
+      recoveryWorker = null;
+      playerB.disconnect();
+    }
+  });
+
+  it("exposes match reconnect prometheus metrics", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/metrics`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("match_reconnect_total");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements US-038: players disconnected mid-match can reconnect within 10s and receive `matchResumed` with current round, scores, phase, and deadline.
- Schedules a BullMQ `match-disconnect-forfeit` job on WS disconnect; cancels it on successful reconnect; forfeits with `DISCONNECT_FORFEIT` when the window expires.
- Adds Prometheus metric `match_reconnect_total{outcome="resumed"|"forfeited"}` and E2E coverage for same-instance reconnect, cross-instance reconnect, and forfeit.

Closes #39

## Acceptance criteria

- [x] AC1: reconnect within 10s emits `matchResumed` with match state
- [x] AC2: disconnect > 10s triggers `matchEnded` with `DISCONNECT_FORFEIT`
- [x] AC3: reconnect on another Game Service instance via Redis state
- [x] AC4: queue players still removed immediately on disconnect
- [x] AC5: `match_reconnect_total` Prometheus metric

## Test plan

- [x] `pnpm biome check` (game-service)
- [x] `pnpm --filter @chifoumi/game-service typecheck`
- [x] Unit specs with coverage (71 passed)
- [ ] `pnpm --filter @chifoumi/game-service test:e2e` (requires Redis — verified in CI)
