### PR TITLE
feat(front): add leaderboard and profile pages (#43)

### DIFF
--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -17,7 +17,9 @@
     "vite": "^8.0.13"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.101.0",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "react-router-dom": "^7.18.0"
   }
 }

--- a/apps/front/src/App.css
+++ b/apps/front/src/App.css
@@ -1,12 +1,73 @@
-.app {
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 24px;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
   background: #f7f8fa;
   color: #15171a;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: #1f5fbf;
+}
+
+.layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px solid #d9dee7;
+  background: #ffffff;
+}
+
+.brand {
+  font-weight: 700;
+  text-decoration: none;
+  color: #15171a;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  text-decoration: none;
+  color: #5d6675;
+  padding: 6px 10px;
+  border-radius: 6px;
+}
+
+.nav-link.active {
+  background: #eef3fb;
+  color: #1f5fbf;
+  font-weight: 600;
+}
+
+.nav-user {
+  color: #5d6675;
+  font-size: 14px;
+}
+
+.page {
+  flex: 1;
+  display: grid;
+  place-items: start center;
+  padding: 24px;
 }
 
 .panel {
@@ -16,6 +77,10 @@
   background: #ffffff;
   padding: 24px;
   box-shadow: 0 16px 40px rgb(21 23 26 / 8%);
+}
+
+.panel-wide {
+  width: min(100%, 920px);
 }
 
 .title {
@@ -29,25 +94,272 @@
   color: #5d6675;
 }
 
