### PR TITLE
feat(db): add Season, League and SeasonStanding Prisma models (#111)

### DIFF
--- a/packages/db/prisma/migrations/20260623000000_add_seasons_leagues/migration.sql
+++ b/packages/db/prisma/migrations/20260623000000_add_seasons_leagues/migration.sql
@@ -1,0 +1,56 @@
+-- CreateEnum
+CREATE TYPE "SeasonStatus" AS ENUM ('upcoming', 'active', 'closed');
+
+-- CreateTable
+CREATE TABLE "leagues" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "min_rating" INTEGER NOT NULL,
+    "max_rating" INTEGER,
+    "tier" INTEGER NOT NULL,
+
+    CONSTRAINT "leagues_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "seasons" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "started_at" TIMESTAMP(3) NOT NULL,
+    "ends_at" TIMESTAMP(3),
+    "status" "SeasonStatus" NOT NULL DEFAULT 'upcoming',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "seasons_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "season_standings" (
+    "id" UUID NOT NULL,
+    "season_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "final_rating" INTEGER NOT NULL,
+    "final_league_id" UUID NOT NULL,
+    "rank" INTEGER NOT NULL,
+    "rewards_distributed" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "season_standings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "leagues_tier_key" ON "leagues"("tier");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "season_standings_season_id_user_id_key" ON "season_standings"("season_id", "user_id");
+
+-- CreateIndex
+CREATE INDEX "season_standings_season_id_rank_idx" ON "season_standings"("season_id", "rank");
+
+-- AddForeignKey
+ALTER TABLE "season_standings" ADD CONSTRAINT "season_standings_season_id_fkey" FOREIGN KEY ("season_id") REFERENCES "seasons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "season_standings" ADD CONSTRAINT "season_standings_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "season_standings" ADD CONSTRAINT "season_standings_final_league_id_fkey" FOREIGN KEY ("final_league_id") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260623000000_add_seasons_leagues/migration.sql
+++ b/packages/db/prisma/migrations/20260623000000_add_seasons_leagues/migration.sql
@@ -48,6 +48,10 @@ CREATE UNIQUE INDEX "leagues_tier_key" ON "leagues"("tier");
 CREATE INDEX "seasons_status_idx" ON "seasons"("status");
 
 -- CreateIndex
+-- Prisma schema cannot represent PostgreSQL partial indexes; this enforces AC1.
+CREATE UNIQUE INDEX "seasons_single_active_idx" ON "seasons"("status") WHERE "status" = 'active';
+
+-- CreateIndex
 CREATE UNIQUE INDEX "season_standings_season_id_user_id_key" ON "season_standings"("season_id", "user_id");
 
 -- CreateIndex

--- a/packages/db/prisma/migrations/20260623000000_add_seasons_leagues/migration.sql
+++ b/packages/db/prisma/migrations/20260623000000_add_seasons_leagues/migration.sql
@@ -20,6 +20,7 @@ CREATE TABLE "seasons" (
     "ends_at" TIMESTAMP(3),
     "status" "SeasonStatus" NOT NULL DEFAULT 'upcoming',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "seasons_pkey" PRIMARY KEY ("id")
 );
@@ -38,13 +39,22 @@ CREATE TABLE "season_standings" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "leagues_name_key" ON "leagues"("name");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "leagues_tier_key" ON "leagues"("tier");
+
+-- CreateIndex
+CREATE INDEX "seasons_status_idx" ON "seasons"("status");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "season_standings_season_id_user_id_key" ON "season_standings"("season_id", "user_id");
 
 -- CreateIndex
 CREATE INDEX "season_standings_season_id_rank_idx" ON "season_standings"("season_id", "rank");
+
+-- CreateIndex
+CREATE INDEX "season_standings_user_id_idx" ON "season_standings"("user_id");
 
 -- AddForeignKey
 ALTER TABLE "season_standings" ADD CONSTRAINT "season_standings_season_id_fkey" FOREIGN KEY ("season_id") REFERENCES "seasons"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -11,6 +11,12 @@ enum UserRole {
   admin
 }
 
+enum SeasonStatus {
+  upcoming
+  active
+  closed
+}
+
 enum MatchStatus {
   in_progress
   ended
@@ -38,13 +44,14 @@ model User {
   createdAt    DateTime   @default(now()) @map("created_at")
   updatedAt    DateTime   @updatedAt @map("updated_at")
 
-  eloRating       EloRating?
-  refreshTokens   RefreshToken[]
+  eloRating           EloRating?
+  refreshTokens       RefreshToken[]
   passwordResetTokens PasswordResetToken[]
-  matchesAsPlayerA Match[]      @relation("PlayerA")
-  matchesAsPlayerB Match[]      @relation("PlayerB")
-  matchesWon       Match[]      @relation("Winner")
-  eloHistory       EloHistory[]
+  matchesAsPlayerA    Match[]          @relation("PlayerA")
+  matchesAsPlayerB    Match[]          @relation("PlayerB")
+  matchesWon          Match[]          @relation("Winner")
+  eloHistory          EloHistory[]
+  seasonStandings     SeasonStanding[]
 
   @@map("users")
 }
@@ -143,4 +150,47 @@ model EloHistory {
 
   @@index([userId, createdAt(sort: Desc)])
   @@map("elo_history")
+}
+
+model League {
+  id        String @id @default(uuid()) @db.Uuid
+  name      String
+  minRating Int    @map("min_rating")
+  maxRating Int?   @map("max_rating")
+  tier      Int    @unique
+
+  seasonStandings SeasonStanding[]
+
+  @@map("leagues")
+}
+
+model Season {
+  id        String       @id @default(uuid()) @db.Uuid
+  name      String
+  startedAt DateTime     @map("started_at")
+  endsAt    DateTime?    @map("ends_at")
+  status    SeasonStatus @default(upcoming)
+  createdAt DateTime     @default(now()) @map("created_at")
+
+  standings SeasonStanding[]
+
+  @@map("seasons")
+}
+
+model SeasonStanding {
+  id                 String  @id @default(uuid()) @db.Uuid
+  seasonId           String  @map("season_id") @db.Uuid
+  userId             String  @map("user_id") @db.Uuid
+  finalRating        Int     @map("final_rating")
+  finalLeagueId      String  @map("final_league_id") @db.Uuid
+  rank               Int
+  rewardsDistributed Boolean @default(false) @map("rewards_distributed")
+
+  season      Season @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  user        User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  finalLeague League @relation(fields: [finalLeagueId], references: [id])
+
+  @@unique([seasonId, userId])
+  @@index([seasonId, rank])
+  @@map("season_standings")
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -154,7 +154,7 @@ model EloHistory {
 
 model League {
   id        String @id @default(uuid()) @db.Uuid
-  name      String
+  name      String @unique
   minRating Int    @map("min_rating")
   maxRating Int?   @map("max_rating")
   tier      Int    @unique
@@ -171,9 +171,11 @@ model Season {
   endsAt    DateTime?    @map("ends_at")
   status    SeasonStatus @default(upcoming)
   createdAt DateTime     @default(now()) @map("created_at")
+  updatedAt DateTime     @updatedAt @map("updated_at")
 
   standings SeasonStanding[]
 
+  @@index([status])
   @@map("seasons")
 }
 
@@ -192,5 +194,6 @@ model SeasonStanding {
 
   @@unique([seasonId, userId])
   @@index([seasonId, rank])
+  @@index([userId])
   @@map("season_standings")
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,9 +1,12 @@
 export type {
   EloHistory,
   EloRating,
+  League,
   Match,
   RefreshToken,
   Round,
+  Season,
+  SeasonStanding,
   User,
 } from "@prisma/client";
 export {
@@ -12,5 +15,6 @@ export {
   Prisma,
   PrismaClient,
   RoundWinner,
+  SeasonStatus,
   UserRole,
 } from "@prisma/client";


### PR DESCRIPTION
## Résumé

Pose le socle data du Sprint 2 (saisons & ligues).

### Schéma

- **`SeasonStatus`** enum : `upcoming | active | closed`
- **`League`** : `id`, `name`, `minRating`, `maxRating?`, `tier` (unique)
- **`Season`** : `id`, `name`, `startedAt`, `endsAt?`, `status`, `createdAt`
- **`SeasonStanding`** : FK → season (Cascade), user (Cascade), league (Restrict) ; `unique(seasonId, userId)`, `index(seasonId, rank)`
- Relation `User.seasonStandings` ajoutée
- Barrel `packages/db/src/index.ts` mis à jour (`League`, `Season`, `SeasonStanding`, `SeasonStatus`)

### Migration

`20260623000000_add_seasons_leagues` — créée manuellement (Docker offline lors de la génération). À valider avec `prisma migrate deploy` sur la prochaine base disponible.

Closes #111

## Checklist DoD
- [x] Modèles conformes aux AC1–AC4
- [x] Index : `leagues.tier` unique, `season_standings (seasonId, userId)` unique, `season_standings (seasonId, rank)` index
- [x] `onDelete: Cascade` sur `SeasonStanding → Season` et `SeasonStanding → User`
- [x] Client Prisma régénéré
- [x] `pnpm -r typecheck` vert
- [x] Biome vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)