### PR TITLE
docs: document Redis keys table (US-051)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,4 +178,5 @@ sequenceDiagram
 - Le Game Service ne lit pas directement la base applicative pour l'authentification en temps reel : il delegue la verification JWT a l'API via gRPC.
 - Le protocole WebSocket public de jeu utilise l'evenement `play`; les champs commit/reveal appartiennent a l'etat interne des phases avancees.
 - Redis porte a la fois les files BullMQ, la file de matchmaking, les sessions de match, le pub/sub inter-instances et la blacklist des JWT deconnectes.
+- La table detaillee des cles Redis est disponible dans [docs/architecture/redis-keys.md](architecture/redis-keys.md).
 - Les jobs `match-events` terminent le flux metier apres `matchEnded` : persistance, calcul ELO et invalidation du cache leaderboard.

--- a/docs/architecture/redis-keys.md
+++ b/docs/architecture/redis-keys.md
@@ -1,0 +1,48 @@
+# Table des cles Redis
+
+Ce document centralise les cles, channels et prefixes BullMQ utilises par Chifoumi Ranked. Il sert de support court pour expliquer l'usage de Redis pendant la soutenance.
+
+## Synthese architecture
+
+- Redis porte la scalabilite temps reel : etat de match partage, mappings user -> match, locks distribues et pub/sub inter-replicas.
+- Redis sert de bus technique : channels pub/sub cross-instances et structures BullMQ pour les jobs asynchrones.
+- Redis reduit la charge et renforce la securite : cache leaderboard, cache anti-race de refresh token et blacklist JWT.
+
+## Table des cles et channels
+
+| Cle (pattern) | Type Redis | TTL | Service | Role/justification |
+|---|---|---:|---|---|
+| `matchmaking:queue` | Sorted set | Aucun TTL | Game Service | File de matchmaking. Le score est le rating ELO, le membre est `userId`; permet un parcours ordonne des joueurs en attente. |
+| `matchmaking:meta:<userId>` | Hash | Aucun TTL | Game Service | Metadonnees du joueur en file (`userId`, `rating`, `displayName`, `queuedAt`) lues par le worker. Supprimee au `leaveQueue` ou au pairing. |
+| `matchmaking:lock:<userId>` | String lock NX | 5 s | Game Service | Lock individuel pendant `joinQueue`; evite deux inscriptions concurrentes du meme joueur. |
+| `matchmaking:pair-lock:<userA>:<userB>` | String lock NX | 5 s | Game Service | Lock distribue de paire, avec ids tries, pour qu'une seule replica cree le match. |
+| `matchmaking:rate:<userId>` | String compteur | 1 s | Game Service | Rate limit WS `joinQueue`; limite le spam a une tentative par seconde. |
+| `matchmaking:match-found` | Pub/sub channel | N/A | Game Service | Channel d'evenements `matchFound` pour relayer une paire creee entre replicas. |
+| `user:rating:<userId>` | String | Aucun TTL | Game Service | Cache local Redis du rating joueur cote matchmaking; fallback `1000` si absent. |
+| `match:byUser:<userId>` | String | 3600 s | Game Service | Pointeur vers le `matchId` courant; bloque une nouvelle file et permet la reconnexion. |
+| `match:<matchId>:state` | String JSON | 3600 s | Game Service | Etat serialise de la state machine BO3; rend le match recuperable par n'importe quelle replica. |
+| `match:<matchId>:lock` | String lock NX | 2 s | Game Service | Lock de mutation d'un match; evite deux resolutions concurrentes sur le meme round. |
+| `match:<matchId>` | Pub/sub channel | N/A | Game Service | Bus d'evenements de match (`roundStart`, `roundResolved`, `matchEnded`) entre replicas Socket.io. |
+| `match:<matchId>:timeoutJob` | String | 3600 s | Game Service | Stocke l'id BullMQ du job `round-timeout`; permet d'annuler/remplacer le timeout du round. |
+| `match:disconnectForfeit:<userId>` | String | 60 s | Game Service | Stocke l'id BullMQ du job de forfeit apres deconnexion; annule le forfeit si le joueur revient. |
+| `leaderboard:top:<limit>` | String JSON | 30 s | API | Cache du classement public pour limiter les lectures PostgreSQL repetitives. |
+| `leaderboard:invalidate` | Pub/sub channel | N/A | API + Job Runner | Invalidation cross-service du cache leaderboard apres persistance d'un match et recalcul ELO. |
+| `blacklist:jwt:<jti>` | String | Duree restante du JWT access | API + Game Service | Blacklist des access tokens apres logout; chaque requete auth et verification gRPC consulte ce marqueur. |
+| `refresh:lock:<refreshTokenHash>` | String lock NX | 10 s | API | Lock anti-race pendant la rotation d'un refresh token; empeche deux rotations concurrentes du meme token. |
+| `refresh:rotation:<refreshTokenHash>` | String JSON | 30 s | API | Cache temporaire du resultat de rotation; renvoie les memes tokens aux requetes concurrentes gagnantes. |
+| `<BULLMQ_PREFIX>:match-events:*` | Structures BullMQ | Selon retention BullMQ | Game Service + Job Runner | Queue `match-events`, job `match-ended`; persistance match, rounds, ELO puis invalidation leaderboard. Prefix par defaut `rps`. |
+| `<BULLMQ_PREFIX>:match-timeouts:*` | Structures BullMQ | Selon retention BullMQ | Game Service | Queue `match-timeouts`, job `round-timeout`; resout un round si un joueur ne joue/reveal pas avant deadline. |
+| `<BULLMQ_PREFIX>:match-disconnect-forfeits:*` | Structures BullMQ | Selon retention BullMQ | Game Service | Queue `match-disconnect-forfeits`, job `match-disconnect-forfeit`; declare forfait apres 10 s de deconnexion continue. |
+| `<BULLMQ_PREFIX>:notifications:*` | Structures BullMQ | Selon retention BullMQ | API + Job Runner | Queue `notifications`, job `send-mail`; emails de bienvenue et reset password. |
+| `<BULLMQ_PREFIX>:seasons:*` | Structures BullMQ | Selon retention BullMQ | Job Runner | Queue `seasons`, job repeatable `season-reset`; traitements planifies de saisons. |
+| `<BULLMQ_PREFIX>:tournaments:*` | Structures BullMQ | Selon retention BullMQ | Job Runner | Queue reservee aux traitements asynchrones de tournois. |
+| `<BULLMQ_PREFIX>:job-runner:cron-scheduler-lock` | String lock NX | 60 s | Job Runner | Lock de leader election courte pour qu'une seule instance enregistre les jobs cron repeatables. |
+
+## Notes de synchronisation avec le code
+
+- Les TTL matchmaking viennent de `apps/game-service/src/matchmaking/matchmaking.constants.ts`.
+- Les TTL de session et locks match viennent de `apps/game-service/src/match-session/match-session.types.ts`.
+- Les TTL de jobs timeout/deconnexion viennent de `apps/game-service/src/match/match-timeout.constants.ts` et `apps/game-service/src/match/match-disconnect.constants.ts`.
+- Le cache leaderboard et la blacklist JWT sont dans `apps/api/src/redis/redis.service.ts` et `apps/api/src/leaderboard/leaderboard.service.ts`.
+- Les locks/cache de rotation refresh sont dans `apps/api/src/auth/auth.service.ts`.
+- Le prefix BullMQ est `BULLMQ_PREFIX`, par defaut `rps`, configurable par service.


### PR DESCRIPTION
## Summary
- Adds `docs/architecture/redis-keys.md` with Redis key/channel patterns, Redis type, TTL, owning service, and justification.
- Covers matchmaking, match state, pub/sub, leaderboard cache, JWT blacklist, refresh rotation, BullMQ queues, and cron scheduler lock.
- Links the Redis key table from `docs/architecture.md`.

Closes #106

## Acceptance criteria
- [x] AC1: table includes key pattern, Redis type, TTL, service, and role/justification.
- [x] AC2: keys/channels from the issue context are documented.
- [x] AC3: intro summarizes Redis roles for scalability, pub/sub, BullMQ, cache, and security.
- [x] AC4: `docs/architecture.md` links to the new file.
- [x] AC5: TTL values were synchronized with code constants.

## Validation
- [x] `git diff --cached --check`
- [x] Pre-commit hook ran; Biome/typecheck skipped because only ignored Markdown/docs files were staged.
- [x] Attempted `npx pnpm@9.15.9 biome check docs/architecture.md docs/architecture/redis-keys.md`; Biome reported these Markdown paths are ignored by config.