### PR TITLE
fix: @Inject() sur tous les constructeurs + seed démo complet

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Post,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -39,7 +48,7 @@ const FORGOT_PASSWORD_THROTTLE_LIMIT = IS_TEST_ENV ? 1_000_000 : 3;
 @Throttle({ auth: { limit: AUTH_THROTTLE_LIMIT, ttl: 60_000 } })
 @Controller("auth")
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(@Inject(AuthService) private readonly authService: AuthService) {}
 
   @Post("register")
   @HttpCode(HttpStatus.CREATED)

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ConflictException, Inject, Injectable, UnauthorizedException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { NotificationsQueueService } from "../queues/notifications-queue.service.js";
 import { RedisService } from "../redis/redis.service.js";
@@ -20,11 +20,12 @@ const DEFAULT_FRONTEND_URL = "http://localhost:5173";
 @Injectable()
 export class AuthService {
   constructor(
-    private readonly usersService: UsersService,
-    private readonly passwordService: PasswordService,
-    private readonly tokenService: TokenService,
-    private readonly prisma: PrismaService,
-    private readonly redisService: RedisService,
+    @Inject(UsersService) private readonly usersService: UsersService,
+    @Inject(PasswordService) private readonly passwordService: PasswordService,
+    @Inject(TokenService) private readonly tokenService: TokenService,
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(RedisService) private readonly redisService: RedisService,
+    @Inject(NotificationsQueueService)
     private readonly notificationsQueue: NotificationsQueueService,
   ) {}
 

--- a/apps/api/src/auth/dto/auth-response.dto.ts
+++ b/apps/api/src/auth/dto/auth-response.dto.ts
@@ -2,13 +2,13 @@ import { ApiProperty } from "@nestjs/swagger";
 import { TokensDto } from "./tokens.dto.js";
 
 export class SafeUserDto {
-  @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
+  @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   id!: string;
 
-  @ApiProperty({ format: "email", example: "player@example.com" })
+  @ApiProperty({ type: String, format: "email", example: "player@example.com" })
   email!: string;
 
-  @ApiProperty({ example: "player1" })
+  @ApiProperty({ type: String, example: "player1" })
   displayName!: string;
 
   @ApiProperty({ enum: ["player", "admin"], example: "player" })
@@ -16,9 +16,9 @@ export class SafeUserDto {
 }
 
 export class AuthResponseDto {
-  @ApiProperty({ type: SafeUserDto })
+  @ApiProperty({ type: () => SafeUserDto })
   user!: SafeUserDto;
 
-  @ApiProperty({ type: TokensDto })
+  @ApiProperty({ type: () => TokensDto })
   tokens!: TokensDto;
 }

--- a/apps/api/src/auth/dto/forgot-password.dto.ts
+++ b/apps/api/src/auth/dto/forgot-password.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from "@nestjs/swagger";
 import { IsEmail } from "class-validator";
 
 export class ForgotPasswordDto {
-  @ApiProperty({ format: "email", example: "player@example.com" })
+  @ApiProperty({ type: String, format: "email", example: "player@example.com" })
   @IsEmail()
   email!: string;
 }

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -2,11 +2,11 @@ import { ApiProperty } from "@nestjs/swagger";
 import { IsEmail, IsString, Length } from "class-validator";
 
 export class LoginDto {
-  @ApiProperty({ format: "email", example: "player@example.com" })
+  @ApiProperty({ type: String, format: "email", example: "player@example.com" })
   @IsEmail()
   email!: string;
 
-  @ApiProperty({ minLength: 1, maxLength: 128, example: "password1234" })
+  @ApiProperty({ type: String, minLength: 1, maxLength: 128, example: "password1234" })
   @IsString()
   @Length(1, 128)
   password!: string;

--- a/apps/api/src/auth/dto/refresh-response.dto.ts
+++ b/apps/api/src/auth/dto/refresh-response.dto.ts
@@ -2,6 +2,6 @@ import { ApiProperty } from "@nestjs/swagger";
 import { TokensDto } from "./tokens.dto.js";
 
 export class RefreshResponseDto {
-  @ApiProperty({ type: TokensDto })
+  @ApiProperty({ type: () => TokensDto })
   tokens!: TokensDto;
 }

--- a/apps/api/src/auth/dto/refresh.dto.ts
+++ b/apps/api/src/auth/dto/refresh.dto.ts
@@ -3,6 +3,7 @@ import { IsString, Length } from "class-validator";
 
 export class RefreshDto {
   @ApiProperty({
+    type: String,
     description: "Opaque refresh token issued at login or a prior refresh",
     minLength: 20,
     example: "dGhpcyBpcyBhbiBvcGFxdWUgcmVmcmVzaCB0b2tlbg",

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -2,16 +2,17 @@ import { ApiProperty } from "@nestjs/swagger";
 import { IsEmail, IsString, Length, Matches } from "class-validator";
 
 export class RegisterDto {
-  @ApiProperty({ format: "email", example: "player@example.com" })
+  @ApiProperty({ type: String, format: "email", example: "player@example.com" })
   @IsEmail()
   email!: string;
 
-  @ApiProperty({ minLength: 10, maxLength: 128, example: "password1234" })
+  @ApiProperty({ type: String, minLength: 10, maxLength: 128, example: "password1234" })
   @IsString()
   @Length(10, 128)
   password!: string;
 
   @ApiProperty({
+    type: String,
     minLength: 3,
     maxLength: 30,
     pattern: "^[a-zA-Z0-9_-]+$",

--- a/apps/api/src/auth/dto/reset-password.dto.ts
+++ b/apps/api/src/auth/dto/reset-password.dto.ts
@@ -3,6 +3,7 @@ import { IsString, IsUUID, Length } from "class-validator";
 
 export class ResetPasswordDto {
   @ApiProperty({
+    type: String,
     description: "Opaque password reset token received by email",
     example: "5a7a7a8e-6c4a-4b1a-9f24-9b6f7c2a4e8c",
   })
@@ -10,7 +11,7 @@ export class ResetPasswordDto {
   @IsUUID(4)
   token!: string;
 
-  @ApiProperty({ minLength: 10, maxLength: 128, example: "newPassword1234" })
+  @ApiProperty({ type: String, minLength: 10, maxLength: 128, example: "newPassword1234" })
   @IsString()
   @Length(10, 128)
   newPassword!: string;

--- a/apps/api/src/auth/dto/tokens.dto.ts
+++ b/apps/api/src/auth/dto/tokens.dto.ts
@@ -2,12 +2,14 @@ import { ApiProperty } from "@nestjs/swagger";
 
 export class TokensDto {
   @ApiProperty({
+    type: String,
     description: "RS256 JWT access token (15 min TTL)",
     example: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
   })
   access!: string;
 
   @ApiProperty({
+    type: String,
     description: "Opaque refresh token (7 day TTL)",
     example: "vJ6E3j6bU5Wc3cS8mQf9Rk5H2q3T4p1N",
   })

--- a/apps/api/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/api/src/auth/guards/jwt-auth.guard.ts
@@ -1,11 +1,11 @@
-import { type ExecutionContext, Injectable } from "@nestjs/common";
+import { type ExecutionContext, Inject, Injectable } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { AuthGuard } from "@nestjs/passport";
 import { IS_PUBLIC_KEY } from "../decorators/public.decorator.js";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {
-  constructor(private readonly reflector: Reflector) {
+  constructor(@Inject(Reflector) private readonly reflector: Reflector) {
     super();
   }
 

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -21,8 +21,8 @@ export type JwtPayload = {
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     @Inject(JWT_CONFIG) jwtConfig: JwtConfig,
-    private readonly usersService: UsersService,
-    private readonly redisService: RedisService,
+    @Inject(UsersService) private readonly usersService: UsersService,
+    @Inject(RedisService) private readonly redisService: RedisService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/apps/api/src/grpc/auth-grpc.controller.ts
+++ b/apps/api/src/grpc/auth-grpc.controller.ts
@@ -1,10 +1,13 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Inject } from "@nestjs/common";
 import { GrpcMethod } from "@nestjs/microservices";
 import { AuthVerificationService } from "./auth-verification.service.js";
 
 @Controller()
 export class AuthGrpcController {
-  constructor(private readonly authVerificationService: AuthVerificationService) {}
+  constructor(
+    @Inject(AuthVerificationService)
+    private readonly authVerificationService: AuthVerificationService,
+  ) {}
 
   @GrpcMethod("Auth", "VerifyToken")
   async verifyToken(data: { token: string }) {

--- a/apps/api/src/grpc/auth-verification.service.ts
+++ b/apps/api/src/grpc/auth-verification.service.ts
@@ -1,5 +1,5 @@
 import type { VerifyTokenResponse } from "@chifoumi/proto";
-import { Injectable, Logger } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { JwtService, TokenExpiredError } from "@nestjs/jwt";
 import type { AccessTokenPayload } from "../auth/token.service.js";
 import { RedisService } from "../redis/redis.service.js";
@@ -9,8 +9,8 @@ export class AuthVerificationService {
   private readonly logger = new Logger(AuthVerificationService.name);
 
   constructor(
-    private readonly jwtService: JwtService,
-    private readonly redisService: RedisService,
+    @Inject(JwtService) private readonly jwtService: JwtService,
+    @Inject(RedisService) private readonly redisService: RedisService,
   ) {}
 
   async verifyToken(token: string): Promise<VerifyTokenResponse> {

--- a/apps/api/src/grpc/users-grpc.controller.ts
+++ b/apps/api/src/grpc/users-grpc.controller.ts
@@ -1,11 +1,11 @@
 import { status as GrpcStatus } from "@grpc/grpc-js";
-import { Controller } from "@nestjs/common";
+import { Controller, Inject } from "@nestjs/common";
 import { GrpcMethod, RpcException } from "@nestjs/microservices";
 import { UsersService } from "../users/users.service.js";
 
 @Controller()
 export class UsersGrpcController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(@Inject(UsersService) private readonly usersService: UsersService) {}
 
   @GrpcMethod("Users", "GetRating")
   async getRating(data: { userId: string }) {

--- a/apps/api/src/leaderboard/dto/leaderboard-response.dto.ts
+++ b/apps/api/src/leaderboard/dto/leaderboard-response.dto.ts
@@ -1,23 +1,23 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class LeaderboardEntryDto {
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ type: Number, example: 1 })
   rank!: number;
 
-  @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
+  @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   userId!: string;
 
-  @ApiProperty({ example: "player1" })
+  @ApiProperty({ type: String, example: "player1" })
   displayName!: string;
 
-  @ApiProperty({ example: 1600 })
+  @ApiProperty({ type: Number, example: 1600 })
   rating!: number;
 
-  @ApiProperty({ example: 42 })
+  @ApiProperty({ type: Number, example: 42 })
   gamesPlayed!: number;
 }
 
 export class LeaderboardResponseDto {
-  @ApiProperty({ type: [LeaderboardEntryDto] })
+  @ApiProperty({ type: () => LeaderboardEntryDto, isArray: true })
   items!: LeaderboardEntryDto[];
 }

--- a/apps/api/src/leaderboard/leaderboard.controller.ts
+++ b/apps/api/src/leaderboard/leaderboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Res, UseGuards } from "@nestjs/common";
+import { Controller, Get, Inject, Query, Res, UseGuards } from "@nestjs/common";
 import {
   ApiBadRequestResponse,
   ApiOkResponse,
@@ -18,7 +18,9 @@ import { LeaderboardService } from "./leaderboard.service.js";
 @UseGuards(JwtAuthGuard)
 @Controller("leaderboard")
 export class LeaderboardController {
-  constructor(private readonly leaderboardService: LeaderboardService) {}
+  constructor(
+    @Inject(LeaderboardService) private readonly leaderboardService: LeaderboardService,
+  ) {}
 
   @Public()
   @Get()

--- a/apps/api/src/leaderboard/leaderboard.service.ts
+++ b/apps/api/src/leaderboard/leaderboard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { LEADERBOARD_CACHE_KEY_PREFIX, RedisService } from "../redis/redis.service.js";
 import type { LeaderboardResponseDto } from "./dto/leaderboard-response.dto.js";
@@ -15,8 +15,8 @@ export type LeaderboardResult = {
 @Injectable()
 export class LeaderboardService {
   constructor(
-    private readonly prisma: PrismaService,
-    private readonly redis: RedisService,
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(RedisService) private readonly redis: RedisService,
   ) {}
 
   async get(limit: number): Promise<LeaderboardResult> {
@@ -39,7 +39,7 @@ export class LeaderboardService {
   private async fetchFromDatabase(limit: number): Promise<LeaderboardResponseDto> {
     const rows = await this.prisma.eloRating.findMany({
       orderBy: [{ rating: "desc" }, { gamesPlayed: "desc" }],
-      take: limit,
+      take: Math.trunc(Number(limit)),
       include: {
         user: {
           select: {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -41,7 +41,11 @@ async function bootstrap() {
   app.enableCors({
     origin: resolveCorsOrigins(),
   });
-  setupSwagger(app);
+  try {
+    setupSwagger(app);
+  } catch (err) {
+    console.warn("[Swagger] Skipped — schema generation failed:", (err as Error).message);
+  }
 
   const grpcPort = Number(process.env.API_GRPC_PORT ?? DEFAULT_GRPC_PORT);
   app.connectMicroservice<MicroserviceOptions>({

--- a/apps/api/src/matches/audit.service.ts
+++ b/apps/api/src/matches/audit.service.ts
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
-import { ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import { ForbiddenException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { MatchStatus } from "@prisma/client";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { AuditRoundDto, MatchAuditResponseDto } from "./dto/match-audit-response.dto.js";
 
 @Injectable()
 export class AuditService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async buildAudit(matchId: string): Promise<MatchAuditResponseDto> {
     const match = await this.prisma.match.findUnique({

--- a/apps/api/src/matches/dto/match-audit-response.dto.ts
+++ b/apps/api/src/matches/dto/match-audit-response.dto.ts
@@ -9,13 +9,13 @@ export class HashCheckDto {
 }
 
 export class AuditRoundDto {
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ type: Number, example: 1 })
   roundNumber!: number;
 
-  @ApiProperty({ nullable: true, example: "a1b2c3..." })
+  @ApiProperty({ type: String, nullable: true, example: "a1b2c3..." })
   commitA!: string | null;
 
-  @ApiProperty({ nullable: true, example: "d4e5f6..." })
+  @ApiProperty({ type: String, nullable: true, example: "d4e5f6..." })
   commitB!: string | null;
 
   @ApiProperty({ enum: ["rock", "paper", "scissors"], nullable: true, example: "rock" })
@@ -24,32 +24,31 @@ export class AuditRoundDto {
   @ApiProperty({ enum: ["rock", "paper", "scissors"], nullable: true, example: "paper" })
   moveB!: string | null;
 
-  @ApiProperty({ nullable: true, example: "deadbeef..." })
+  @ApiProperty({ type: String, nullable: true, example: "deadbeef..." })
   nonceA!: string | null;
 
-  @ApiProperty({ nullable: true, example: "cafebabe..." })
+  @ApiProperty({ type: String, nullable: true, example: "cafebabe..." })
   nonceB!: string | null;
 
-  @ApiProperty({ type: HashCheckDto })
+  @ApiProperty({ type: () => HashCheckDto })
   hashCheck!: HashCheckDto;
 }
 
 export class MatchPlayerDto {
   @ApiProperty({
+    type: String,
     description: "Player ID (UUID)",
     example: "550e8400-e29b-41d4-a716-446655440000",
   })
   id!: string;
 
-  @ApiProperty({
-    description: "Player display name",
-    example: "johndoe",
-  })
+  @ApiProperty({ type: String, description: "Player display name", example: "johndoe" })
   displayName!: string;
 }
 
 export class MatchAuditResponseDto {
   @ApiProperty({
+    type: String,
     description: "Match ID (UUID)",
     example: "550e8400-e29b-41d4-a716-446655440000",
   })
@@ -57,23 +56,19 @@ export class MatchAuditResponseDto {
 
   @ApiProperty({
     description: "Players involved in the match (player A and player B)",
-    type: [MatchPlayerDto],
+    type: () => MatchPlayerDto,
+    isArray: true,
     example: [
-      {
-        id: "550e8400-e29b-41d4-a716-446655440000",
-        displayName: "alice",
-      },
-      {
-        id: "660e8400-e29b-41d4-a716-446655440001",
-        displayName: "bob",
-      },
+      { id: "550e8400-e29b-41d4-a716-446655440000", displayName: "alice" },
+      { id: "660e8400-e29b-41d4-a716-446655440001", displayName: "bob" },
     ],
   })
   players!: MatchPlayerDto[];
 
   @ApiProperty({
     description: "All rounds of the match with cryptographic details",
-    type: [AuditRoundDto],
+    type: () => AuditRoundDto,
+    isArray: true,
   })
   rounds!: AuditRoundDto[];
 
@@ -84,6 +79,7 @@ export class MatchAuditResponseDto {
   finalScore!: [number, number];
 
   @ApiProperty({
+    type: String,
     description: "Winner player ID or null if draw",
     example: "550e8400-e29b-41d4-a716-446655440000",
     nullable: true,
@@ -91,6 +87,7 @@ export class MatchAuditResponseDto {
   winner!: string | null;
 
   @ApiProperty({
+    type: String,
     description: "Match end time (ISO 8601)",
     example: "2026-06-22T10:30:45.123Z",
   })

--- a/apps/api/src/matches/matches.controller.ts
+++ b/apps/api/src/matches/matches.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from "@nestjs/common";
+import { Controller, Get, Inject, Param } from "@nestjs/common";
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
 import { Public } from "../auth/decorators/public.decorator.js";
@@ -8,7 +8,7 @@ import { MatchAuditResponseDto } from "./dto/match-audit-response.dto.js";
 @ApiTags("Matches")
 @Controller("matches")
 export class MatchesController {
-  constructor(private readonly auditService: AuditService) {}
+  constructor(@Inject(AuditService) private readonly auditService: AuditService) {}
 
   @Get(":id/audit")
   @Public()

--- a/apps/api/src/me/dto/me-history-query.dto.ts
+++ b/apps/api/src/me/dto/me-history-query.dto.ts
@@ -12,6 +12,7 @@ export class MeHistoryQueryDto {
   limit = 20;
 
   @ApiPropertyOptional({
+    type: String,
     description: "Opaque cursor returned by the previous page",
     example: "eyJ0cyI6IjIwMjYtMDEtMDFUMDA6MDA6MzEuMDAwWiIsImlkIjoiIn0",
   })

--- a/apps/api/src/me/dto/me-history-response.dto.ts
+++ b/apps/api/src/me/dto/me-history-response.dto.ts
@@ -1,41 +1,42 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class MeHistoryOpponentDto {
-  @ApiProperty({ example: "opponent42" })
+  @ApiProperty({ type: String, example: "opponent42" })
   displayName!: string;
 
-  @ApiProperty({ description: "Opponent rating at match time", example: 1040 })
+  @ApiProperty({ type: Number, description: "Opponent rating at match time", example: 1040 })
   ratingAtMatch!: number;
 }
 
 export class MeHistoryItemDto {
-  @ApiProperty({ format: "uuid", example: "499abac5-30b8-4a28-bf95-4ef0b3df6098" })
+  @ApiProperty({ type: String, format: "uuid", example: "499abac5-30b8-4a28-bf95-4ef0b3df6098" })
   matchId!: string;
 
-  @ApiProperty({ type: MeHistoryOpponentDto })
+  @ApiProperty({ type: () => MeHistoryOpponentDto })
   opponent!: MeHistoryOpponentDto;
 
-  @ApiProperty({ example: 2 })
+  @ApiProperty({ type: Number, example: 2 })
   scoreA!: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ type: Number, example: 1 })
   scoreB!: number;
 
-  @ApiProperty({ example: true })
+  @ApiProperty({ type: Boolean, example: true })
   isWinner!: boolean;
 
-  @ApiProperty({ example: 16 })
+  @ApiProperty({ type: Number, example: 16 })
   eloDelta!: number;
 
-  @ApiProperty({ format: "date-time", example: "2026-06-08T12:00:00.000Z" })
+  @ApiProperty({ type: Date, format: "date-time", example: "2026-06-08T12:00:00.000Z" })
   endedAt!: Date;
 }
 
 export class MeHistoryResponseDto {
-  @ApiProperty({ type: [MeHistoryItemDto] })
+  @ApiProperty({ type: () => MeHistoryItemDto, isArray: true })
   items!: MeHistoryItemDto[];
 
   @ApiPropertyOptional({
+    type: String,
     description: "Cursor for the next page; omitted on the last page",
     nullable: true,
   })

--- a/apps/api/src/me/dto/me-profile.dto.ts
+++ b/apps/api/src/me/dto/me-profile.dto.ts
@@ -1,24 +1,24 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class MeProfileDto {
-  @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
+  @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   id!: string;
 
-  @ApiProperty({ format: "email", example: "player@example.com" })
+  @ApiProperty({ type: String, format: "email", example: "player@example.com" })
   email!: string;
 
-  @ApiProperty({ example: "player1" })
+  @ApiProperty({ type: String, example: "player1" })
   displayName!: string;
 
   @ApiProperty({ enum: ["player", "admin"], example: "player" })
   role!: "player" | "admin";
 
-  @ApiProperty({ example: 1000 })
+  @ApiProperty({ type: Number, example: 1000 })
   rating!: number;
 
-  @ApiProperty({ example: 0 })
+  @ApiProperty({ type: Number, example: 0 })
   gamesPlayed!: number;
 
-  @ApiProperty({ format: "date-time", example: "2026-06-08T12:00:00.000Z" })
+  @ApiProperty({ type: Date, format: "date-time", example: "2026-06-08T12:00:00.000Z" })
   createdAt!: Date;
 }

--- a/apps/api/src/me/me-history.service.ts
+++ b/apps/api/src/me/me-history.service.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from "@chifoumi/db";
 import { MatchStatus } from "@chifoumi/db";
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { decodeHistoryCursor, encodeHistoryCursor } from "./history-cursor.js";
 
@@ -24,7 +24,7 @@ export type MeHistoryPage = {
 
 @Injectable()
 export class MeHistoryService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async getHistory(userId: string, limit: number, cursor?: string): Promise<MeHistoryPage> {
     const decodedCursor = cursor ? decodeHistoryCursor(cursor) : undefined;
@@ -50,10 +50,11 @@ export class MeHistoryService {
         : {}),
     };
 
+    const safeLimit = Math.trunc(Number(limit));
     const rows = await this.prisma.match.findMany({
       where,
       orderBy: [{ endedAt: "desc" }, { id: "desc" }],
-      take: limit + 1,
+      take: safeLimit + 1,
       include: {
         playerA: { select: { id: true, displayName: true } },
         playerB: { select: { id: true, displayName: true } },
@@ -61,8 +62,8 @@ export class MeHistoryService {
       },
     });
 
-    const hasMore = rows.length > limit;
-    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const hasMore = rows.length > safeLimit;
+    const pageRows = hasMore ? rows.slice(0, safeLimit) : rows;
 
     const items = pageRows.map((match) => this.toHistoryItem(match, userId));
 

--- a/apps/api/src/me/me.controller.ts
+++ b/apps/api/src/me/me.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Req, UseGuards } from "@nestjs/common";
+import { Controller, Get, Inject, Query, Req, UseGuards } from "@nestjs/common";
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -24,8 +24,8 @@ type AuthenticatedRequest = { user: SafeUser };
 @Controller("me")
 export class MeController {
   constructor(
-    private readonly meService: MeService,
-    private readonly meHistoryService: MeHistoryService,
+    @Inject(MeService) private readonly meService: MeService,
+    @Inject(MeHistoryService) private readonly meHistoryService: MeHistoryService,
   ) {}
 
   @UseGuards(JwtAuthGuard)

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { Inject, Injectable, UnauthorizedException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 
 export type MeProfile = {
@@ -13,7 +13,7 @@ export type MeProfile = {
 
 @Injectable()
 export class MeService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async getProfile(userId: string): Promise<MeProfile> {
     const user = await this.prisma.user.findUnique({

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, Header } from "@nestjs/common";
+import { Controller, Get, Header, Inject } from "@nestjs/common";
 import { SkipThrottle } from "@nestjs/throttler";
 import { HttpMetricsMiddleware } from "./http-metrics.middleware.js";
 
 @SkipThrottle({ auth: true, audit: true })
 @Controller("metrics")
 export class MetricsController {
-  constructor(private readonly httpMetrics: HttpMetricsMiddleware) {}
+  constructor(@Inject(HttpMetricsMiddleware) private readonly httpMetrics: HttpMetricsMiddleware) {}
 
   @Get()
   @Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")

--- a/apps/api/src/users/dto/public-profile.dto.ts
+++ b/apps/api/src/users/dto/public-profile.dto.ts
@@ -1,21 +1,25 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class PublicProfileDto {
-  @ApiProperty({ format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
+  @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
   id!: string;
 
-  @ApiProperty({ example: "player1" })
+  @ApiProperty({ type: String, example: "player1" })
   displayName!: string;
 
-  @ApiProperty({ example: 1000 })
+  @ApiProperty({ type: Number, example: 1000 })
   rating!: number;
 
-  @ApiProperty({ example: 0 })
+  @ApiProperty({ type: Number, example: 0 })
   gamesPlayed!: number;
 
-  @ApiProperty({ example: 0, description: "Wins divided by games played, rounded to 2 decimals." })
+  @ApiProperty({
+    type: Number,
+    example: 0,
+    description: "Wins divided by games played, rounded to 2 decimals.",
+  })
   winRate!: number;
 
-  @ApiProperty({ format: "date-time", example: "2026-06-08T12:00:00.000Z" })
+  @ApiProperty({ type: Date, format: "date-time", example: "2026-06-08T12:00:00.000Z" })
   createdAt!: Date;
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseUUIDPipe, UseGuards } from "@nestjs/common";
+import { Controller, Get, Inject, Param, ParseUUIDPipe, UseGuards } from "@nestjs/common";
 import {
   ApiBearerAuth,
   ApiNotFoundResponse,
@@ -18,7 +18,7 @@ import { UsersService } from "./users.service.js";
 @UseGuards(JwtAuthGuard)
 @Controller("users")
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(@Inject(UsersService) private readonly usersService: UsersService) {}
 
   @Get(":id/profile")
   @ApiOperation({

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { Prisma, type User, UserRole } from "@chifoumi/db";
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import type { PublicProfileDto } from "./dto/public-profile.dto.js";
 
@@ -12,7 +12,7 @@ export type SafeUser = {
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   findByEmail(email: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { email } });

--- a/apps/game-service/src/game.gateway.ts
+++ b/apps/game-service/src/game.gateway.ts
@@ -1,3 +1,4 @@
+import { Inject } from "@nestjs/common";
 import {
   type OnGatewayConnection,
   type OnGatewayDisconnect,
@@ -38,12 +39,14 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   server!: Server;
 
   constructor(
-    private readonly wsAuthService: WsAuthService,
-    private readonly redisService: RedisService,
+    @Inject(WsAuthService) private readonly wsAuthService: WsAuthService,
+    @Inject(RedisService) private readonly redisService: RedisService,
+    @Inject(MatchmakingEventsService)
     private readonly matchmakingEventsService: MatchmakingEventsService,
+    @Inject(MatchEventsRelayService)
     private readonly matchEventsRelayService: MatchEventsRelayService,
-    private readonly matchReconnectService: MatchReconnectService,
-    private readonly logger: Logger,
+    @Inject(MatchReconnectService) private readonly matchReconnectService: MatchReconnectService,
+    @Inject(Logger) private readonly logger: Logger,
   ) {}
 
   afterInit(server: Server): void {

--- a/apps/game-service/src/grpc/api-auth.client.ts
+++ b/apps/game-service/src/grpc/api-auth.client.ts
@@ -54,8 +54,8 @@ export class ApiAuthClient implements OnModuleInit {
   constructor(
     @Inject(AUTH_GRPC_CLIENT) private readonly client: ClientGrpc,
     @Inject(GRPC_CLIENT_CONFIG) private readonly grpcConfig: GrpcClientConfig,
-    private readonly cache: AuthTokenCacheService,
-    private readonly metrics: GrpcMetricsService,
+    @Inject(AuthTokenCacheService) private readonly cache: AuthTokenCacheService,
+    @Inject(GrpcMetricsService) private readonly metrics: GrpcMetricsService,
   ) {}
 
   onModuleInit(): void {

--- a/apps/game-service/src/match-session/match-event-bus.ts
+++ b/apps/game-service/src/match-session/match-event-bus.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { RedisService } from "../redis/redis.service.js";
 import {
   type MatchSessionEvent,
@@ -14,7 +14,7 @@ export type SerializedMatchEvent<E extends MatchSessionEvent = MatchSessionEvent
 
 @Injectable()
 export class MatchEventBus {
-  constructor(private readonly redis: RedisService) {}
+  constructor(@Inject(RedisService) private readonly redis: RedisService) {}
 
   async broadcastToMatch<E extends MatchSessionEvent>(
     matchId: string,

--- a/apps/game-service/src/match-session/match-session.service.ts
+++ b/apps/game-service/src/match-session/match-session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { v4 as uuidv4 } from "uuid";
 import { RedisService } from "../redis/redis.service.js";
 import { MatchEventBus } from "./match-event-bus.js";
@@ -38,8 +38,8 @@ export class MatchSessionCorruptStateError extends Error {
 @Injectable()
 export class MatchSessionService {
   constructor(
-    private readonly redis: RedisService,
-    private readonly eventBus: MatchEventBus,
+    @Inject(RedisService) private readonly redis: RedisService,
+    @Inject(MatchEventBus) private readonly eventBus: MatchEventBus,
   ) {}
 
   buildInitialState(

--- a/apps/game-service/src/match/match-disconnect-scheduler.service.ts
+++ b/apps/game-service/src/match/match-disconnect-scheduler.service.ts
@@ -19,7 +19,7 @@ export class MatchDisconnectSchedulerService implements OnModuleInit, OnModuleDe
 
   constructor(
     @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
-    private readonly redisService: RedisService,
+    @Inject(RedisService) private readonly redisService: RedisService,
   ) {}
 
   onModuleInit(): void {

--- a/apps/game-service/src/match/match-disconnect-worker.service.ts
+++ b/apps/game-service/src/match/match-disconnect-worker.service.ts
@@ -13,9 +13,10 @@ export class MatchDisconnectWorkerService implements OnModuleInit, OnModuleDestr
 
   constructor(
     @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
-    private readonly matchPlayService: MatchPlayService,
+    @Inject(MatchPlayService) private readonly matchPlayService: MatchPlayService,
+    @Inject(MatchReconnectMetricsService)
     private readonly matchReconnectMetrics: MatchReconnectMetricsService,
-    private readonly logger: Logger,
+    @Inject(Logger) private readonly logger: Logger,
   ) {}
 
   onModuleInit(): void {

--- a/apps/game-service/src/match/match-events-relay.service.ts
+++ b/apps/game-service/src/match/match-events-relay.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import type { Redis } from "ioredis";
 import type { Server } from "socket.io";
 import type { SerializedMatchEvent } from "../match-session/match-event-bus.js";
@@ -9,7 +9,7 @@ export class MatchEventsRelayService implements OnModuleInit, OnModuleDestroy {
   private server: Server | null = null;
   private subscriber: Redis | null = null;
 
-  constructor(private readonly redisService: RedisService) {}
+  constructor(@Inject(RedisService) private readonly redisService: RedisService) {}
 
   setServer(server: Server): void {
     this.server = server;

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { Logger } from "nestjs-pino";
 import { MatchEventBus } from "../match-session/match-event-bus.js";
 import {
@@ -48,14 +48,16 @@ type RoundResolution = {
 @Injectable()
 export class MatchPlayService {
   constructor(
-    private readonly matchSessionService: MatchSessionService,
-    private readonly eventBus: MatchEventBus,
-    private readonly matchEndedPublisher: MatchEndedPublisher,
+    @Inject(MatchSessionService) private readonly matchSessionService: MatchSessionService,
+    @Inject(MatchEventBus) private readonly eventBus: MatchEventBus,
+    @Inject(MatchEndedPublisher) private readonly matchEndedPublisher: MatchEndedPublisher,
+    @Inject(MatchTimeoutSchedulerService)
     private readonly matchTimeoutScheduler: MatchTimeoutSchedulerService,
-    private readonly metrics: MatchmakingMetricsService,
+    @Inject(MatchmakingMetricsService) private readonly metrics: MatchmakingMetricsService,
+    @Inject(MatchDisconnectSchedulerService)
     private readonly matchDisconnectScheduler: MatchDisconnectSchedulerService,
-    private readonly redisService: RedisService,
-    private readonly logger: Logger,
+    @Inject(RedisService) private readonly redisService: RedisService,
+    @Inject(Logger) private readonly logger: Logger,
   ) {}
 
   async onMatchStarted(state: MatchState): Promise<void> {

--- a/apps/game-service/src/match/match-reconnect.service.ts
+++ b/apps/game-service/src/match/match-reconnect.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { MatchSessionService } from "../match-session/match-session.service.js";
 import {
   type MatchResumedCurrentState,
@@ -13,11 +13,14 @@ import { MatchReconnectMetricsService } from "./match-reconnect-metrics.service.
 @Injectable()
 export class MatchReconnectService {
   constructor(
+    @Inject(forwardRef(() => MatchmakingService))
     private readonly matchmakingService: MatchmakingService,
-    private readonly matchSessionService: MatchSessionService,
+    @Inject(MatchSessionService) private readonly matchSessionService: MatchSessionService,
+    @Inject(MatchDisconnectSchedulerService)
     private readonly matchDisconnectScheduler: MatchDisconnectSchedulerService,
+    @Inject(MatchReconnectMetricsService)
     private readonly matchReconnectMetrics: MatchReconnectMetricsService,
-    private readonly redisService: RedisService,
+    @Inject(RedisService) private readonly redisService: RedisService,
   ) {}
 
   async handleDisconnect(userId: string, socketId: string): Promise<void> {

--- a/apps/game-service/src/match/match-timeout-scheduler.service.ts
+++ b/apps/game-service/src/match/match-timeout-scheduler.service.ts
@@ -16,7 +16,7 @@ export class MatchTimeoutSchedulerService implements OnModuleInit, OnModuleDestr
 
   constructor(
     @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
-    private readonly redisService: RedisService,
+    @Inject(RedisService) private readonly redisService: RedisService,
   ) {}
 
   onModuleInit(): void {

--- a/apps/game-service/src/match/match-timeout-worker.service.ts
+++ b/apps/game-service/src/match/match-timeout-worker.service.ts
@@ -12,8 +12,8 @@ export class MatchTimeoutWorkerService implements OnModuleInit, OnModuleDestroy 
 
   constructor(
     @Inject(REDIS_CONFIG) private readonly redisConfig: RedisConfig,
-    private readonly matchPlayService: MatchPlayService,
-    private readonly logger: Logger,
+    @Inject(MatchPlayService) private readonly matchPlayService: MatchPlayService,
+    @Inject(Logger) private readonly logger: Logger,
   ) {}
 
   onModuleInit(): void {

--- a/apps/game-service/src/matchmaking/matchmaking-events.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-events.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import type { Redis } from "ioredis";
 import type { Server } from "socket.io";
 import { RedisService } from "../redis/redis.service.js";
@@ -9,7 +9,7 @@ export class MatchmakingEventsService implements OnModuleInit, OnModuleDestroy {
   private server: Server | null = null;
   private subscriber: Redis | null = null;
 
-  constructor(private readonly redisService: RedisService) {}
+  constructor(@Inject(RedisService) private readonly redisService: RedisService) {}
 
   setServer(server: Server): void {
     this.server = server;

--- a/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from "@nestjs/common";
 import { Logger } from "nestjs-pino";
 import { v4 as uuidv4 } from "uuid";
 import { MatchPlayService } from "../match/match-play.service.js";
@@ -52,12 +58,12 @@ export class MatchmakingWorkerService implements OnModuleInit, OnModuleDestroy {
   private running = false;
 
   constructor(
-    private readonly redisService: RedisService,
-    private readonly matchmakingService: MatchmakingService,
-    private readonly matchSessionService: MatchSessionService,
-    private readonly matchPlayService: MatchPlayService,
-    private readonly metricsService: MatchmakingMetricsService,
-    private readonly logger: Logger,
+    @Inject(RedisService) private readonly redisService: RedisService,
+    @Inject(MatchmakingService) private readonly matchmakingService: MatchmakingService,
+    @Inject(MatchSessionService) private readonly matchSessionService: MatchSessionService,
+    @Inject(forwardRef(() => MatchPlayService)) private readonly matchPlayService: MatchPlayService,
+    @Inject(MatchmakingMetricsService) private readonly metricsService: MatchmakingMetricsService,
+    @Inject(Logger) private readonly logger: Logger,
   ) {}
 
   onModuleInit(): void {

--- a/apps/game-service/src/matchmaking/matchmaking.gateway.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.gateway.ts
@@ -1,3 +1,4 @@
+import { Inject } from "@nestjs/common";
 import {
   ConnectedSocket,
   MessageBody,
@@ -23,8 +24,8 @@ type PlayPayload = {
 })
 export class MatchmakingGateway {
   constructor(
-    private readonly matchmakingService: MatchmakingService,
-    private readonly matchPlayService: MatchPlayService,
+    @Inject(MatchmakingService) private readonly matchmakingService: MatchmakingService,
+    @Inject(MatchPlayService) private readonly matchPlayService: MatchPlayService,
   ) {}
 
   @SubscribeMessage("joinQueue")

--- a/apps/game-service/src/matchmaking/matchmaking.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { RedisService } from "../redis/redis.service.js";
 import {
   MATCH_BY_USER_PREFIX,
@@ -20,8 +20,8 @@ export type JoinQueueResult =
 @Injectable()
 export class MatchmakingService {
   constructor(
-    private readonly redisService: RedisService,
-    private readonly ratingService: RatingService,
+    @Inject(RedisService) private readonly redisService: RedisService,
+    @Inject(RatingService) private readonly ratingService: RatingService,
   ) {}
 
   async joinQueue(userId: string, displayName: string): Promise<JoinQueueResult> {

--- a/apps/game-service/src/matchmaking/rating.service.ts
+++ b/apps/game-service/src/matchmaking/rating.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { RedisService } from "../redis/redis.service.js";
 import { DEFAULT_RATING, USER_RATING_PREFIX } from "./matchmaking.constants.js";
 
 @Injectable()
 export class RatingService {
-  constructor(private readonly redisService: RedisService) {}
+  constructor(@Inject(RedisService) private readonly redisService: RedisService) {}
 
   async getRating(userId: string): Promise<number> {
     const stored = await this.redisService.get(`${USER_RATING_PREFIX}${userId}`);

--- a/apps/game-service/src/metrics/metrics.controller.ts
+++ b/apps/game-service/src/metrics/metrics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Header } from "@nestjs/common";
+import { Controller, Get, Header, Inject } from "@nestjs/common";
 import { GrpcMetricsService } from "../grpc/grpc-metrics.service.js";
 import { MatchReconnectMetricsService } from "../match/match-reconnect-metrics.service.js";
 import { MatchmakingMetricsService } from "../matchmaking/matchmaking-metrics.service.js";
@@ -6,8 +6,10 @@ import { MatchmakingMetricsService } from "../matchmaking/matchmaking-metrics.se
 @Controller("metrics")
 export class MetricsController {
   constructor(
+    @Inject(MatchmakingMetricsService)
     private readonly matchmakingMetricsService: MatchmakingMetricsService,
-    private readonly grpcMetricsService: GrpcMetricsService,
+    @Inject(GrpcMetricsService) private readonly grpcMetricsService: GrpcMetricsService,
+    @Inject(MatchReconnectMetricsService)
     private readonly matchReconnectMetricsService: MatchReconnectMetricsService,
   ) {}
 

--- a/apps/game-service/src/testing/test-api-auth.client.ts
+++ b/apps/game-service/src/testing/test-api-auth.client.ts
@@ -1,5 +1,5 @@
 import type { VerifyTokenResponse } from "@chifoumi/proto";
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { JwtService, TokenExpiredError } from "@nestjs/jwt";
 import { RedisService } from "../redis/redis.service.js";
 import { testJwtKeys } from "./issue-test-access-token.js";
@@ -18,7 +18,7 @@ export class TestApiAuthClient {
     verifyOptions: { algorithms: ["RS256"] },
   });
 
-  constructor(private readonly redisService: RedisService) {}
+  constructor(@Inject(RedisService) private readonly redisService: RedisService) {}
 
   async verifyToken(token: string): Promise<VerifyTokenResponse> {
     if (token.trim().length === 0) {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
     "typecheck": "prisma generate && tsc -p tsconfig.json",
     "seed": "tsx prisma/seed.ts",
     "seed:bench": "tsx scripts/seed-bench.ts",
+    "seed:demo": "tsx scripts/seed-demo.ts",
     "explain:queries": "tsx scripts/explain-queries.ts",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },

--- a/packages/db/scripts/seed-demo.ts
+++ b/packages/db/scripts/seed-demo.ts
@@ -375,7 +375,16 @@ async function main(): Promise<void> {
 
   if (existing) {
     console.log("Deleting existing demo data…");
-    await prisma.user.deleteMany({ where: { email: { endsWith: DEMO_DOMAIN } } });
+    // Must delete matches before users (no onDelete:Cascade on Match→User FK)
+    const demoUsers = await prisma.user.findMany({
+      where: { email: { endsWith: DEMO_DOMAIN } },
+      select: { id: true },
+    });
+    const ids = demoUsers.map((u) => u.id);
+    await prisma.match.deleteMany({
+      where: { OR: [{ playerAId: { in: ids } }, { playerBId: { in: ids } }] },
+    });
+    await prisma.user.deleteMany({ where: { id: { in: ids } } });
   }
 
   console.log("Hashing demo password…");

--- a/packages/db/scripts/seed-demo.ts
+++ b/packages/db/scripts/seed-demo.ts
@@ -7,6 +7,7 @@ import { hashPassword } from "../src/seed/password.js";
 const FORCE = process.argv.includes("--force");
 const DEMO_PASSWORD = "Demo1234!";
 const DEMO_DOMAIN = "@chifoumi.demo";
+const ADMIN_EMAIL = "admin@chifoumi.local";
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) throw new Error("DATABASE_URL is required");
@@ -360,6 +361,73 @@ const MATCHES: MatchDef[] = [
   },
 ];
 
+// Admin is index 8 in the combined player arrays (fetched at runtime).
+// Round winner rules: rock>scissors, scissors>paper, paper>rock.
+const ADMIN_MATCHES: MatchDef[] = [
+  {
+    a: 8,
+    b: 7,
+    daysAgo: 19,
+    rounds: [
+      // admin beats birdie 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 8,
+    b: 4,
+    daysAgo: 14,
+    rounds: [
+      // admin beats zangief 2-1
+      { moveA: M.rock, moveB: M.scissors }, //   A wins
+      { moveA: M.scissors, moveB: M.rock }, //   B wins (rock>scissors)
+      { moveA: M.paper, moveB: M.rock }, //   A wins → 2-1
+    ],
+  },
+  {
+    a: 5,
+    b: 8,
+    daysAgo: 10,
+    rounds: [
+      // blanka beats admin 2-0
+      { moveA: M.rock, moveB: M.scissors }, //   A(blanka) wins
+      { moveA: M.paper, moveB: M.rock }, //   A(blanka) wins
+    ],
+  },
+  {
+    a: 8,
+    b: 3,
+    daysAgo: 6,
+    rounds: [
+      // chunli beats admin 2-1
+      { moveA: M.rock, moveB: M.scissors }, //   A(admin) wins
+      { moveA: M.paper, moveB: M.scissors }, //   B wins (scissors>paper)
+      { moveA: M.rock, moveB: M.paper }, //   B wins (paper>rock) → 1-2
+    ],
+  },
+  {
+    a: 2,
+    b: 8,
+    daysAgo: 3,
+    rounds: [
+      // ken beats admin 2-0
+      { moveA: M.paper, moveB: M.rock }, //   A(ken) wins
+      { moveA: M.scissors, moveB: M.paper }, //   A(ken) wins
+    ],
+  },
+  {
+    a: 8,
+    b: 6,
+    daysAgo: 0,
+    rounds: [
+      // admin beats dan 2-0 (today)
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+];
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -385,6 +453,17 @@ async function main(): Promise<void> {
       where: { OR: [{ playerAId: { in: ids } }, { playerBId: { in: ids } }] },
     });
     await prisma.user.deleteMany({ where: { id: { in: ids } } });
+    // Reset admin ELO (admin matches were deleted above since they all involve demo players)
+    const adminUser = await prisma.user.findUnique({
+      where: { email: ADMIN_EMAIL },
+      select: { id: true },
+    });
+    if (adminUser) {
+      await prisma.eloRating.update({
+        where: { userId: adminUser.id },
+        data: { rating: 1000, gamesPlayed: 0 },
+      });
+    }
   }
 
   console.log("Hashing demo password…");
@@ -406,20 +485,35 @@ async function main(): Promise<void> {
     userIds.push(user.id);
   }
 
-  // Live ELO state (updated as matches are processed in chronological order)
-  const ratings = new Array<number>(PLAYERS.length).fill(1000);
-  const games = new Array<number>(PLAYERS.length).fill(0);
+  // Fetch admin — must exist (run admin seed first)
+  const adminUser = await prisma.user.findUnique({
+    where: { email: ADMIN_EMAIL },
+    select: { id: true, eloRating: { select: { rating: true } } },
+  });
+  if (!adminUser) throw new Error(`Admin user not found — run: pnpm --filter @chifoumi/db seed`);
 
-  console.log(`Creating ${MATCHES.length} demo matches…`);
+  // allUserIds[0..7] = demo players, allUserIds[8] = admin
+  const allUserIds = [...userIds, adminUser.id];
+  const allRatings = [
+    ...new Array<number>(PLAYERS.length).fill(1000),
+    adminUser.eloRating?.rating ?? 1000,
+  ];
+  const allGames = new Array<number>(PLAYERS.length + 1).fill(0);
+  const allWins = new Array<number>(PLAYERS.length + 1).fill(0);
+
+  // Sort all matches oldest-first so ELO progresses chronologically
+  const allMatchDefs = [...MATCHES, ...ADMIN_MATCHES].sort((a, b) => b.daysAgo - a.daysAgo);
+  console.log(
+    `Creating ${allMatchDefs.length} matches (${MATCHES.length} demo + ${ADMIN_MATCHES.length} admin)…`,
+  );
   const now = Date.now();
 
-  for (const def of MATCHES) {
-    const playerAId = userIds[def.a];
-    const playerBId = userIds[def.b];
-    const ratingA = ratings[def.a];
-    const ratingB = ratings[def.b];
+  for (const def of allMatchDefs) {
+    const playerAId = allUserIds[def.a];
+    const playerBId = allUserIds[def.b];
+    const ratingA = allRatings[def.a];
+    const ratingB = allRatings[def.b];
 
-    // Score from round results
     let scoreA = 0;
     let scoreB = 0;
     for (const r of def.rounds) {
@@ -487,69 +581,48 @@ async function main(): Promise<void> {
       },
     });
 
-    ratings[def.a] += deltaA;
-    ratings[def.b] += deltaB;
-    games[def.a]++;
-    games[def.b]++;
+    allRatings[def.a] += deltaA;
+    allRatings[def.b] += deltaB;
+    allGames[def.a]++;
+    allGames[def.b]++;
+    if (outcome === "a") allWins[def.a]++;
+    else if (outcome === "b") allWins[def.b]++;
   }
 
   console.log("Flushing ELO ratings…");
   for (let i = 0; i < PLAYERS.length; i++) {
     await prisma.eloRating.update({
-      where: { userId: userIds[i] },
-      data: { rating: ratings[i], gamesPlayed: games[i] },
+      where: { userId: allUserIds[i] },
+      data: { rating: allRatings[i], gamesPlayed: allGames[i] },
     });
   }
+  await prisma.eloRating.update({
+    where: { userId: adminUser.id },
+    data: { rating: allRatings[PLAYERS.length], gamesPlayed: allGames[PLAYERS.length] },
+  });
+
+  const allPlayerNames = [...PLAYERS.map((p) => p.displayName), "admin"];
+  const leaderboard = allPlayerNames
+    .map((name, i) => ({
+      name,
+      rating: allRatings[i],
+      g: allGames[i],
+      w: allWins[i],
+      l: allGames[i] - allWins[i],
+    }))
+    .sort((a, b) => b.rating - a.rating);
 
   console.log(`
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Demo seed complete
-  Password (all demo accounts): ${DEMO_PASSWORD}
+  Demo password  : ${DEMO_PASSWORD}
+  Admin          : ${ADMIN_EMAIL} (existing password)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Rank  Player            ELO    G  W  L
 `);
-
-  // Print leaderboard sorted by rating desc
-  const entries = PLAYERS.map((p, i) => ({
-    name: p.displayName,
-    email: p.email,
-    rating: ratings[i],
-    g: games[i],
-  }));
-  entries.sort((x, y) => y.rating - x.rating);
-  entries.forEach((e, rank) => {
-    const wins = MATCHES.filter(
-      (m) =>
-        (m.a === PLAYERS.findIndex((p) => p.displayName === e.name) &&
-          ["a"].includes(
-            (() => {
-              let sA = 0,
-                sB = 0;
-              for (const r of m.rounds) {
-                const w = resolveRound(r.moveA, r.moveB);
-                if (w === RoundWinner.a) sA++;
-                else if (w === RoundWinner.b) sB++;
-              }
-              return sA > sB ? "a" : "b";
-            })(),
-          )) ||
-        (m.b === PLAYERS.findIndex((p) => p.displayName === e.name) &&
-          ["b"].includes(
-            (() => {
-              let sA = 0,
-                sB = 0;
-              for (const r of m.rounds) {
-                const w = resolveRound(r.moveA, r.moveB);
-                if (w === RoundWinner.a) sA++;
-                else if (w === RoundWinner.b) sB++;
-              }
-              return sA > sB ? "a" : "b";
-            })(),
-          )),
-    ).length;
-    const losses = e.g - wins;
+  leaderboard.forEach((e, rank) => {
     console.log(
-      `  ${String(rank + 1).padStart(4)}  ${e.name.padEnd(16)}  ${String(e.rating).padStart(4)}   ${e.g}  ${wins}  ${losses}`,
+      `  ${String(rank + 1).padStart(4)}  ${e.name.padEnd(16)}  ${String(e.rating).padStart(4)}   ${e.g}  ${e.w}  ${e.l}`,
     );
   });
   console.log("");

--- a/packages/db/scripts/seed-demo.ts
+++ b/packages/db/scripts/seed-demo.ts
@@ -1,0 +1,556 @@
+import "dotenv/config";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { MatchStatus, Move, PrismaClient, RoundWinner, UserRole } from "@prisma/client";
+import { hashPassword } from "../src/seed/password.js";
+
+const FORCE = process.argv.includes("--force");
+const DEMO_PASSWORD = "Demo1234!";
+const DEMO_DOMAIN = "@chifoumi.demo";
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error("DATABASE_URL is required");
+
+const prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) });
+
+// ── ELO ──────────────────────────────────────────────────────────────────────
+
+function eloDeltas(
+  ratingA: number,
+  ratingB: number,
+  outcome: "a" | "b" | "draw",
+): { deltaA: number; deltaB: number } {
+  const K = 32;
+  const ea = 1 / (1 + 10 ** ((ratingB - ratingA) / 400));
+  const saA = outcome === "a" ? 1 : outcome === "draw" ? 0.5 : 0;
+  const deltaA = Math.round(K * (saA - ea));
+  return { deltaA, deltaB: -deltaA };
+}
+
+// ── Move helpers ─────────────────────────────────────────────────────────────
+
+function resolveRound(moveA: Move, moveB: Move): RoundWinner {
+  if (moveA === moveB) return RoundWinner.draw;
+  if (
+    (moveA === Move.rock && moveB === Move.scissors) ||
+    (moveA === Move.scissors && moveB === Move.paper) ||
+    (moveA === Move.paper && moveB === Move.rock)
+  )
+    return RoundWinner.a;
+  return RoundWinner.b;
+}
+
+function fakeCommit(move: Move, nonce: string): string {
+  return createHash("sha256").update(`${move}:${nonce}`).digest("hex");
+}
+
+function randomHex(): string {
+  return randomBytes(16).toString("hex");
+}
+
+// ── Player & match data ───────────────────────────────────────────────────────
+
+const PLAYERS = [
+  { email: `ryu${DEMO_DOMAIN}`, displayName: "ryu_sensei" }, // 0  top player
+  { email: `sakura${DEMO_DOMAIN}`, displayName: "sakura_bloom" }, // 1
+  { email: `ken${DEMO_DOMAIN}`, displayName: "ken_masters" }, // 2
+  { email: `chunli${DEMO_DOMAIN}`, displayName: "chunli_kicks" }, // 3
+  { email: `zangief${DEMO_DOMAIN}`, displayName: "zangief_crush" }, // 4
+  { email: `blanka${DEMO_DOMAIN}`, displayName: "blanka_wild" }, // 5
+  { email: `dan${DEMO_DOMAIN}`, displayName: "dan_hibiki" }, // 6
+  { email: `birdie${DEMO_DOMAIN}`, displayName: "birdie_spike" }, // 7  bottom
+];
+
+type RoundDef = { moveA: Move; moveB: Move };
+type MatchDef = { a: number; b: number; daysAgo: number; rounds: RoundDef[] };
+
+const M = Move;
+
+// Each 2-round match produces a 2-0; 3-round matches produce a 2-1.
+// Round winner rules: rock>scissors, scissors>paper, paper>rock.
+const MATCHES: MatchDef[] = [
+  // ── Week 4 ───────────────────────────────────────────────────────────────
+  {
+    a: 0,
+    b: 7,
+    daysAgo: 28,
+    rounds: [
+      // ryu beats birdie 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 1,
+    b: 6,
+    daysAgo: 27,
+    rounds: [
+      // sakura beats dan 2-0
+      { moveA: M.scissors, moveB: M.paper },
+      { moveA: M.rock, moveB: M.scissors },
+    ],
+  },
+  {
+    a: 2,
+    b: 7,
+    daysAgo: 26,
+    rounds: [
+      // ken beats birdie 2-0
+      { moveA: M.paper, moveB: M.rock },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 0,
+    b: 6,
+    daysAgo: 25,
+    rounds: [
+      // ryu beats dan 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 3,
+    b: 5,
+    daysAgo: 24,
+    rounds: [
+      // chunli beats blanka 2-0
+      { moveA: M.paper, moveB: M.rock },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  // ── Week 3 ───────────────────────────────────────────────────────────────
+  {
+    a: 1,
+    b: 4,
+    daysAgo: 23,
+    rounds: [
+      // sakura beats zangief 2-0
+      { moveA: M.scissors, moveB: M.paper },
+      { moveA: M.rock, moveB: M.scissors },
+    ],
+  },
+  {
+    a: 2,
+    b: 6,
+    daysAgo: 22,
+    rounds: [
+      // ken beats dan 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 0,
+    b: 5,
+    daysAgo: 21,
+    rounds: [
+      // ryu beats blanka 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 4,
+    b: 7,
+    daysAgo: 20,
+    rounds: [
+      // zangief beats birdie 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 3,
+    b: 6,
+    daysAgo: 19,
+    rounds: [
+      // chunli beats dan 2-0
+      { moveA: M.paper, moveB: M.rock },
+      { moveA: M.rock, moveB: M.scissors },
+    ],
+  },
+  // ── Week 2 ───────────────────────────────────────────────────────────────
+  {
+    a: 1,
+    b: 5,
+    daysAgo: 18,
+    rounds: [
+      // sakura beats blanka 2-0
+      { moveA: M.scissors, moveB: M.paper },
+      { moveA: M.rock, moveB: M.scissors },
+    ],
+  },
+  {
+    a: 0,
+    b: 2,
+    daysAgo: 17,
+    rounds: [
+      // ryu beats ken 2-1 (close!)
+      { moveA: M.rock, moveB: M.paper }, //   B wins round
+      { moveA: M.scissors, moveB: M.paper }, //   A wins round (scissors>paper)
+      { moveA: M.paper, moveB: M.rock }, //   A wins round → 2-1
+    ],
+  },
+  {
+    a: 5,
+    b: 7,
+    daysAgo: 16,
+    rounds: [
+      // blanka beats birdie 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 2,
+    b: 4,
+    daysAgo: 15,
+    rounds: [
+      // ken beats zangief 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 1,
+    b: 3,
+    daysAgo: 14,
+    rounds: [
+      // sakura beats chunli 2-1
+      { moveA: M.rock, moveB: M.scissors }, //   A wins round
+      { moveA: M.paper, moveB: M.scissors }, //   B wins round (scissors>paper)
+      { moveA: M.scissors, moveB: M.paper }, //   A wins round → 2-1
+    ],
+  },
+  // ── Week 1 ───────────────────────────────────────────────────────────────
+  {
+    a: 0,
+    b: 3,
+    daysAgo: 13,
+    rounds: [
+      // ryu beats chunli 2-0
+      { moveA: M.scissors, moveB: M.paper },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 6,
+    b: 7,
+    daysAgo: 12,
+    rounds: [
+      // dan beats birdie 2-0 (dan's only win!)
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 4,
+    b: 5,
+    daysAgo: 11,
+    rounds: [
+      // zangief beats blanka 2-0
+      { moveA: M.paper, moveB: M.rock },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 0,
+    b: 1,
+    daysAgo: 10,
+    rounds: [
+      // ryu beats sakura 2-1 (rivalry!)
+      { moveA: M.scissors, moveB: M.paper }, //   A wins round
+      { moveA: M.paper, moveB: M.scissors }, //   B wins round (scissors>paper)
+      { moveA: M.rock, moveB: M.scissors }, //   A wins round → 2-1
+    ],
+  },
+  {
+    a: 2,
+    b: 3,
+    daysAgo: 9,
+    rounds: [
+      // ken beats chunli 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 1,
+    b: 2,
+    daysAgo: 8,
+    rounds: [
+      // sakura beats ken 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 0,
+    b: 4,
+    daysAgo: 7,
+    rounds: [
+      // ryu beats zangief 2-0
+      { moveA: M.scissors, moveB: M.paper },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 3,
+    b: 7,
+    daysAgo: 6,
+    rounds: [
+      // chunli beats birdie 2-0
+      { moveA: M.paper, moveB: M.rock },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 5,
+    b: 6,
+    daysAgo: 5,
+    rounds: [
+      // blanka beats dan 2-0
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.paper, moveB: M.rock },
+    ],
+  },
+  {
+    a: 0,
+    b: 2,
+    daysAgo: 4,
+    rounds: [
+      // ryu beats ken 2-1 (rematch)
+      { moveA: M.rock, moveB: M.scissors }, //   A wins round
+      { moveA: M.scissors, moveB: M.rock }, //   B wins round (rock>scissors)
+      { moveA: M.paper, moveB: M.rock }, //   A wins round → 2-1
+    ],
+  },
+  {
+    a: 1,
+    b: 0,
+    daysAgo: 3,
+    rounds: [
+      // sakura beats ryu 2-0 (revenge!)
+      { moveA: M.paper, moveB: M.rock },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+  {
+    a: 2,
+    b: 1,
+    daysAgo: 2,
+    rounds: [
+      // ken beats sakura 2-1
+      { moveA: M.rock, moveB: M.scissors }, //   A wins round
+      { moveA: M.paper, moveB: M.scissors }, //   B wins round (scissors>paper)
+      { moveA: M.scissors, moveB: M.paper }, //   A wins round → 2-1
+    ],
+  },
+  {
+    a: 0,
+    b: 1,
+    daysAgo: 1,
+    rounds: [
+      // ryu beats sakura 2-0 (final showdown)
+      { moveA: M.rock, moveB: M.scissors },
+      { moveA: M.scissors, moveB: M.paper },
+    ],
+  },
+];
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const existing = await prisma.user.findFirst({
+    where: { email: `ryu${DEMO_DOMAIN}` },
+    select: { id: true },
+  });
+
+  if (existing && !FORCE) {
+    console.log("Demo data already exists. Run with --force to recreate it.");
+    return;
+  }
+
+  if (existing) {
+    console.log("Deleting existing demo data…");
+    await prisma.user.deleteMany({ where: { email: { endsWith: DEMO_DOMAIN } } });
+  }
+
+  console.log("Hashing demo password…");
+  const passwordHash = await hashPassword(DEMO_PASSWORD);
+
+  console.log(`Creating ${PLAYERS.length} demo players…`);
+  const userIds: string[] = [];
+  for (const p of PLAYERS) {
+    const user = await prisma.user.create({
+      data: {
+        email: p.email,
+        displayName: p.displayName,
+        passwordHash,
+        role: UserRole.player,
+        eloRating: { create: { rating: 1000, gamesPlayed: 0 } },
+      },
+      select: { id: true },
+    });
+    userIds.push(user.id);
+  }
+
+  // Live ELO state (updated as matches are processed in chronological order)
+  const ratings = new Array<number>(PLAYERS.length).fill(1000);
+  const games = new Array<number>(PLAYERS.length).fill(0);
+
+  console.log(`Creating ${MATCHES.length} demo matches…`);
+  const now = Date.now();
+
+  for (const def of MATCHES) {
+    const playerAId = userIds[def.a];
+    const playerBId = userIds[def.b];
+    const ratingA = ratings[def.a];
+    const ratingB = ratings[def.b];
+
+    // Score from round results
+    let scoreA = 0;
+    let scoreB = 0;
+    for (const r of def.rounds) {
+      const w = resolveRound(r.moveA, r.moveB);
+      if (w === RoundWinner.a) scoreA++;
+      else if (w === RoundWinner.b) scoreB++;
+    }
+
+    const outcome = scoreA > scoreB ? "a" : scoreB > scoreA ? "b" : "draw";
+    const winnerId = outcome === "a" ? playerAId : outcome === "b" ? playerBId : null;
+    const { deltaA, deltaB } = eloDeltas(ratingA, ratingB, outcome);
+
+    const matchDurationMs = 3 * 60_000 + Math.floor(Math.random() * 7 * 60_000);
+    const endedAt = new Date(now - def.daysAgo * 24 * 60 * 60_000);
+    const startedAt = new Date(endedAt.getTime() - matchDurationMs);
+    const roundSlice = Math.floor(matchDurationMs / def.rounds.length);
+
+    await prisma.match.create({
+      data: {
+        id: randomUUID(),
+        playerAId,
+        playerBId,
+        winnerId,
+        scoreA,
+        scoreB,
+        startedAt,
+        endedAt,
+        status: MatchStatus.ended,
+        rounds: {
+          create: def.rounds.map((r, i) => {
+            const nonceA = randomHex();
+            const nonceB = randomHex();
+            return {
+              id: randomUUID(),
+              roundNumber: i + 1,
+              moveA: r.moveA,
+              moveB: r.moveB,
+              nonceA,
+              nonceB,
+              commitA: fakeCommit(r.moveA, nonceA),
+              commitB: fakeCommit(r.moveB, nonceB),
+              winner: resolveRound(r.moveA, r.moveB),
+              resolvedAt: new Date(startedAt.getTime() + (i + 1) * roundSlice),
+            };
+          }),
+        },
+        eloHistory: {
+          create: [
+            {
+              id: randomUUID(),
+              userId: playerAId,
+              ratingBefore: ratingA,
+              ratingAfter: ratingA + deltaA,
+              delta: deltaA,
+            },
+            {
+              id: randomUUID(),
+              userId: playerBId,
+              ratingBefore: ratingB,
+              ratingAfter: ratingB + deltaB,
+              delta: deltaB,
+            },
+          ],
+        },
+      },
+    });
+
+    ratings[def.a] += deltaA;
+    ratings[def.b] += deltaB;
+    games[def.a]++;
+    games[def.b]++;
+  }
+
+  console.log("Flushing ELO ratings…");
+  for (let i = 0; i < PLAYERS.length; i++) {
+    await prisma.eloRating.update({
+      where: { userId: userIds[i] },
+      data: { rating: ratings[i], gamesPlayed: games[i] },
+    });
+  }
+
+  console.log(`
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Demo seed complete
+  Password (all demo accounts): ${DEMO_PASSWORD}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Rank  Player            ELO    G  W  L
+`);
+
+  // Print leaderboard sorted by rating desc
+  const entries = PLAYERS.map((p, i) => ({
+    name: p.displayName,
+    email: p.email,
+    rating: ratings[i],
+    g: games[i],
+  }));
+  entries.sort((x, y) => y.rating - x.rating);
+  entries.forEach((e, rank) => {
+    const wins = MATCHES.filter(
+      (m) =>
+        (m.a === PLAYERS.findIndex((p) => p.displayName === e.name) &&
+          ["a"].includes(
+            (() => {
+              let sA = 0,
+                sB = 0;
+              for (const r of m.rounds) {
+                const w = resolveRound(r.moveA, r.moveB);
+                if (w === RoundWinner.a) sA++;
+                else if (w === RoundWinner.b) sB++;
+              }
+              return sA > sB ? "a" : "b";
+            })(),
+          )) ||
+        (m.b === PLAYERS.findIndex((p) => p.displayName === e.name) &&
+          ["b"].includes(
+            (() => {
+              let sA = 0,
+                sB = 0;
+              for (const r of m.rounds) {
+                const w = resolveRound(r.moveA, r.moveB);
+                if (w === RoundWinner.a) sA++;
+                else if (w === RoundWinner.b) sB++;
+              }
+              return sA > sB ? "a" : "b";
+            })(),
+          )),
+    ).length;
+    const losses = e.g - wins;
+    console.log(
+      `  ${String(rank + 1).padStart(4)}  ${e.name.padEnd(16)}  ${String(e.rating).padStart(4)}   ${e.g}  ${wins}  ${losses}`,
+    );
+  });
+  console.log("");
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary

- **fix(api):** coerce `limit` query param en `int` avant `prisma.match.findMany` (historique 500)
- **fix(api,game-service):** ajout de `@Inject()` sur tous les constructeurs — workaround pour le bug esbuild/tsx `emitDecoratorMetadata` qui empêchait `@Type(() => Number)` de fonctionner au runtime
- **fix(api):** corrections de types sur les DTOs (match-audit, leaderboard, me, users)
- **feat(db):** seed démo — 8 joueurs (Street Fighter), 34 matchs terminés (28 + 6 admin), ELO calculé chronologiquement, commit-reveal complet

## Seed démo

```bash
# Premier lancement
DATABASE_URL="postgresql://app:chifoumi_dev@localhost:5432/chifoumi" \
  pnpm --filter @chifoumi/db seed:demo

# Réinitialiser
DATABASE_URL="..." pnpm --filter @chifoumi/db seed:demo -- --force
```

Mot de passe commun : `Demo1234!`

## Test plan

- [ ] `pnpm biome check` vert
- [ ] `pnpm -r typecheck` vert
- [ ] GET /leaderboard retourne 200 avec les 9 joueurs triés par ELO
- [ ] Profil → Historique ne retourne plus 500 pour aucun compte démo
- [ ] Admin connecté : historique affiche 6 matchs

🤖 Generated with [Claude Code](https://claude.com/claude-code)