### PR TITLE
Fix PR #99 review feedback

### DIFF
--- a/apps/game-service/src/match-session/match-state-machine.spec.ts
+++ b/apps/game-service/src/match-session/match-state-machine.spec.ts
@@ -154,6 +154,20 @@ describe("match state machine", () => {
     });
   });
 
+  it("ends timeout without a winner when both players are silent", () => {
+    const next = transitionMatchState(baseState, {
+      type: "TIMEOUT",
+      silentPlayer: "BOTH",
+      now: new Date("2026-06-09T10:00:06.000Z"),
+    });
+
+    expect(next).toMatchObject({
+      status: "ENDED",
+      winnerId: undefined,
+      endReason: "FORFEIT_TIMEOUT",
+    });
+  });
+
   it("rejects invalid transitions", () => {
     expect(() =>
       transitionMatchState(baseState, {

--- a/apps/game-service/src/match-session/match-state-machine.ts
+++ b/apps/game-service/src/match-session/match-state-machine.ts
@@ -18,7 +18,7 @@ export class InvalidMatchTransitionError extends Error {
 export type MatchStateMachineEvent =
   | { type: "PLAYS_RECEIVED" }
   | { type: "ROUND_RESOLVED"; winner: "A" | "B" | "DRAW"; now: Date }
-  | { type: "TIMEOUT"; silentPlayer: "A" | "B"; now: Date };
+  | { type: "TIMEOUT"; silentPlayer: "A" | "B" | "BOTH"; now: Date };
 
 export function transitionMatchState(state: MatchState, event: MatchStateMachineEvent): MatchState {
   if (state.status === "ENDED") {
@@ -47,6 +47,10 @@ export function transitionMatchState(state: MatchState, event: MatchStateMachine
     ) {
       throw new InvalidMatchTransitionError(state.status, event.type);
     }
+    if (event.silentPlayer === "BOTH") {
+      return endMatch(state, null, "FORFEIT_TIMEOUT");
+    }
+
     const winnerIndex = event.silentPlayer === "A" ? 1 : 0;
     return endMatch(state, state.players[winnerIndex].userId, "FORFEIT_TIMEOUT");
   }

--- a/apps/game-service/src/match/match-play.service.spec.ts
+++ b/apps/game-service/src/match/match-play.service.spec.ts
@@ -231,6 +231,34 @@ describe("MatchPlayService", () => {
     expect(state?.endReason).toBe("FORFEIT_TIMEOUT");
   });
 
+  it("ends the match without a winner when both players miss the play timeout", async () => {
+    await service.handleMatchTimeout("match-1", 1, "WAITING_PLAYS");
+
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("ENDED");
+    expect(state?.winnerId).toBeUndefined();
+    expect(state?.endReason).toBe("FORFEIT_TIMEOUT");
+    expect(publishedJobs).toHaveLength(1);
+  });
+
+  it("ends the match without a winner when both players miss the reveal timeout", async () => {
+    await matchSessionService.mutateState("match-1", (state) => ({
+      ...state,
+      status: "WAITING_REVEALS",
+      roundCommits: { a: "abc123", b: "def456" },
+      roundReveals: { a: null, b: null },
+      revealDeadline: "2026-06-09T10:00:10.000Z",
+    }));
+
+    await service.handleMatchTimeout("match-1", 1, "WAITING_REVEALS");
+
+    const state = await matchSessionService.loadState("match-1");
+    expect(state?.status).toBe("ENDED");
+    expect(state?.winnerId).toBeUndefined();
+    expect(state?.endReason).toBe("FORFEIT_TIMEOUT");
+    expect(publishedJobs).toHaveLength(1);
+  });
+
   it("schedules commit phase timeout with expected state", async () => {
     await service.onCommitPhaseStarted({
       matchId: "match-1",

--- a/apps/game-service/src/match/match-play.service.ts
+++ b/apps/game-service/src/match/match-play.service.ts
@@ -45,6 +45,8 @@ type RoundResolution = {
   roundNumber: number;
 };
 
+type SilentPlayer = "A" | "B" | "BOTH";
+
 @Injectable()
 export class MatchPlayService {
   constructor(
@@ -202,7 +204,7 @@ export class MatchPlayService {
       matchId,
       roundNumber,
       "WAITING_PLAYS",
-      () => "A",
+      () => "BOTH",
     );
 
     if (nextState.status === "ENDED") {
@@ -282,7 +284,7 @@ export class MatchPlayService {
     matchId: string,
     roundNumber: number,
     expectedStatus: MatchTimeoutExpectedState,
-    resolveSilentPlayer: (state: MatchState) => "A" | "B",
+    resolveSilentPlayer: (state: MatchState) => SilentPlayer,
   ): Promise<MatchState> {
     return this.matchSessionService.mutateState(matchId, (state) => {
       if (state.status !== expectedStatus || state.currentRound !== roundNumber) {
@@ -295,6 +297,15 @@ export class MatchPlayService {
           : resolveSilentPlayer(state);
 
       const resolvedAt = new Date();
+
+      if (silentPlayer === "BOTH") {
+        return transitionMatchState(state, {
+          type: "TIMEOUT",
+          silentPlayer,
+          now: resolvedAt,
+        });
+      }
+
       const winnerLabel = silentPlayer === "A" ? "b" : "a";
 
       if (expectedStatus === "WAITING_PLAYS") {
@@ -328,14 +339,20 @@ export class MatchPlayService {
     });
   }
 
-  private resolveSilentPlayer(slotA: string | Move | null, slotB: string | Move | null): "A" | "B" {
+  private resolveSilentPlayer(
+    slotA: string | Move | null,
+    slotB: string | Move | null,
+  ): SilentPlayer {
+    if (slotA === null && slotB === null) {
+      return "BOTH";
+    }
     if (slotA === null && slotB !== null) {
       return "A";
     }
     if (slotB === null && slotA !== null) {
       return "B";
     }
-    return "A";
+    return "BOTH";
   }
 
   private async afterRoundResolved(state: MatchState, resolution: RoundResolution): Promise<void> {

--- a/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.service.ts
@@ -12,6 +12,8 @@ import { MatchSessionService } from "../match-session/match-session.service.js";
 import { RedisService } from "../redis/redis.service.js";
 import { getEloWindow, ratingsMatch } from "./elo-window.js";
 import {
+  MATCH_BY_USER_PREFIX,
+  MATCH_STATE_TTL_SECONDS,
   MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
   MATCHMAKING_QUEUE_KEY,
   MATCHMAKING_WORKER_INTERVAL_MS,
@@ -37,7 +39,10 @@ if redis.call("EXISTS", pairLockKey) == 0 then
   return 0
 end
 
-if redis.call("ZSCORE", queueKey, userA) == false or redis.call("ZSCORE", queueKey, userB) == false then
+local scoreA = redis.call("ZSCORE", queueKey, userA)
+local scoreB = redis.call("ZSCORE", queueKey, userB)
+
+if not scoreA or not scoreB then
   redis.call("DEL", pairLockKey)
   return 0
 end
@@ -190,10 +195,10 @@ export class MatchmakingWorkerService implements OnModuleInit, OnModuleDestroy {
         matchId,
         playerA.userId,
         playerB.userId,
-        "match:byUser:",
+        MATCH_BY_USER_PREFIX,
         `match:${matchId}:state`,
         JSON.stringify(matchState),
-        String(3600),
+        String(MATCH_STATE_TTL_SECONDS),
       ],
     );
 

--- a/apps/game-service/src/matchmaking/matchmaking-worker.spec.ts
+++ b/apps/game-service/src/matchmaking/matchmaking-worker.spec.ts
@@ -60,8 +60,9 @@ describe("MatchmakingWorkerService", () => {
   let redisService: RedisService;
   let worker: MatchmakingWorkerService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     client = new Redis(`redis://matchmaking-worker-test/${Date.now()}-${Math.random()}`);
+    await client.flushall();
     redisService = new RedisService({ url: "redis://localhost:6379" });
     Object.assign(redisService, { client });
     worker = createWorker(redisService);
@@ -129,5 +130,27 @@ describe("MatchmakingWorkerService", () => {
     expect(first + second).toBe(1);
     expect(await client.zcard(MATCHMAKING_QUEUE_KEY)).toBe(0);
     expect(await client.exists(matchmakingPairLockKey("player-a", "player-b"))).toBe(0);
+  });
+
+  it("does not publish a match when the Lua commit rejects a stale pair", async () => {
+    const now = Date.now();
+    await seedQueueMember(client, "player-a", 1000, "Ace", now);
+    await seedQueueMember(client, "player-b", 1020, "Bob", now);
+
+    const evalScriptSpy = jest.spyOn(redisService, "evalScript").mockImplementation(async <T>() => {
+      await client.zrem(MATCHMAKING_QUEUE_KEY, "player-b");
+      await client.del(matchmakingPairLockKey("player-a", "player-b"));
+      return 0 as T;
+    });
+
+    const matches = await worker.tick(now + 100);
+
+    expect(matches).toBe(0);
+    expect(await client.get(matchByUserKey("player-a"))).toBeNull();
+    expect(await client.get(matchByUserKey("player-b"))).toBeNull();
+    expect(await client.zrange(MATCHMAKING_QUEUE_KEY, 0, -1)).toEqual(["player-a"]);
+    expect(await client.exists(matchmakingPairLockKey("player-a", "player-b"))).toBe(0);
+
+    evalScriptSpy.mockRestore();
   });
 });

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -299,7 +299,7 @@ describe("Match timeout BullMQ (e2e)", () => {
     }
   });
 
-  it("defaults reveal-phase forfeit to player-b when both players are silent", async () => {
+  it("ends reveal-phase timeout without a winner when both players are silent", async () => {
     const { playerA, playerB, matchId, roundStart } = await pairPlayers();
 
     await matchSessionService.mutateState(matchId, (state) => ({
@@ -337,7 +337,8 @@ describe("Match timeout BullMQ (e2e)", () => {
 
       expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
       expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
-      expect(endedA.winner).toBe("player-b");
+      expect(endedA.winner).toBeNull();
+      expect(endedB.winner).toBeNull();
     } finally {
       await recoveryWorker.close();
       recoveryWorker = null;

--- a/apps/game-service/test/match-timeout.e2e-spec.ts
+++ b/apps/game-service/test/match-timeout.e2e-spec.ts
@@ -213,8 +213,13 @@ describe("Match timeout BullMQ (e2e)", () => {
     }
   });
 
-  it("applies forfeit when another instance consumes the delayed timeout job", async () => {
+  it("applies play-phase forfeit when another instance consumes the delayed timeout job", async () => {
     const { playerA, playerB, matchId, roundStart } = await pairPlayers();
+
+    await matchSessionService.mutateState(matchId, (state) => ({
+      ...state,
+      roundPlays: { a: "rock", b: null },
+    }));
 
     await scheduler.cancelTimeout(matchId);
     await scheduler.scheduleTimeout(matchId, roundStart.roundNumber, "WAITING_PLAYS", 200);
@@ -243,7 +248,8 @@ describe("Match timeout BullMQ (e2e)", () => {
 
       expect(endedA.reason).toBe("FORFEIT_TIMEOUT");
       expect(endedB.reason).toBe("FORFEIT_TIMEOUT");
-      expect(endedA.winner).toBeTruthy();
+      expect(endedA.winner).toBe("player-a");
+      expect(endedB.winner).toBe("player-a");
     } finally {
       await recoveryWorker.close();
       recoveryWorker = null;


### PR DESCRIPTION
## Summary
- Harden the matchmaking Lua commit by checking missing `ZSCORE` results with nil-safe truthiness before creating match mappings.
- Represent double-silent timeouts explicitly as `BOTH` so the match ends without awarding an arbitrary winner.
- Add unit/e2e coverage for stale matchmaking commits and double-silent timeout outcomes.

## Validation
- `npx pnpm@9.15.9 --filter @chifoumi/game-service exec node --experimental-vm-modules node_modules/jest/bin/jest.js src/match-session/match-state-machine.spec.ts src/match/match-play.service.spec.ts src/matchmaking/matchmaking-worker.spec.ts --coverage=false`
- `npx pnpm@9.15.9 exec biome check apps/game-service/src/matchmaking/matchmaking-worker.service.ts apps/game-service/src/matchmaking/matchmaking-worker.spec.ts apps/game-service/src/match-session/match-state-machine.ts apps/game-service/src/match-session/match-state-machine.spec.ts apps/game-service/src/match/match-play.service.ts apps/game-service/src/match/match-play.service.spec.ts apps/game-service/test/match-timeout.e2e-spec.ts`
- `npx pnpm@9.15.9 --filter @chifoumi/game-service typecheck`
- Pre-commit hook: `biome` + root `typecheck` with `DATABASE_URL=postgresql://app:chifoumi_dev@localhost:5432/chifoumi`