-.health {
-  display: grid;
-  gap: 8px;
-  padding: 16px;
-  border-radius: 8px;
-  background: #eef8f1;
-  border: 1px solid #bfe8cc;
+.muted {
+  color: #5d6675;
 }
 
-.health.error {
+.page-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.page-heading .title,
+.page-heading .subtitle {
+  margin: 0;
+}
+
+.badge {
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #eef3fb;
+  color: #1f5fbf;
+}
+
+.form {
+  display: grid;
+  gap: 16px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.field input {
+  padding: 10px 12px;
+  border: 1px solid #d9dee7;
+  border-radius: 6px;
+  font: inherit;
+}
+
+.form-error {
+  margin: 0;
+  color: #b42318;
+  font-size: 14px;
+}
+
+.button {
+  border: none;
+  border-radius: 6px;
+  padding: 10px 14px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  background: #1f5fbf;
+  color: #ffffff;
+}
+
+.button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.button-secondary {
+  background: #eef3fb;
+  color: #1f5fbf;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: 12px;
+  border-bottom: 1px solid #e7ebf2;
+  text-align: left;
+}
+
+.data-table th {
+  font-size: 14px;
+  color: #5d6675;
+}
+
+.table-link {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.profile-header {
+  margin-bottom: 24px;
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  margin: 0;
+}
+
+.profile-stats dt {
+  color: #5d6675;
+}
+
+.profile-stats dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.tab {
+  border: 1px solid #d9dee7;
+  background: #ffffff;
+  border-radius: 999px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.tab-active {
+  background: #1f5fbf;
+  border-color: #1f5fbf;
+  color: #ffffff;
+}
+
+.section-title {
+  margin: 0 0 16px;
+  font-size: 20px;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.history-item {
+  border: 1px solid #e7ebf2;
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.history-item-main,
+.history-item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  justify-content: space-between;
+}
+
+.history-item-meta {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #5d6675;
+}
+
+.history-opponent {
+  font-weight: 600;
+}
+
+.result-win {
+  color: #067647;
+  font-weight: 600;
+}
+
+.result-loss {
+  color: #b42318;
+  font-weight: 600;
+}
+
+.delta-positive {
+  color: #067647;
+}
+
+.delta-negative {
+  color: #b42318;
+}
+
+.load-more {
+  margin-top: 16px;
+}
+
+.state {
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid #e7ebf2;
+}
+
+.state-error {
   background: #fff3f0;
   border-color: #ffc7bd;
 }
 
-.label {
+.state-empty {
+  background: #f7f8fa;
   color: #5d6675;
-  font-size: 14px;
 }
 
-.value {
-  font-weight: 700;
+.skeleton-table,
+.skeleton-list {
+  display: grid;
+  gap: 10px;
+}
+
+.skeleton-row,
+.skeleton-card,
+.skeleton-line {
+  border-radius: 6px;
+  background: linear-gradient(90deg, #eef1f6 25%, #f8f9fb 50%, #eef1f6 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
+.skeleton-row {
+  height: 42px;
+}
+
+.skeleton-card {
+  height: 72px;
+}
+
+.skeleton-profile {
+  display: grid;
+  gap: 12px;
+}
+
+.skeleton-line {
+  height: 18px;
+}
+
+.skeleton-line-lg {
+  height: 32px;
+  width: 60%;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .page {
+    padding: 16px;
+  }
 }

--- a/apps/front/src/App.tsx
+++ b/apps/front/src/App.tsx
@@ -1,87 +1,35 @@
-import { useEffect, useState } from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+import { Header } from "./components/Header.js";
+import { GuestRoute, ProtectedRoute } from "./components/ProtectedRoute.js";
+import { LeaderboardPage } from "./pages/LeaderboardPage.js";
+import { LobbyPage } from "./pages/LobbyPage.js";
+import { LoginPage } from "./pages/LoginPage.js";
+import { ProfilePage } from "./pages/ProfilePage.js";
+import { RegisterPage } from "./pages/RegisterPage.js";
 import "./App.css";
 
-type HealthResponse = {
-  status: string;
-  service: string;
-  version: string;
-};
-
-type HealthState =
-  | { state: "loading" }
-  | { state: "ready"; data: HealthResponse }
-  | { state: "error"; message: string };
-
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
-
 export function App() {
-  const [health, setHealth] = useState<HealthState>({ state: "loading" });
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    async function fetchHealth() {
-      try {
-        const response = await fetch(`${apiBaseUrl}/health`, {
-          signal: controller.signal,
-        });
-
-        if (!response.ok) {
-          throw new Error(`API returned ${response.status}`);
-        }
-
-        const data = (await response.json()) as HealthResponse;
-        setHealth({ state: "ready", data });
-      } catch (error) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          return;
-        }
-
-        setHealth({
-          state: "error",
-          message: error instanceof Error ? error.message : "API unavailable",
-        });
-      }
-    }
-
-    void fetchHealth();
-
-    return () => {
-      controller.abort();
-    };
-  }, []);
-
   return (
-    <main className="app">
-      <section className="panel" aria-labelledby="app-title">
-        <h1 className="title" id="app-title">
-          Chifoumi Ranked
-        </h1>
-        <p className="subtitle">Sprint 0 application shell</p>
+    <div className="layout">
+      <Header />
+      <Routes>
+        <Route path="/" element={<Navigate to="/lobby" replace />} />
 
-        {health.state === "loading" ? (
-          <div className="health">
-            <span className="label">API health</span>
-            <span className="value">Loading</span>
-          </div>
-        ) : null}
+        <Route element={<GuestRoute />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+        </Route>
 
-        {health.state === "ready" ? (
-          <div className="health">
-            <span className="label">API health</span>
-            <span className="value">
-              {health.data.service} {health.data.version}: {health.data.status}
-            </span>
-          </div>
-        ) : null}
+        <Route path="/leaderboard" element={<LeaderboardPage />} />
 
-        {health.state === "error" ? (
-          <div className="health error">
-            <span className="label">API health</span>
-            <span className="value">{health.message}</span>
-          </div>
-        ) : null}
-      </section>
-    </main>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/lobby" element={<LobbyPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/profile/:id" element={<ProfilePage />} />
+        </Route>
+
+        <Route path="*" element={<Navigate to="/lobby" replace />} />
+      </Routes>
+    </div>
   );
 }

--- a/apps/front/src/api/apiClient.ts
+++ b/apps/front/src/api/apiClient.ts
@@ -1,0 +1,109 @@
+import type { RefreshResponse } from "./types.js";
+
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+
+type TokenProvider = () => string | null;
+type RefreshHandler = () => Promise<string | null>;
+type AuthFailureHandler = () => void;
+
+let getAccessToken: TokenProvider = () => null;
+let refreshAccessToken: RefreshHandler = async () => null;
+let onAuthFailure: AuthFailureHandler = () => undefined;
+
+export function configureApiClient(config: {
+  getAccessToken: TokenProvider;
+  refreshAccessToken: RefreshHandler;
+  onAuthFailure: AuthFailureHandler;
+}): void {
+  getAccessToken = config.getAccessToken;
+  refreshAccessToken = config.refreshAccessToken;
+  onAuthFailure = config.onAuthFailure;
+}
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: string | string[] };
+    if (Array.isArray(body.message)) {
+      return body.message.join(", ");
+    }
+    if (typeof body.message === "string") {
+      return body.message;
+    }
+  } catch {
+    // ignore parse errors
+  }
+
+  return `Request failed with status ${response.status}`;
+}
+
+async function fetchWithAuth(
+  path: string,
+  init: RequestInit = {},
+  allowRetry = true,
+): Promise<Response> {
+  const headers = new Headers(init.headers);
+  const accessToken = getAccessToken();
+
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`);
+  }
+
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers,
+  });
+
+  if (response.status !== 401 || !allowRetry || !accessToken) {
+    return response;
+  }
+
+  const newAccessToken = await refreshAccessToken();
+  if (!newAccessToken) {
+    onAuthFailure();
+    return response;
+  }
+
+  return fetchWithAuth(path, init, false);
+}
+
+export async function apiRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetchWithAuth(path, init);
+
+  if (!response.ok) {
+    throw new ApiError(await parseErrorMessage(response), response.status);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function refreshTokens(refreshToken: string): Promise<RefreshResponse> {
+  const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!response.ok) {
+    throw new ApiError(await parseErrorMessage(response), response.status);
+  }
+
+  return (await response.json()) as RefreshResponse;
+}

--- a/apps/front/src/api/types.ts
+++ b/apps/front/src/api/types.ts
@@ -1,0 +1,71 @@
+export type AuthUser = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "player" | "admin";
+};
+
+export type AuthTokens = {
+  access: string;
+  refresh: string;
+};
+
+export type AuthResponse = {
+  user: AuthUser;
+  tokens: AuthTokens;
+};
+
+export type RefreshResponse = {
+  tokens: AuthTokens;
+};
+
+export type MeProfile = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "player" | "admin";
+  rating: number;
+  gamesPlayed: number;
+  createdAt: string;
+};
+
+export type PublicProfile = {
+  id: string;
+  displayName: string;
+  rating: number;
+  gamesPlayed: number;
+  winRate: number;
+  createdAt: string;
+};
+
+export type LeaderboardEntry = {
+  rank: number;
+  userId: string;
+  displayName: string;
+  rating: number;
+  gamesPlayed: number;
+};
+
+export type LeaderboardResponse = {
+  items: LeaderboardEntry[];
+};
+
+export type MeHistoryOpponent = {
+  displayName: string;
+  ratingAtMatch: number;
+};
+
+export type MeHistoryItem = {
+  matchId: string;
+  opponent: MeHistoryOpponent;
+  scoreA: number;
+  scoreB: number;
+  isWinner: boolean;
+  eloDelta: number;
+  endedAt: string;
+};
+
+export type MeHistoryResponse = {
+  items: MeHistoryItem[];
+  nextCursor: string | null;
+};

--- a/apps/front/src/auth/AuthContext.tsx
+++ b/apps/front/src/auth/AuthContext.tsx
@@ -1,0 +1,172 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { apiRequest, configureApiClient, refreshTokens } from "../api/apiClient.js";
+import type { AuthResponse, AuthUser, MeProfile } from "../api/types.js";
+import {
+  clearStoredRefreshToken,
+  getStoredRefreshToken,
+  setStoredRefreshToken,
+} from "./authStorage.js";
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isBootstrapping: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, displayName: string) => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function toAuthUser(profile: MeProfile): AuthUser {
+  return {
+    id: profile.id,
+    email: profile.email,
+    displayName: profile.displayName,
+    role: profile.role,
+  };
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+  const accessTokenRef = useRef<string | null>(null);
+  const refreshPromiseRef = useRef<Promise<string | null> | null>(null);
+
+  const clearSession = useCallback(() => {
+    accessTokenRef.current = null;
+    clearStoredRefreshToken();
+    setUser(null);
+  }, []);
+
+  const applyTokens = useCallback((access: string, refresh: string) => {
+    accessTokenRef.current = access;
+    setStoredRefreshToken(refresh);
+  }, []);
+
+  const refreshAccessToken = useCallback(async (): Promise<string | null> => {
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    const storedRefresh = getStoredRefreshToken();
+    if (!storedRefresh) {
+      clearSession();
+      return null;
+    }
+
+    refreshPromiseRef.current = (async () => {
+      try {
+        const { tokens } = await refreshTokens(storedRefresh);
+        applyTokens(tokens.access, tokens.refresh);
+        return tokens.access;
+      } catch {
+        clearSession();
+        return null;
+      } finally {
+        refreshPromiseRef.current = null;
+      }
+    })();
+
+    return refreshPromiseRef.current;
+  }, [applyTokens, clearSession]);
+
+  const bootstrapSession = useCallback(async () => {
+    const storedRefresh = getStoredRefreshToken();
+    if (!storedRefresh) {
+      setIsBootstrapping(false);
+      return;
+    }
+
+    try {
+      const access = await refreshAccessToken();
+      if (!access) {
+        setIsBootstrapping(false);
+        return;
+      }
+
+      const profile = await apiRequest<MeProfile>("/me");
+      setUser(toAuthUser(profile));
+    } catch {
+      clearSession();
+    } finally {
+      setIsBootstrapping(false);
+    }
+  }, [clearSession, refreshAccessToken]);
+
+  useEffect(() => {
+    configureApiClient({
+      getAccessToken: () => accessTokenRef.current,
+      refreshAccessToken,
+      onAuthFailure: clearSession,
+    });
+    void bootstrapSession();
+  }, [bootstrapSession, clearSession, refreshAccessToken]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      const result = await apiRequest<AuthResponse>("/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ email, password }),
+      });
+
+      applyTokens(result.tokens.access, result.tokens.refresh);
+      setUser(result.user);
+    },
+    [applyTokens],
+  );
+
+  const register = useCallback(
+    async (email: string, password: string, displayName: string) => {
+      const result = await apiRequest<AuthResponse>("/auth/register", {
+        method: "POST",
+        body: JSON.stringify({ email, password, displayName }),
+      });
+
+      applyTokens(result.tokens.access, result.tokens.refresh);
+      setUser(result.user);
+    },
+    [applyTokens],
+  );
+
+  const logout = useCallback(async () => {
+    try {
+      await apiRequest<void>("/auth/logout", { method: "POST" });
+    } catch {
+      // logout is best-effort client-side
+    } finally {
+      clearSession();
+    }
+  }, [clearSession]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      isAuthenticated: user !== null,
+      isBootstrapping,
+      login,
+      register,
+      logout,
+    }),
+    [user, isBootstrapping, login, register, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return context;
+}

--- a/apps/front/src/auth/authStorage.ts
+++ b/apps/front/src/auth/authStorage.ts
@@ -1,0 +1,13 @@
+const REFRESH_TOKEN_KEY = "chifoumi.refreshToken";
+
+export function getStoredRefreshToken(): string | null {
+  return sessionStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function setStoredRefreshToken(token: string): void {
+  sessionStorage.setItem(REFRESH_TOKEN_KEY, token);
+}
+
+export function clearStoredRefreshToken(): void {
+  sessionStorage.removeItem(REFRESH_TOKEN_KEY);
+}

--- a/apps/front/src/components/AsyncState.tsx
+++ b/apps/front/src/components/AsyncState.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+
+type AsyncPanelProps = {
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  onRetry?: () => void;
+  isEmpty?: boolean;
+  emptyMessage?: string;
+  skeleton: ReactNode;
+  children: ReactNode;
+};
+
+export function AsyncPanel({
+  isLoading,
+  isError,
+  errorMessage,
+  onRetry,
+  isEmpty = false,
+  emptyMessage = "Aucune donnée disponible.",
+  skeleton,
+  children,
+}: AsyncPanelProps) {
+  if (isLoading) {
+    return <>{skeleton}</>;
+  }
+
+  if (isError) {
+    return (
+      <div className="state state-error" role="alert">
+        <p>{errorMessage ?? "Une erreur est survenue."}</p>
+        {onRetry ? (
+          <button type="button" className="button" onClick={onRetry}>
+            Réessayer
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return <div className="state state-empty">{emptyMessage}</div>;
+  }
+
+  return <>{children}</>;
+}
+
+export function TableSkeleton({ rows = 8 }: { rows?: number }) {
+  const placeholders = Array.from({ length: rows }, (_, index) => `row-${index}`);
+
+  return (
+    <div className="skeleton-table" aria-hidden="true">
+      {placeholders.map((key) => (
+        <div key={key} className="skeleton-row" />
+      ))}
+    </div>
+  );
+}
+
+export function ProfileSkeleton() {
+  return (
+    <div className="skeleton-profile" aria-hidden="true">
+      <div className="skeleton-line skeleton-line-lg" />
+      <div className="skeleton-line" />
+      <div className="skeleton-line" />
+      <div className="skeleton-line" />
+    </div>
+  );
+}
+
+export function HistorySkeleton({ rows = 4 }: { rows?: number }) {
+  const placeholders = Array.from({ length: rows }, (_, index) => `history-${index}`);
+
+  return (
+    <div className="skeleton-list" aria-hidden="true">
+      {placeholders.map((key) => (
+        <div key={key} className="skeleton-card" />
+      ))}
+    </div>
+  );
+}

--- a/apps/front/src/components/Header.tsx
+++ b/apps/front/src/components/Header.tsx
@@ -1,0 +1,43 @@
+import { Link, NavLink } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext.js";
+
+export function Header() {
+  const { user, isAuthenticated, logout } = useAuth();
+
+  return (
+    <header className="header">
+      <Link to={isAuthenticated ? "/lobby" : "/login"} className="brand">
+        Chifoumi Ranked
+      </Link>
+
+      <nav className="nav" aria-label="Main navigation">
+        {isAuthenticated ? (
+          <>
+            <NavLink to="/lobby" className="nav-link">
+              Lobby
+            </NavLink>
+            <NavLink to="/leaderboard" className="nav-link">
+              Leaderboard
+            </NavLink>
+            <NavLink to="/profile" className="nav-link">
+              Profil
+            </NavLink>
+            <span className="nav-user">{user?.displayName}</span>
+            <button type="button" className="button button-secondary" onClick={() => void logout()}>
+              Logout
+            </button>
+          </>
+        ) : (
+          <>
+            <NavLink to="/leaderboard" className="nav-link">
+              Leaderboard
+            </NavLink>
+            <NavLink to="/login" className="nav-link">
+              Login
+            </NavLink>
+          </>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/apps/front/src/components/LeaderboardTable.tsx
+++ b/apps/front/src/components/LeaderboardTable.tsx
@@ -1,0 +1,37 @@
+import { Link } from "react-router-dom";
+import type { LeaderboardEntry } from "../api/types.js";
+
+type LeaderboardTableProps = {
+  items: LeaderboardEntry[];
+};
+
+export function LeaderboardTable({ items }: LeaderboardTableProps) {
+  return (
+    <div className="table-wrap">
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Rang</th>
+            <th scope="col">Joueur</th>
+            <th scope="col">Rating</th>
+            <th scope="col">Matchs joués</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((entry) => (
+            <tr key={entry.userId}>
+              <td>{entry.rank}</td>
+              <td>
+                <Link to={`/profile/${entry.userId}`} className="table-link">
+                  {entry.displayName}
+                </Link>
+              </td>
+              <td>{entry.rating}</td>
+              <td>{entry.gamesPlayed}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/front/src/components/MatchHistoryList.tsx
+++ b/apps/front/src/components/MatchHistoryList.tsx
@@ -1,0 +1,86 @@
+import type { MeHistoryItem } from "../api/types.js";
+import { AsyncPanel, HistorySkeleton } from "./AsyncState.js";
+
+type MatchHistoryListProps = {
+  items: MeHistoryItem[];
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  onRetry: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+};
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("fr-FR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatEloDelta(value: number): string {
+  return value >= 0 ? `+${value}` : String(value);
+}
+
+export function MatchHistoryList({
+  items,
+  isLoading,
+  isError,
+  errorMessage,
+  onRetry,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: MatchHistoryListProps) {
+  return (
+    <section className="history-section" aria-labelledby="history-title">
+      <h2 id="history-title" className="section-title">
+        Historique
+      </h2>
+
+      <AsyncPanel
+        isLoading={isLoading}
+        isError={isError}
+        errorMessage={errorMessage}
+        onRetry={onRetry}
+        isEmpty={!isLoading && !isError && items.length === 0}
+        emptyMessage="Aucun match joué encore."
+        skeleton={<HistorySkeleton />}
+      >
+        <ul className="history-list">
+          {items.map((item) => (
+            <li key={item.matchId} className="history-item">
+              <div className="history-item-main">
+                <span className="history-opponent">vs {item.opponent.displayName}</span>
+                <span className="history-score">
+                  {item.scoreA} - {item.scoreB}
+                </span>
+              </div>
+              <div className="history-item-meta">
+                <span className={item.isWinner ? "result-win" : "result-loss"}>
+                  {item.isWinner ? "Victoire" : "Défaite"}
+                </span>
+                <span className={item.eloDelta >= 0 ? "delta-positive" : "delta-negative"}>
+                  {formatEloDelta(item.eloDelta)} ELO
+                </span>
+                <span className="history-date">{formatDate(item.endedAt)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        {hasNextPage ? (
+          <button
+            type="button"
+            className="button button-secondary load-more"
+            disabled={isFetchingNextPage}
+            onClick={onLoadMore}
+          >
+            {isFetchingNextPage ? "Chargement…" : "Charger plus"}
+          </button>
+        ) : null}
+      </AsyncPanel>
+    </section>
+  );
+}

--- a/apps/front/src/components/ProfileHeader.tsx
+++ b/apps/front/src/components/ProfileHeader.tsx
@@ -1,0 +1,45 @@
+import type { ProfileData } from "../hooks/useProfile.js";
+
+type ProfileHeaderProps = {
+  profile: ProfileData;
+};
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("fr-FR", {
+    dateStyle: "medium",
+  }).format(new Date(value));
+}
+
+function formatWinRate(value: number): string {
+  return `${Math.round(value * 100)} %`;
+}
+
+export function ProfileHeader({ profile }: ProfileHeaderProps) {
+  const email = profile.kind === "own" ? profile.me.email : null;
+  const { stats } = profile;
+
+  return (
+    <section className="profile-header" aria-labelledby="profile-title">
+      <h1 id="profile-title" className="title">
+        {stats.displayName}
+      </h1>
+
+      <dl className="profile-stats">
+        {email ? (
+          <>
+            <dt>Email</dt>
+            <dd>{email}</dd>
+          </>
+        ) : null}
+        <dt>Rating</dt>
+        <dd>{stats.rating}</dd>
+        <dt>Matchs joués</dt>
+        <dd>{stats.gamesPlayed}</dd>
+        <dt>Taux de victoire</dt>
+        <dd>{formatWinRate(stats.winRate)}</dd>
+        <dt>Inscription</dt>
+        <dd>{formatDate(stats.createdAt)}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/apps/front/src/components/ProtectedRoute.tsx
+++ b/apps/front/src/components/ProtectedRoute.tsx
@@ -1,0 +1,43 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext.js";
+
+export function ProtectedRoute() {
+  const { isAuthenticated, isBootstrapping } = useAuth();
+  const location = useLocation();
+
+  if (isBootstrapping) {
+    return (
+      <div className="page">
+        <div className="panel">
+          <p className="muted">Chargement de la session…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  return <Outlet />;
+}
+
+export function GuestRoute() {
+  const { isAuthenticated, isBootstrapping } = useAuth();
+
+  if (isBootstrapping) {
+    return (
+      <div className="page">
+        <div className="panel">
+          <p className="muted">Chargement…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/lobby" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/apps/front/src/hooks/useLeaderboard.ts
+++ b/apps/front/src/hooks/useLeaderboard.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { LeaderboardResponse } from "../api/types.js";
+
+const LEADERBOARD_LIMIT = 50;
+const LEADERBOARD_REFRESH_MS = 30_000;
+
+export function useLeaderboard() {
+  return useQuery({
+    queryKey: ["leaderboard", LEADERBOARD_LIMIT],
+    queryFn: () => apiRequest<LeaderboardResponse>(`/leaderboard?limit=${LEADERBOARD_LIMIT}`),
+    refetchInterval: LEADERBOARD_REFRESH_MS,
+    refetchIntervalInBackground: true,
+  });
+}

--- a/apps/front/src/hooks/useMyHistory.ts
+++ b/apps/front/src/hooks/useMyHistory.ts
@@ -1,0 +1,21 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { MeHistoryResponse } from "../api/types.js";
+
+const HISTORY_PAGE_SIZE = 20;
+
+export function useMyHistory(enabled: boolean) {
+  return useInfiniteQuery({
+    queryKey: ["me", "history", HISTORY_PAGE_SIZE],
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(HISTORY_PAGE_SIZE) });
+      if (pageParam) {
+        params.set("cursor", pageParam);
+      }
+      return apiRequest<MeHistoryResponse>(`/me/history?${params.toString()}`);
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/apps/front/src/hooks/useProfile.ts
+++ b/apps/front/src/hooks/useProfile.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { MeProfile, PublicProfile } from "../api/types.js";
+
+export type OwnProfileData = {
+  kind: "own";
+  me: MeProfile;
+  stats: PublicProfile;
+};
+
+export type OtherProfileData = {
+  kind: "other";
+  stats: PublicProfile;
+};
+
+export type ProfileData = OwnProfileData | OtherProfileData;
+
+export function useProfile(userId: string | undefined, isOwnProfile: boolean) {
+  return useQuery({
+    queryKey: ["profile", userId, isOwnProfile],
+    enabled: Boolean(userId),
+    queryFn: async (): Promise<ProfileData> => {
+      if (!userId) {
+        throw new Error("Missing user id");
+      }
+
+      if (isOwnProfile) {
+        const [me, stats] = await Promise.all([
+          apiRequest<MeProfile>("/me"),
+          apiRequest<PublicProfile>(`/users/${userId}/profile`),
+        ]);
+        return { kind: "own", me, stats };
+      }
+
+      const stats = await apiRequest<PublicProfile>(`/users/${userId}/profile`);
+      return { kind: "other", stats };
+    },
+  });
+}

--- a/apps/front/src/main.tsx
+++ b/apps/front/src/main.tsx
@@ -1,6 +1,18 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import { App } from "./App.js";
+import { AuthProvider } from "./auth/AuthContext.js";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 5_000,
+    },
+  },
+});
 
 const root = document.getElementById("root");
 
@@ -10,6 +22,12 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/front/src/pages/LeaderboardPage.tsx
+++ b/apps/front/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,35 @@
+import { AsyncPanel, TableSkeleton } from "../components/AsyncState.js";
+import { LeaderboardTable } from "../components/LeaderboardTable.js";
+import { useLeaderboard } from "../hooks/useLeaderboard.js";
+
+export function LeaderboardPage() {
+  const { data, isLoading, isError, error, refetch, isFetching } = useLeaderboard();
+
+  return (
+    <div className="page">
+      <section className="panel panel-wide" aria-labelledby="leaderboard-title">
+        <div className="page-heading">
+          <h1 id="leaderboard-title" className="title">
+            Leaderboard
+          </h1>
+          <p className="subtitle">
+            Top 50 joueurs par rating. Actualisation automatique toutes les 30s.
+          </p>
+          {isFetching && !isLoading ? <span className="badge">Mise à jour…</span> : null}
+        </div>
+
+        <AsyncPanel
+          isLoading={isLoading}
+          isError={isError}
+          errorMessage={error instanceof Error ? error.message : undefined}
+          onRetry={() => void refetch()}
+          isEmpty={!isLoading && !isError && (data?.items.length ?? 0) === 0}
+          emptyMessage="Aucun joueur classé pour le moment."
+          skeleton={<TableSkeleton rows={10} />}
+        >
+          {data ? <LeaderboardTable items={data.items} /> : null}
+        </AsyncPanel>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/src/pages/LobbyPage.tsx
+++ b/apps/front/src/pages/LobbyPage.tsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+export function LobbyPage() {
+  return (
+    <div className="page">
+      <section className="panel" aria-labelledby="lobby-title">
+        <h1 id="lobby-title" className="title">
+          Lobby
+        </h1>
+        <p className="subtitle">
+          L&apos;écran de matchmaking arrive avec l&apos;US-041. En attendant, consultez le{" "}
+          <Link to="/leaderboard">leaderboard</Link> ou votre <Link to="/profile">profil</Link>.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/src/pages/LoginPage.tsx
+++ b/apps/front/src/pages/LoginPage.tsx
@@ -1,0 +1,86 @@
+import { type FormEvent, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { ApiError } from "../api/apiClient.js";
+import { useAuth } from "../auth/AuthContext.js";
+
+export function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const redirectTo =
+    (location.state as { from?: string } | null)?.from && typeof location.state === "object"
+      ? (location.state as { from?: string }).from
+      : "/lobby";
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await login(email, password);
+      navigate(redirectTo ?? "/lobby", { replace: true });
+    } catch (caught) {
+      if (caught instanceof ApiError && caught.status === 401) {
+        setError("Identifiants invalides.");
+      } else {
+        setError(caught instanceof Error ? caught.message : "Connexion impossible.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="page">
+      <section className="panel" aria-labelledby="login-title">
+        <h1 id="login-title" className="title">
+          Connexion
+        </h1>
+        <p className="subtitle">
+          Pas encore de compte ? <Link to="/register">Créer un compte</Link>
+        </p>
+
+        <form className="form" onSubmit={(event) => void handleSubmit(event)}>
+          <label className="field">
+            <span>Email</span>
+            <input
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span>Mot de passe</span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              required
+              minLength={10}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+
+          {error ? (
+            <p className="form-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <button type="submit" className="button" disabled={isSubmitting}>
+            {isSubmitting ? "Connexion…" : "Se connecter"}
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/src/pages/ProfilePage.tsx
+++ b/apps/front/src/pages/ProfilePage.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from "react";
+import { Navigate, useParams } from "react-router-dom";
+import { ApiError } from "../api/apiClient.js";
+import { useAuth } from "../auth/AuthContext.js";
+import { AsyncPanel, ProfileSkeleton } from "../components/AsyncState.js";
+import { MatchHistoryList } from "../components/MatchHistoryList.js";
+import { ProfileHeader } from "../components/ProfileHeader.js";
+import { useMyHistory } from "../hooks/useMyHistory.js";
+import { useProfile } from "../hooks/useProfile.js";
+
+export function ProfilePage() {
+  const { id } = useParams();
+  const { user, isAuthenticated } = useAuth();
+  const [activeTab, setActiveTab] = useState<"overview" | "history">("overview");
+
+  const isOwnProfile = !id || id === user?.id;
+  const profileUserId = isOwnProfile ? user?.id : id;
+
+  const profileQuery = useProfile(profileUserId, isOwnProfile);
+  const historyQuery = useMyHistory(isOwnProfile && activeTab === "history");
+
+  const historyItems = useMemo(
+    () => historyQuery.data?.pages.flatMap((page) => page.items) ?? [],
+    [historyQuery.data],
+  );
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: id ? `/profile/${id}` : "/profile" }} />;
+  }
+
+  if (isOwnProfile && !user) {
+    return null;
+  }
+
+  return (
+    <div className="page">
+      <section className="panel panel-wide" aria-labelledby="profile-page-title">
+        <AsyncPanel
+          isLoading={profileQuery.isLoading}
+          isError={profileQuery.isError}
+          errorMessage={
+            profileQuery.error instanceof ApiError && profileQuery.error.status === 404
+              ? "Joueur introuvable."
+              : profileQuery.error instanceof Error
+                ? profileQuery.error.message
+                : undefined
+          }
+          onRetry={() => void profileQuery.refetch()}
+          skeleton={<ProfileSkeleton />}
+        >
+          {profileQuery.data ? (
+            <>
+              <ProfileHeader profile={profileQuery.data} />
+
+              {isOwnProfile ? (
+                <div className="tabs" role="tablist" aria-label="Profil">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === "overview"}
+                    className={activeTab === "overview" ? "tab tab-active" : "tab"}
+                    onClick={() => setActiveTab("overview")}
+                  >
+                    Aperçu
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === "history"}
+                    className={activeTab === "history" ? "tab tab-active" : "tab"}
+                    onClick={() => setActiveTab("history")}
+                  >
+                    Historique
+                  </button>
+                </div>
+              ) : null}
+
+              {isOwnProfile && activeTab === "history" ? (
+                <MatchHistoryList
+                  items={historyItems}
+                  isLoading={historyQuery.isLoading}
+                  isError={historyQuery.isError}
+                  errorMessage={
+                    historyQuery.error instanceof Error ? historyQuery.error.message : undefined
+                  }
+                  onRetry={() => void historyQuery.refetch()}
+                  hasNextPage={historyQuery.hasNextPage}
+                  isFetchingNextPage={historyQuery.isFetchingNextPage}
+                  onLoadMore={() => void historyQuery.fetchNextPage()}
+                />
+              ) : null}
+            </>
+          ) : null}
+        </AsyncPanel>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/src/pages/RegisterPage.tsx
+++ b/apps/front/src/pages/RegisterPage.tsx
@@ -1,0 +1,94 @@
+import { type FormEvent, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ApiError } from "../api/apiClient.js";
+import { useAuth } from "../auth/AuthContext.js";
+
+export function RegisterPage() {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await register(email, password, displayName);
+      navigate("/lobby", { replace: true });
+    } catch (caught) {
+      if (caught instanceof ApiError && caught.status === 409) {
+        setError("Email déjà utilisé.");
+      } else {
+        setError(caught instanceof Error ? caught.message : "Inscription impossible.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="page">
+      <section className="panel" aria-labelledby="register-title">
+        <h1 id="register-title" className="title">
+          Inscription
+        </h1>
+        <p className="subtitle">
+          Déjà un compte ? <Link to="/login">Se connecter</Link>
+        </p>
+
+        <form className="form" onSubmit={(event) => void handleSubmit(event)}>
+          <label className="field">
+            <span>Display name</span>
+            <input
+              type="text"
+              required
+              minLength={3}
+              maxLength={30}
+              pattern="[A-Za-z0-9]+"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span>Email</span>
+            <input
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span>Mot de passe</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={10}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+
+          {error ? (
+            <p className="form-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <button type="submit" className="button" disabled={isSubmitting}>
+            {isSubmitting ? "Création…" : "Créer le compte"}
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,12 +156,18 @@ importers:
 
   apps/front:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      react-router-dom:
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -1507,6 +1513,14 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -1926,6 +1940,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -3187,6 +3205,23 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-router-dom@7.18.0:
+    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
@@ -3294,6 +3329,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4687,6 +4725,13 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.6
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -5156,6 +5201,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -6612,6 +6659,20 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-router-dom@7.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-router: 7.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+
+  react-router@7.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.6
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.6(react@19.2.6)
+
   react@19.2.6: {}
 
   readable-stream@3.6.2:
@@ -6730,6 +6791,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 


### PR DESCRIPTION
## Summary

- Closes #43 (US-042)
- Adds React Router + TanStack Query foundation with minimal auth shell (login/register, api client with refresh, Header)
- Implements /leaderboard (top 50, 30s auto-refresh) and /profile / /profile/:id (own profile with email + paginated history, public profile without email/history)
- Includes skeleton, error+retry, and empty states per AC5

## Acceptance criteria

- [x] AC1: Leaderboard table with rank, clickable displayName, rating, games played (max 50)
- [x] AC2: Auto-refresh every 30s via react-query refetchInterval
- [x] AC3: Own profile shows displayName, email, rating, gamesPlayed, winRate, createdAt + History tab with cursor pagination
- [x] AC4: Other player profile shows public fields only, no history tab
- [x] AC5: Loading skeletons, error retry, empty states

## Test plan

- [x] pnpm biome check apps/front
- [x] pnpm --filter @chifoumi/front typecheck
- [x] pnpm --filter @chifoumi/front build
- [ ] Manual: login, open /leaderboard, verify table + auto-refresh badge
- [ ] Manual: open /profile, verify stats + history pagination
- [ ] Manual: open /profile/:id for another player, verify no email/history

Made with [Cursor](https://cursor.com)