### PR TITLE
feat(front): add forgot/reset password pages and flow (US-046)

### DIFF
--- a/apps/front/src/App.tsx
+++ b/apps/front/src/App.tsx
@@ -3,12 +3,14 @@ import { useAuth } from "./auth/AuthContext.js";
 import { Header } from "./components/Header.js";
 import { GuestRoute, ProtectedRoute } from "./components/ProtectedRoute.js";
 import { GameSocketProvider } from "./game/GameSocketContext.js";
+import { ForgotPasswordPage } from "./pages/ForgotPasswordPage.js";
 import { LeaderboardPage } from "./pages/LeaderboardPage.js";
 import { LobbyPage } from "./pages/LobbyPage.js";
 import { LoginPage } from "./pages/LoginPage.js";
 import { MatchPage } from "./pages/MatchPage.js";
 import { ProfilePage } from "./pages/ProfilePage.js";
 import { RegisterPage } from "./pages/RegisterPage.js";
+import { ResetPasswordPage } from "./pages/ResetPasswordPage.js";
 import "./App.css";
 
 function CatchAllRedirect() {
@@ -38,6 +40,8 @@ export function App() {
           <Route element={<GuestRoute />}>
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+            <Route path="/reset-password" element={<ResetPasswordPage />} />
           </Route>
 
           <Route path="/leaderboard" element={<LeaderboardPage />} />

--- a/apps/front/src/api/apiClient.test.ts
+++ b/apps/front/src/api/apiClient.test.ts
@@ -3,6 +3,7 @@ import {
   ApiError,
   apiRequest,
   configureApiClient,
+  forgotPassword,
   formatApiError,
   refreshTokens,
 } from "./apiClient.js";
@@ -81,6 +82,21 @@ describe("apiRequest", () => {
 
     await expect(apiRequest("/users/missing/profile")).rejects.toEqual(
       new ApiError("USER_NOT_FOUND", 404),
+    );
+  });
+
+  it("resolves successful empty 200 responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(forgotPassword("player@example.com")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/forgot-password"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ email: "player@example.com" }),
+      }),
     );
   });
 });

--- a/apps/front/src/api/apiClient.ts
+++ b/apps/front/src/api/apiClient.ts
@@ -120,6 +120,20 @@ export async function apiRequest<T>(path: string, init: RequestInit = {}): Promi
   return (await response.json()) as T;
 }
 
+export async function forgotPassword(email: string): Promise<void> {
+  await apiRequest<void>("/auth/forgot-password", {
+    method: "POST",
+    body: JSON.stringify({ email }),
+  });
+}
+
+export async function resetPassword(token: string, newPassword: string): Promise<void> {
+  await apiRequest<void>("/auth/reset-password", {
+    method: "POST",
+    body: JSON.stringify({ token, newPassword }),
+  });
+}
+
 export async function refreshTokens(refreshToken: string): Promise<RefreshResponse> {
   const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
     method: "POST",

--- a/apps/front/src/api/apiClient.ts
+++ b/apps/front/src/api/apiClient.ts
@@ -117,7 +117,8 @@ export async function apiRequest<T>(path: string, init: RequestInit = {}): Promi
     return undefined as T;
   }
 
