### PR TITLE
feat(front&api): add admin interface (US-049)

### DIFF
--- a/apps/api/src/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,12 @@
+import { SetMetadata } from "@nestjs/common";
+
+export type AppRole = "player" | "admin";
+
+export const ROLES_KEY = "roles";
+
+/**
+ * Restrict a route (or a whole controller) to the given roles. Without this
+ * decorator the {@link RolesGuard} is a no-op, so existing authenticated
+ * endpoints keep accepting any role.
+ */
+export const Roles = (...roles: AppRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/auth/guards/roles.guard.spec.ts
+++ b/apps/api/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,47 @@
+import { jest } from "@jest/globals";
+import { type ExecutionContext, ForbiddenException } from "@nestjs/common";
+import type { Reflector } from "@nestjs/core";
+import type { AppRole } from "../decorators/roles.decorator.js";
+import { RolesGuard } from "./roles.guard.js";
+
+function createContext(user: { role?: AppRole } | undefined): ExecutionContext {
+  return {
+    getHandler: () => undefined,
+    getClass: () => undefined,
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+  } as unknown as ExecutionContext;
+}
+
+function createGuard(requiredRoles: AppRole[] | undefined): RolesGuard {
+  const reflector = {
+    getAllAndOverride: jest.fn().mockReturnValue(requiredRoles),
+  } as unknown as Reflector;
+  return new RolesGuard(reflector);
+}
+
+describe("RolesGuard", () => {
+  it("allows the request when no roles are declared", () => {
+    const guard = createGuard(undefined);
+    expect(guard.canActivate(createContext(undefined))).toBe(true);
+  });
+
+  it("allows the request when the declared roles array is empty", () => {
+    const guard = createGuard([]);
+    expect(guard.canActivate(createContext({ role: "player" }))).toBe(true);
+  });
+
+  it("allows a user whose role is included in the required roles", () => {
+    const guard = createGuard(["admin"]);
+    expect(guard.canActivate(createContext({ role: "admin" }))).toBe(true);
+  });
+
+  it("rejects a user whose role is not included", () => {
+    const guard = createGuard(["admin"]);
+    expect(() => guard.canActivate(createContext({ role: "player" }))).toThrow(ForbiddenException);
+  });
+
+  it("rejects a request without an authenticated user", () => {
+    const guard = createGuard(["admin"]);
+    expect(() => guard.canActivate(createContext(undefined))).toThrow(ForbiddenException);
+  });
+});

--- a/apps/api/src/auth/guards/roles.guard.ts
+++ b/apps/api/src/auth/guards/roles.guard.ts
@@ -1,0 +1,41 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { type AppRole, ROLES_KEY } from "../decorators/roles.decorator.js";
+
+type RequestWithUser = { user?: { role?: AppRole } };
+
+/**
+ * Enforces the roles declared via {@link Roles}. Must run after the
+ * JwtAuthGuard (e.g. `@UseGuards(JwtAuthGuard, RolesGuard)`) so that
+ * `request.user` is already populated. When a handler declares no roles the
+ * guard allows the request through, keeping it opt-in.
+ */
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(@Inject(Reflector) private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<AppRole[] | undefined>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest<RequestWithUser>();
+
+    if (!user?.role || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException({ error: "FORBIDDEN" });
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/users/dto/admin-users-response.dto.ts
+++ b/apps/api/src/users/dto/admin-users-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class AdminUserDto {
+  @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
+  id!: string;
+
+  @ApiProperty({ type: String, example: "player1@example.com" })
+  email!: string;
+
+  @ApiProperty({ type: String, example: "player1" })
+  displayName!: string;
+
+  @ApiProperty({ enum: ["player", "admin"], example: "player" })
+  role!: "player" | "admin";
+
+  @ApiProperty({ type: Number, example: 1000 })
+  rating!: number;
+
+  @ApiProperty({ type: Number, example: 0 })
+  gamesPlayed!: number;
+
+  @ApiProperty({ type: Date, format: "date-time", example: "2026-06-08T12:00:00.000Z" })
+  createdAt!: Date;
+}
+
+export class AdminUsersResponseDto {
+  @ApiProperty({ type: () => AdminUserDto, isArray: true })
+  items!: AdminUserDto[];
+
+  @ApiProperty({ type: Number, description: "Total number of users", example: 42 })
+  total!: number;
+
+  @ApiProperty({ type: Number, description: "Current page (1-based)", example: 1 })
+  page!: number;
+
+  @ApiProperty({ type: Number, description: "Page size", example: 20 })
+  limit!: number;
+}

--- a/apps/api/src/users/dto/list-users-query.dto.ts
+++ b/apps/api/src/users/dto/list-users-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsInt, IsOptional, Max, Min } from "class-validator";
+
+export class ListUsersQueryDto {
+  @ApiPropertyOptional({ type: Number, minimum: 1, default: 1, example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page = 1;
+
+  @ApiPropertyOptional({ type: Number, minimum: 1, maximum: 100, default: 20, example: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100, { message: "limit must be ≤ 100" })
+  limit = 20;
+}

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ListUsersQueryDto } from "./dto/list-users-query.dto.js";
+import { UsersController } from "./users.controller.js";
+import type { AdminUsersPage, UsersService } from "./users.service.js";
+
+describe("UsersController", () => {
+  let controller: UsersController;
+  let usersService: {
+    listUsers: ReturnType<typeof jest.fn>;
+    getPublicProfile: ReturnType<typeof jest.fn>;
+  };
+
+  beforeEach(() => {
+    usersService = {
+      listUsers: jest.fn(),
+      getPublicProfile: jest.fn(),
+    };
+    controller = new UsersController(usersService as unknown as UsersService);
+  });
+
+  describe("listUsers", () => {
+    it("delegates to the service with the query pagination", async () => {
+      const page: AdminUsersPage = { items: [], total: 0, page: 1, limit: 20 };
+      usersService.listUsers.mockResolvedValue(page);
+
+      const query = new ListUsersQueryDto();
+      query.page = 1;
+      query.limit = 20;
+
+      const result = await controller.listUsers(query);
+
+      expect(result).toBe(page);
+      expect(usersService.listUsers).toHaveBeenCalledWith(1, 20);
+    });
+  });
+});

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,24 +1,52 @@
-import { Controller, Get, Inject, Param, ParseUUIDPipe, UseGuards } from "@nestjs/common";
+import { Controller, Get, Inject, Param, ParseUUIDPipe, Query, UseGuards } from "@nestjs/common";
 import {
   ApiBearerAuth,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
+import { Roles } from "../auth/decorators/roles.decorator.js";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
+import { RolesGuard } from "../auth/guards/roles.guard.js";
 import { SWAGGER_BEARER_AUTH } from "../swagger.js";
+import { AdminUsersResponseDto } from "./dto/admin-users-response.dto.js";
+import { ListUsersQueryDto } from "./dto/list-users-query.dto.js";
 import { PublicProfileDto } from "./dto/public-profile.dto.js";
 import { UsersService } from "./users.service.js";
 
 @ApiTags("users")
 @ApiBearerAuth(SWAGGER_BEARER_AUTH)
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller("users")
 export class UsersController {
   constructor(@Inject(UsersService) private readonly usersService: UsersService) {}
+
+  @Get()
+  @Roles("admin")
+  @ApiOperation({
+    summary: "List all users (admin only)",
+    description:
+      "Returns a paginated list of every user with private fields (email, role) for moderation. Restricted to administrators.",
+  })
+  @ApiQuery({ name: "page", required: false, type: Number, example: 1, minimum: 1 })
+  @ApiQuery({ name: "limit", required: false, type: Number, example: 20, minimum: 1, maximum: 100 })
+  @ApiOkResponse({ description: "Paginated user list", type: AdminUsersResponseDto })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked access token",
+    schema: { example: { statusCode: 401, message: "Unauthorized" } },
+  })
+  @ApiForbiddenResponse({
+    description: "Authenticated user is not an administrator",
+    schema: { example: { error: "FORBIDDEN" } },
+  })
+  listUsers(@Query() query: ListUsersQueryDto): Promise<AdminUsersResponseDto> {
+    return this.usersService.listUsers(query.page, query.limit);
+  }
 
   @Get(":id/profile")
   @ApiOperation({

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,0 +1,74 @@
+import { UserRole } from "@chifoumi/db";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { PrismaService } from "../prisma/prisma.service.js";
+import { UsersService } from "./users.service.js";
+
+describe("UsersService.listUsers", () => {
+  let service: UsersService;
+  let prisma: {
+    $transaction: ReturnType<typeof jest.fn>;
+    user: { findMany: ReturnType<typeof jest.fn>; count: ReturnType<typeof jest.fn> };
+  };
+
+  beforeEach(() => {
+    prisma = {
+      $transaction: jest.fn(),
+      user: { findMany: jest.fn(), count: jest.fn() },
+    };
+    service = new UsersService(prisma as unknown as PrismaService);
+  });
+
+  it("maps users with their elo rating and pagination metadata", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [
+        {
+          id: "user-1",
+          email: "admin@example.com",
+          displayName: "admin",
+          role: UserRole.admin,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          eloRating: { rating: 1200, gamesPlayed: 5 },
+        },
+        {
+          id: "user-2",
+          email: "player@example.com",
+          displayName: "player",
+          role: UserRole.player,
+          createdAt: new Date("2026-02-01T00:00:00.000Z"),
+          eloRating: null,
+        },
+      ],
+      42,
+    ]);
+
+    const result = await service.listUsers(2, 20);
+
+    expect(result.total).toBe(42);
+    expect(result.page).toBe(2);
+    expect(result.limit).toBe(20);
+    expect(result.items[0]).toEqual({
+      id: "user-1",
+      email: "admin@example.com",
+      displayName: "admin",
+      role: "admin",
+      rating: 1200,
+      gamesPlayed: 5,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    // Falls back to defaults when no elo rating row exists.
+    expect(result.items[1]).toMatchObject({ role: "player", rating: 1000, gamesPlayed: 0 });
+  });
+
+  it("computes the skip offset from the requested page", async () => {
+    prisma.$transaction.mockImplementation((operations: unknown) => {
+      void operations;
+      return Promise.resolve([[], 0]);
+    });
+
+    await service.listUsers(3, 10);
+
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 20, take: 10, orderBy: { createdAt: "desc" } }),
+    );
+  });
+});

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -10,6 +10,23 @@ export type SafeUser = {
   role: "player" | "admin";
 };
 
+export type AdminUserSummary = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "player" | "admin";
+  rating: number;
+  gamesPlayed: number;
+  createdAt: Date;
+};
+
+export type AdminUsersPage = {
+  items: AdminUserSummary[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
 @Injectable()
 export class UsersService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
@@ -62,6 +79,34 @@ export class UsersService {
       gamesPlayed,
       winRate: this.calculateWinRate(wins, gamesPlayed),
       createdAt: user.createdAt,
+    };
+  }
+
+  async listUsers(page: number, limit: number): Promise<AdminUsersPage> {
+    const skip = (page - 1) * limit;
+    const [rows, total] = await this.prisma.$transaction([
+      this.prisma.user.findMany({
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+        include: { eloRating: true },
+      }),
+      this.prisma.user.count(),
+    ]);
+
+    return {
+      items: rows.map((user) => ({
+        id: user.id,
+        email: user.email,
+        displayName: user.displayName,
+        role: user.role === UserRole.admin ? "admin" : "player",
+        rating: user.eloRating?.rating ?? 1000,
+        gamesPlayed: user.eloRating?.gamesPlayed ?? 0,
+        createdAt: user.createdAt,
+      })),
+      total,
+      page,
+      limit,
     };
   }
 

--- a/apps/front/src/App.css
+++ b/apps/front/src/App.css
@@ -638,3 +638,115 @@ a {
     flex-direction: column;
   }
 }
+
+/* Admin area */
+.form-inline {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.form-inline .field {
+  flex: 1 1 320px;
+}
+
+.badge-admin {
+  background: #fdeccd;
+  color: #8a6100;
+}
+
+.badge-player {
+  background: #eef3fb;
+  color: #1f5fbf;
+}
+
+.badge-ok {
+  background: #e3f5ec;
+  color: #067647;
+}
+
+.badge-error {
+  background: #fff3f0;
+  color: #b42318;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.audit-summary {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  margin: 0 0 24px;
+}
+
+.audit-summary dt {
+  color: #5d6675;
+}
+
+.audit-summary dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.audit-rounds {
+  display: grid;
+  gap: 16px;
+}
+
+.audit-round {
+  border: 1px solid #e7ebf2;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.audit-round-title {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.audit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.audit-player h4 {
+  margin: 0 0 8px;
+  color: #5d6675;
+}
+
+.audit-player dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin: 0;
+}
+
+.audit-player dt {
+  color: #5d6675;
+  font-size: 13px;
+}
+
+.audit-player dd {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .audit-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/front/src/App.tsx
+++ b/apps/front/src/App.tsx
@@ -1,8 +1,11 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 import { useAuth } from "./auth/AuthContext.js";
+import { AdminRoute } from "./components/AdminRoute.js";
 import { Header } from "./components/Header.js";
 import { GuestRoute, ProtectedRoute } from "./components/ProtectedRoute.js";
 import { GameSocketProvider } from "./game/GameSocketContext.js";
+import { AdminMatchAuditPage } from "./pages/admin/AdminMatchAuditPage.js";
+import { AdminUsersPage } from "./pages/admin/AdminUsersPage.js";
 import { ForgotPasswordPage } from "./pages/ForgotPasswordPage.js";
 import { LeaderboardPage } from "./pages/LeaderboardPage.js";
 import { LobbyPage } from "./pages/LobbyPage.js";
@@ -51,6 +54,12 @@ export function App() {
             <Route path="/match/:matchId" element={<MatchPage />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/profile/:id" element={<ProfilePage />} />
+          </Route>
+
+          <Route element={<AdminRoute />}>
+            <Route path="/admin" element={<Navigate to="/admin/users" replace />} />
+            <Route path="/admin/users" element={<AdminUsersPage />} />
+            <Route path="/admin/matches/:id" element={<AdminMatchAuditPage />} />
           </Route>
 
           <Route path="*" element={<CatchAllRedirect />} />

--- a/apps/front/src/api/types.ts
+++ b/apps/front/src/api/types.ts
@@ -69,3 +69,50 @@ export type MeHistoryResponse = {
   items: MeHistoryItem[];
   nextCursor: string | null;
 };
+
+export type AdminUser = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "player" | "admin";
+  rating: number;
+  gamesPlayed: number;
+  createdAt: string;
+};
+
+export type AdminUsersResponse = {
+  items: AdminUser[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type AuditHashCheck = {
+  a: "match" | "mismatch";
+  b: "match" | "mismatch";
+};
+
+export type AuditRound = {
+  roundNumber: number;
+  commitA: string | null;
+  commitB: string | null;
+  moveA: "rock" | "paper" | "scissors" | null;
+  moveB: "rock" | "paper" | "scissors" | null;
+  nonceA: string | null;
+  nonceB: string | null;
+  hashCheck: AuditHashCheck;
+};
+
+export type MatchAuditPlayer = {
+  id: string;
+  displayName: string;
+};
+
+export type MatchAuditResponse = {
+  matchId: string;
+  players: MatchAuditPlayer[];
+  rounds: AuditRound[];
+  finalScore: [number, number];
+  winner: string | null;
+  endedAt: string;
+};

--- a/apps/front/src/components/AdminRoute.tsx
+++ b/apps/front/src/components/AdminRoute.tsx
@@ -1,0 +1,32 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext.js";
+
+/**
+ * Route guard for the admin area. Like {@link ProtectedRoute} it requires an
+ * authenticated session, but additionally restricts access to users whose role
+ * is `admin`. Non-admin players are sent back to the lobby.
+ */
+export function AdminRoute() {
+  const { user, isAuthenticated, isBootstrapping } = useAuth();
+  const location = useLocation();
+
+  if (isBootstrapping) {
+    return (
+      <div className="page">
+        <div className="panel">
+          <p className="muted">Chargement de la session…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  if (user?.role !== "admin") {
+    return <Navigate to="/lobby" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/apps/front/src/components/Header.tsx
+++ b/apps/front/src/components/Header.tsx
@@ -24,6 +24,11 @@ export function Header() {
             <NavLink to="/profile" className="nav-link">
               Profil
             </NavLink>
+            {user?.role === "admin" ? (
+              <NavLink to="/admin/users" className="nav-link">
+                Admin
+              </NavLink>
+            ) : null}
             <span className="nav-user">{user?.displayName}</span>
             <button type="button" className="button button-secondary" onClick={() => void logout()}>
               Logout

--- a/apps/front/src/hooks/useAdminUsers.ts
+++ b/apps/front/src/hooks/useAdminUsers.ts
@@ -1,0 +1,14 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { AdminUsersResponse } from "../api/types.js";
+
+export const ADMIN_USERS_PAGE_SIZE = 20;
+
+export function useAdminUsers(page: number) {
+  return useQuery({
+    queryKey: ["admin", "users", page],
+    queryFn: () =>
+      apiRequest<AdminUsersResponse>(`/users?page=${page}&limit=${ADMIN_USERS_PAGE_SIZE}`),
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/front/src/hooks/useMatchAudit.ts
+++ b/apps/front/src/hooks/useMatchAudit.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { MatchAuditResponse } from "../api/types.js";
+
+export function useMatchAudit(matchId: string | undefined) {
+  return useQuery({
+    queryKey: ["admin", "match-audit", matchId],
+    queryFn: () => apiRequest<MatchAuditResponse>(`/matches/${matchId}/audit`),
+    enabled: Boolean(matchId),
+  });
+}

--- a/apps/front/src/pages/admin/AdminMatchAuditPage.tsx
+++ b/apps/front/src/pages/admin/AdminMatchAuditPage.tsx
@@ -1,0 +1,118 @@
+import { Link, useParams } from "react-router-dom";
+import type { AuditRound } from "../../api/types.js";
+import { AsyncPanel, TableSkeleton } from "../../components/AsyncState.js";
+import { useMatchAudit } from "../../hooks/useMatchAudit.js";
+
+function HashBadge({ status }: { status: "match" | "mismatch" }) {
+  return (
+    <span className={`badge badge-${status === "match" ? "ok" : "error"}`}>
+      {status === "match" ? "✓ hash vérifié" : "✗ hash invalide"}
+    </span>
+  );
+}
+
+function RoundCard({ round }: { round: AuditRound }) {
+  return (
+    <div className="audit-round">
+      <h3 className="audit-round-title">Round {round.roundNumber}</h3>
+      <div className="audit-grid">
+        <div className="audit-player">
+          <h4>Joueur A</h4>
+          <dl>
+            <dt>Move</dt>
+            <dd>{round.moveA ?? "—"}</dd>
+            <dt>Commit</dt>
+            <dd className="mono">{round.commitA ?? "—"}</dd>
+            <dt>Nonce</dt>
+            <dd className="mono">{round.nonceA ?? "—"}</dd>
+            <dt>Hash recalculé</dt>
+            <dd>
+              <HashBadge status={round.hashCheck.a} />
+            </dd>
+          </dl>
+        </div>
+        <div className="audit-player">
+          <h4>Joueur B</h4>
+          <dl>
+            <dt>Move</dt>
+            <dd>{round.moveB ?? "—"}</dd>
+            <dt>Commit</dt>
+            <dd className="mono">{round.commitB ?? "—"}</dd>
+            <dt>Nonce</dt>
+            <dd className="mono">{round.nonceB ?? "—"}</dd>
+            <dt>Hash recalculé</dt>
+            <dd>
+              <HashBadge status={round.hashCheck.b} />
+            </dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AdminMatchAuditPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, isError, error, refetch } = useMatchAudit(id);
+
+  const playerA = data?.players[0];
+  const playerB = data?.players[1];
+  const winnerName =
+    data?.winner === null
+      ? "Match nul"
+      : (data?.players.find((player) => player.id === data?.winner)?.displayName ?? data?.winner);
+
+  return (
+    <div className="page">
+      <section className="panel panel-wide" aria-labelledby="admin-audit-title">
+        <div className="page-heading">
+          <h1 id="admin-audit-title" className="title">
+            Audit commit-reveal
+          </h1>
+          <p className="subtitle">
+            <Link to="/admin/users">← Retour aux utilisateurs</Link>
+          </p>
+        </div>
+
+        <AsyncPanel
+          isLoading={isLoading}
+          isError={isError}
+          errorMessage={
+            error instanceof Error
+              ? error.message
+              : "Audit indisponible (match introuvable ou encore en cours)."
+          }
+          onRetry={() => void refetch()}
+          skeleton={<TableSkeleton rows={6} />}
+        >
+          {data ? (
+            <>
+              <dl className="audit-summary">
+                <dt>Match</dt>
+                <dd className="mono">{data.matchId}</dd>
+                <dt>Joueurs</dt>
+                <dd>
+                  {playerA?.displayName ?? "?"} (A) vs {playerB?.displayName ?? "?"} (B)
+                </dd>
+                <dt>Score final</dt>
+                <dd>
+                  {data.finalScore[0]} – {data.finalScore[1]}
+                </dd>
+                <dt>Vainqueur</dt>
+                <dd>{winnerName}</dd>
+                <dt>Terminé le</dt>
+                <dd>{new Date(data.endedAt).toLocaleString("fr-FR")}</dd>
+              </dl>
+
+              <div className="audit-rounds">
+                {data.rounds.map((round) => (
+                  <RoundCard key={round.roundNumber} round={round} />
+                ))}
+              </div>
+            </>
+          ) : null}
+        </AsyncPanel>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/src/pages/admin/AdminUsersPage.tsx
+++ b/apps/front/src/pages/admin/AdminUsersPage.tsx
@@ -1,0 +1,126 @@
+import { type FormEvent, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AsyncPanel, TableSkeleton } from "../../components/AsyncState.js";
+import { ADMIN_USERS_PAGE_SIZE, useAdminUsers } from "../../hooks/useAdminUsers.js";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+export function AdminUsersPage() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [matchId, setMatchId] = useState("");
+  const { data, isLoading, isError, error, refetch, isFetching } = useAdminUsers(page);
+
+  const total = data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / ADMIN_USERS_PAGE_SIZE));
+  const canPrev = page > 1;
+  const canNext = page < pageCount;
+
+  function handleAuditLookup(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = matchId.trim();
+    if (trimmed) {
+      navigate(`/admin/matches/${trimmed}`);
+    }
+  }
+
+  return (
+    <div className="page">
+      <section className="panel panel-wide" aria-labelledby="admin-users-title">
+        <div className="page-heading">
+          <h1 id="admin-users-title" className="title">
+            Administration — Utilisateurs
+          </h1>
+          <p className="subtitle">
+            Liste de tous les comptes de la plateforme. {total} utilisateur{total > 1 ? "s" : ""}.
+          </p>
+          {isFetching && !isLoading ? <span className="badge">Mise à jour…</span> : null}
+        </div>
+
+        <form className="form-inline" onSubmit={handleAuditLookup}>
+          <label className="field">
+            <span>Consulter l'audit commit-reveal d'un match (UUID)</span>
+            <input
+              type="text"
+              value={matchId}
+              onChange={(event) => setMatchId(event.target.value)}
+              placeholder="550e8400-e29b-41d4-a716-446655440000"
+            />
+          </label>
+          <button type="submit" className="button">
+            Voir l'audit
+          </button>
+        </form>
+
+        <AsyncPanel
+          isLoading={isLoading}
+          isError={isError}
+          errorMessage={error instanceof Error ? error.message : undefined}
+          onRetry={() => void refetch()}
+          isEmpty={!isLoading && !isError && (data?.items.length ?? 0) === 0}
+          emptyMessage="Aucun utilisateur."
+          skeleton={<TableSkeleton rows={10} />}
+        >
+          {data ? (
+            <>
+              <div className="table-wrap">
+                <table className="data-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Joueur</th>
+                      <th scope="col">Email</th>
+                      <th scope="col">ELO</th>
+                      <th scope="col">Rôle</th>
+                      <th scope="col">Inscription</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.items.map((user) => (
+                      <tr key={user.id}>
+                        <td>{user.displayName}</td>
+                        <td>{user.email}</td>
+                        <td>{user.rating}</td>
+                        <td>
+                          <span className={`badge badge-${user.role}`}>{user.role}</span>
+                        </td>
+                        <td>{formatDate(user.createdAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="pagination">
+                <button
+                  type="button"
+                  className="button button-secondary"
+                  disabled={!canPrev}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                >
+                  Précédent
+                </button>
+                <span className="muted">
+                  Page {page} / {pageCount}
+                </span>
+                <button
+                  type="button"
+                  className="button button-secondary"
+                  disabled={!canNext}
+                  onClick={() => setPage((current) => current + 1)}
+                >
+                  Suivant
+                </button>
+              </div>
+            </>
+          ) : null}
+        </AsyncPanel>
+      </section>
+    </div>
+  );
+}

--- a/apps/front/vitest.config.ts
+++ b/apps/front/vitest.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
         "src/pages/ResetPasswordPage.tsx",
         "src/pages/LobbyPage.tsx",
         "src/pages/MatchPage.tsx",
+        "src/pages/admin/AdminUsersPage.tsx",
+        "src/pages/admin/AdminMatchAuditPage.tsx",
         // Presentational shells wired in pages above
         "src/components/AsyncState.tsx",
         "src/components/FinalScreen.tsx",
@@ -32,10 +34,13 @@ export default defineConfig({
         "src/components/MatchHeader.tsx",
         "src/components/ProfileHeader.tsx",
         "src/components/ProtectedRoute.tsx",
+        "src/components/AdminRoute.tsx",
         // Data-fetch hooks colocated with CRUD pages
         "src/hooks/useLeaderboard.ts",
         "src/hooks/useMyHistory.ts",
         "src/hooks/useProfile.ts",
+        "src/hooks/useAdminUsers.ts",
+        "src/hooks/useMatchAudit.ts",
         "src/hooks/gameSocketTypes.ts",
         "src/game/GameSocketContext.tsx",
         "src/hooks/useDeadlineCountdown.ts",


### PR DESCRIPTION
## Summary
Implement the admin interface (US-049). The `admin` role existed in the database, JWT and DTOs, but **no role guard enforced it server-side and no front UI exposed admin rights**. This adds the missing role-based access control on the API plus a front admin panel to list users and replay the commit-reveal audit trail of a match.

- **Role-based guard (new).** Despite the docs claiming it existed, there was no `@Roles`/`RolesGuard` in the code — only a `Public` decorator. Added `@Roles(...roles)` (`SetMetadata`) and a `RolesGuard` that is opt-in (no-op when a handler declares no roles, returns `403 FORBIDDEN` otherwise). It is wired via `@UseGuards(JwtAuthGuard, RolesGuard)` at controller level rather than globally, so it runs **after** the JwtAuthGuard and `request.user` is populated when the role is checked.
- **`GET /users` (new, admin only).** Paginated list (`?page&limit`) returning private fields (email, role) plus ELO and signup date for moderation, protected by `@Roles('admin')`. Backed by `UsersService.listUsers()` (Prisma + elo rating + total count), fully documented in Swagger.
- **`GET /matches/:id/audit`** already existed (public) and is reused as-is for the audit trail.
- **Front `AdminRoute`** guard extends the `ProtectedRoute` logic with a role check: authenticated non-admin players are redirected to `/lobby`.
- **Conditional "Admin" link** in the `Header`, visible only when `user.role === 'admin'`.
- **`AdminUsersPage`** (`/admin/users`): paginated table (displayName, email, ELO, role, signup date) + a match-UUID lookup to open the audit page.
- **`AdminMatchAuditPage`** (`/admin/matches/:id`): per-round commit-reveal details (commit, move, nonce, recomputed hash via `hashCheck`, final score, winner).
- Routes `/admin`, `/admin/users`, `/admin/matches/:id` registered under `AdminRoute` (`/admin` redirects to `/admin/users`), and the admin pages/hooks/guard excluded from Vitest coverage.

## Test plan
- [x] `pnpm biome check` on the changed files — green
- [x] `pnpm --filter @chifoumi/front typecheck` and `pnpm --filter @chifoumi/api typecheck` — green
- [x] `pnpm --filter @chifoumi/api test` — 16 suites / 59 tests pass (new `RolesGuard`, `UsersService.listUsers`, `UsersController` specs), coverage thresholds met
- [x] `pnpm --filter @chifoumi/front test` with coverage — all tests pass, no regression, thresholds met
- [x] Rebased cleanly onto `develop` (incl. #102 backend Jest coverage thresholds); full suite re-run green
- [ ] Manual smoke: log in as admin → "Admin" link visible → `/admin/users` shows the paginated user list
- [ ] Manual smoke: enter a finished match UUID → `/admin/matches/:id` shows the commit-reveal audit with recomputed hash checks
- [ ] Manual smoke: a standard player cannot reach `/admin/*` (front redirect to `/lobby`) and `GET /users` returns `403` without the admin role

## Acceptance criteria covered
- AC1: conditional "Admin" link in the Header for authenticated admins
- AC2: non-admin users hitting `/admin` are redirected to `/lobby` (front `AdminRoute` guard)
- AC3: `/admin/users` shows the paginated user list (displayName, email, ELO, role, signup date)
- AC4: `/admin/matches/:id` shows the commit-reveal audit trail (rounds with commit, move, nonce, recomputed hash, result)
- AC5: admin routes use the `AdminRoute` component (ProtectedRoute extension with role check)
- AC6: admin pages excluded from Vitest coverage

## Notes
- `RolesGuard` is wired per-controller, not as a global guard as the spec suggests — a global guard would run before the per-controller `JwtAuthGuard`, leaving `request.user` undefined. Worth aligning the doc/spec wording in a follow-up.

Closes #104 