-  return (await response.json()) as T;
+  const text = await response.text();
+  return (text ? JSON.parse(text) : undefined) as T;
 }
 
 export async function forgotPassword(email: string): Promise<void> {

--- a/apps/front/src/pages/ForgotPasswordPage.tsx
+++ b/apps/front/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,73 @@
+import { type FormEvent, useState } from "react";
+import { Link } from "react-router-dom";
+import { forgotPassword } from "../api/apiClient.js";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      await forgotPassword(email);
+    } catch {
+      // Anti-enumeration: never reveal whether the email exists or any
+      // technical detail — always show the same generic confirmation.
+    } finally {
+      setIsSubmitting(false);
+      setIsSubmitted(true);
+    }
+  }
+
+  return (
+    <div className="page">
+      <section className="panel" aria-labelledby="forgot-password-title">
+        <h1 id="forgot-password-title" className="title">
+          Mot de passe oublié
+        </h1>
+
+        {isSubmitted ? (
+          <>
+            <output className="subtitle">
+              Si un compte est associé à cette adresse, un e-mail contenant un lien de
+              réinitialisation vient d'être envoyé.
+            </output>
+            <p className="subtitle">
+              <Link to="/login">Retour à la connexion</Link>
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="subtitle">
+              Saisissez votre adresse e-mail pour recevoir un lien de réinitialisation.
+            </p>
+
+            <form className="form" onSubmit={(event) => void handleSubmit(event)}>
+              <label className="field">
+                <span>Email</span>
+                <input
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                />
+              </label>
+
+              <button type="submit" className="button" disabled={isSubmitting}>
+                {isSubmitting ? "Envoi…" : "Envoyer le lien"}
+              </button>
+            </form>
+
+            <p className="subtitle">
+              <Link to="/login">Retour à la connexion</Link>
+            </p>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/front/src/pages/LoginPage.tsx
+++ b/apps/front/src/pages/LoginPage.tsx
@@ -12,10 +12,10 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const locationState = location.state as { from?: string; notice?: string } | null;
   const redirectTo =
-    (location.state as { from?: string } | null)?.from && typeof location.state === "object"
-      ? (location.state as { from?: string }).from
-      : "/lobby";
+    locationState?.from && typeof location.state === "object" ? locationState.from : "/lobby";
+  const notice = locationState?.notice ?? null;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -45,6 +45,8 @@ export function LoginPage() {
         <p className="subtitle">
           Pas encore de compte ? <Link to="/register">Créer un compte</Link>
         </p>
+
+        {notice ? <output className="subtitle">{notice}</output> : null}
 
         <form className="form" onSubmit={(event) => void handleSubmit(event)}>
           <label className="field">
@@ -80,6 +82,10 @@ export function LoginPage() {
             {isSubmitting ? "Connexion…" : "Se connecter"}
           </button>
         </form>
+
+        <p className="subtitle">
+          <Link to="/forgot-password">Mot de passe oublié ?</Link>
+        </p>
       </section>
     </div>
   );

--- a/apps/front/src/pages/ResetPasswordPage.tsx
+++ b/apps/front/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,112 @@
+import { type FormEvent, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { ApiError, resetPassword } from "../api/apiClient.js";
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    if (!token) {
+      setError("Lien de réinitialisation invalide ou incomplet.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError("Les deux mots de passe ne correspondent pas.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await resetPassword(token, password);
+      navigate("/login", {
+        replace: true,
+        state: { notice: "Mot de passe réinitialisé. Vous pouvez maintenant vous connecter." },
+      });
+    } catch (caught) {
+      if (caught instanceof ApiError && caught.status >= 400 && caught.status < 500) {
+        setError("Ce lien de réinitialisation est invalide ou a expiré. Demandez-en un nouveau.");
+      } else {
+        setError(
+          caught instanceof Error ? caught.message : "Réinitialisation impossible pour le moment.",
+        );
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="page">
+      <section className="panel" aria-labelledby="reset-password-title">
+        <h1 id="reset-password-title" className="title">
+          Nouveau mot de passe
+        </h1>
+
+        {token ? (
+          <p className="subtitle">Choisissez un nouveau mot de passe pour votre compte.</p>
+        ) : (
+          <p className="subtitle">
+            Ce lien de réinitialisation est invalide ou incomplet.{" "}
+            <Link to="/forgot-password">Demander un nouveau lien</Link>
+          </p>
+        )}
+
+        <form className="form" onSubmit={(event) => void handleSubmit(event)}>
+          <label className="field">
+            <span>Nouveau mot de passe</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={10}
+              maxLength={128}
+              disabled={!token}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span>Confirmer le mot de passe</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={10}
+              maxLength={128}
+              disabled={!token}
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+            />
+          </label>
+
+          {error ? (
+            <p className="form-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <button type="submit" className="button" disabled={isSubmitting || !token}>
+            {isSubmitting ? "Réinitialisation…" : "Réinitialiser le mot de passe"}
+          </button>
+        </form>
+
+        <p className="subtitle">
+          <Link to="/login">Retour à la connexion</Link>
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/vitest.config.ts
+++ b/apps/front/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
         "src/pages/ProfilePage.tsx",
         "src/pages/LoginPage.tsx",
         "src/pages/RegisterPage.tsx",
+        "src/pages/ForgotPasswordPage.tsx",
+        "src/pages/ResetPasswordPage.tsx",
         "src/pages/LobbyPage.tsx",
         "src/pages/MatchPage.tsx",
         "src/components/AsyncState.tsx",


### PR DESCRIPTION
## Summary
Implement the front-end password reset flow (US-046). The API endpoints `POST /auth/forgot-password` and `POST /auth/reset-password` already existed and were functional; there was no UI, route, or link to trigger the flow. This adds the missing pages so a user can reset their password end-to-end from the browser.

- New `ForgotPasswordPage` (`/forgot-password`): email form calling `POST /auth/forgot-password`. Always shows the same generic confirmation message — even on error — so the UI never reveals whether an account exists (anti-enumeration, consistent with the API's always-200 behaviour).
- New `ResetPasswordPage` (`/reset-password`): reads the token from the URL via `useSearchParams`, "new password" + "confirm" fields (client-side match check + `minLength 10`/`maxLength 128`, mirroring the back `ResetPasswordDto`). On success → redirect to `/login` with a success message. On a 4xx (invalid/expired/reused token) → clear error message with no technical detail. If the token is missing from the URL, the fields are disabled and a link back to `/forgot-password` is shown.
- Both routes are registered as **guest-only** (`GuestRoute`) in `App.tsx`.
- "Mot de passe oublié ?" link added to `LoginPage`, which also now displays the success notice passed via router state after a reset.
- New API client methods `forgotPassword(email)` and `resetPassword(token, newPassword)` in `apiClient.ts`, reusing the shared `apiRequest` helper (204 handled transparently).
- The two new pages are excluded from Vitest coverage (trivial CRUD pages) via `vitest.config.ts`, consistent with the other auth pages.

The reset link generated by the API (`${FRONTEND_URL}/reset-password?token=…`, default `http://localhost:5173`) matches the new route path and `token` query param exactly, so the MailHog → reset → login flow works without any back-end change.

## Test plan
- [x] `pnpm biome check` on the changed files — green
- [x] `pnpm --filter @chifoumi/front typecheck` — green
- [x] `pnpm --filter @chifoumi/front test` — 24 tests pass, no regression, coverage thresholds met (lines 77% / branches 82%, target 60/50)
- [ ] Manual smoke: from `/login`, click "Mot de passe oublié ?" → land on `/forgot-password`, submit a known email → generic confirmation shown + mail visible in MailHog
- [ ] Manual smoke: follow the MailHog link → `/reset-password?token=…`, submit two matching passwords → redirected to `/login` with success message, then log in with the new password
- [ ] Manual smoke: submit an expired/invalid token → clear error message, no technical detail

## Acceptance criteria covered
- AC1: "Mot de passe oublié ?" link on `/login` → `/forgot-password`
- AC2: `POST /auth/forgot-password` + generic confirmation message (no user enumeration)
- AC3: `/reset-password?token=<token>` renders the "new password" + "confirm" form
- AC4: valid token + matching passwords + success response → redirect to `/login` with success message
- AC5: invalid/expired token (4xx) → clear error message, no technical detail
- AC6: both pages excluded from Vitest coverage via `vitest.config.ts`

Closes #101 