### PR TITLE
docs: add ADRs for challengeable architecture decisions (US-052)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Ce dossier regroupe la documentation projet : consignes, backlog, specs d'archit
 | [`superpowers/specs/`](superpowers/specs/) | Specs de design et decisions structurantes. |
 | [`superpowers/plans/`](superpowers/plans/) | Plans d'execution issus des specs et des tickets. |
 | [`demo/`](demo/) | Script et procedure de demonstration multi-instances (US-032). |
+| [`adr/`](adr/) | Architecture Decision Records pour les choix techniques challengeables. |
 
 ## Entrees principales
 
@@ -22,11 +23,15 @@ Ce dossier regroupe la documentation projet : consignes, backlog, specs d'archit
 - [`backlog/sprint-1-job-runner.md`](backlog/sprint-1-job-runner.md) : workers et jobs asynchrones.
 - [`backlog/sprint-1-devops-demo.md`](backlog/sprint-1-devops-demo.md) : devops, demo et observabilite.
 - [`demo/multi-instances.md`](demo/multi-instances.md) : demo soutenance multi-replicas (US-032).
+- [`adr/001-grpc-game-to-api.md`](adr/001-grpc-game-to-api.md) : gRPC entre Game Service et API.
+- [`adr/002-biome-over-eslint.md`](adr/002-biome-over-eslint.md) : Biome a la place d'ESLint et Prettier.
+- [`adr/003-commit-reveal-anticheat.md`](adr/003-commit-reveal-anticheat.md) : commit-reveal pour l'anti-triche.
+- [`adr/004-jwt-ws-querystring.md`](adr/004-jwt-ws-querystring.md) : JWT WebSocket en query string.
+- [`adr/005-match-state-redis.md`](adr/005-match-state-redis.md) : etat de match dans Redis.
 
 ## Futures sections
 
 Ces emplacements pourront etre ajoutes au fil des sprints :
 
-- `docs/adr/` pour les Architecture Decision Records.
 - `docs/openapi.json` pour l'export Swagger.
 - `docs/runbooks/` pour les procedures d'exploitation.

--- a/docs/adr/001-grpc-game-to-api.md
+++ b/docs/adr/001-grpc-game-to-api.md
@@ -1,0 +1,37 @@
+# ADR-001 — gRPC entre Game Service et API
+
+## Statut
+
+Accepte.
+
+## Contexte
+
+Le Game Service orchestre le temps reel mais ne doit pas acceder directement a la base applicative. Il a besoin de verifier un JWT, connaitre le rating d'un joueur et garder un contrat stable avec l'API. Ces appels sont internes, synchrones et sensibles au typage.
+
+## Options envisagées
+
+| Option | Avantages | Limites |
+|---|---|---|
+| REST interne | Simple, deja connu, facile a debugger avec curl. | Contrats moins stricts, DTOs a synchroniser manuellement, erreurs moins typees. |
+| tRPC | Type-safe en TypeScript, DX confortable. | Couple fortement les deux services a un runtime TS et sort du contrat inter-service standard du projet. |
+| gRPC avec `.proto` | Contrats versionnes, codegen type-safe, erreurs standardisees, streaming possible plus tard. | Setup plus lourd qu'un endpoint REST et outillage de debug moins immediat. |
+
+## Décision
+
+Nous utilisons gRPC entre le Game Service et l'API pour `Auth.VerifyToken` et `Users.GetRating`. Le contrat vit dans `packages/proto`, ce qui rend l'interface explicite et versionnable.
+
+L'alternative principale rejetee est REST interne : acceptable comme fallback, mais moins robuste pour un contrat entre deux services deployes separement.
+
+## Conséquences
+
+- Le Game Service reste isole de PostgreSQL et delegue l'autorite auth/user a l'API.
+- Les changements de contrat passent par les fichiers `.proto`, ce qui rend les ruptures visibles en CI.
+- Le projet garde une porte ouverte vers du streaming gRPC si des besoins temps reel internes apparaissent.
+- Les developpeurs doivent maintenir la generation des stubs et connaitre les codes d'erreur gRPC.
+
+## Références
+
+- `docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md` sections 3.3 et 6.3.
+- `docs/backlog/sprint-1-api.md` US-033.
+- `docs/backlog/sprint-1-game-service.md` US-037.
+

--- a/docs/adr/002-biome-over-eslint.md
+++ b/docs/adr/002-biome-over-eslint.md
@@ -1,0 +1,36 @@
+# ADR-002 — Biome a la place d'ESLint et Prettier
+
+## Statut
+
+Accepte.
+
+## Contexte
+
+Le brief projet demandait une qualite de code verifiable avec lint, format et CI. La stack initiale attendait ESLint et Prettier, mais l'equipe a demande puis obtenu la validation explicite du professeur pour utiliser Biome comme substitution.
+
+## Options envisagées
+
+| Option | Avantages | Limites |
+|---|---|---|
+| ESLint + Prettier separes | Ecosysteme mature, tres configurable, conforme au brief initial. | Deux outils a configurer, conflits possibles formatter/linter, execution plus lente. |
+| Biome | Outil unique lint + format, performance native Rust, configuration unifiee, CI plus simple. | Couverture de certaines regles ESLint moins exhaustive, choix a justifier au jury. |
+
+## Décision
+
+Nous utilisons Biome pour remplacer ESLint + Prettier. La decision est encadree par `packages/biome/README.md`, par `CLAUDE.md`, et par la spec projet section 9.1 qui mentionne la validation explicite du professeur.
+
+L'alternative principale rejetee est ESLint + Prettier separes : elle reste viable, mais apporte plus de configuration et de temps d'execution pour une valeur limitee sur ce projet.
+
+## Conséquences
+
+- Un seul outil gere formatage, lint et import ordering.
+- Les hooks et la CI sont plus simples a expliquer et a maintenir.
+- Les equivalences avec les plugins du brief sont documentees dans `packages/biome/README.md`.
+- Si une regle ESLint precise manque, elle doit etre compensee par TypeScript strict, revue de code ou test cible.
+
+## Références
+
+- `CLAUDE.md` section Stack technique.
+- `packages/biome/README.md`.
+- `docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md` section 9.1.
+

--- a/docs/adr/003-commit-reveal-anticheat.md
+++ b/docs/adr/003-commit-reveal-anticheat.md
@@ -1,0 +1,36 @@
+# ADR-003 — Commit-reveal pour l'anti-triche
+
+## Statut
+
+Accepte.
+
+## Contexte
+
+Dans un Pierre-Feuille-Ciseaux temps reel, si un joueur peut connaitre le coup adverse avant de choisir le sien, il peut toujours gagner. Le serveur doit donc arbitrer les rounds sans donner d'information prematuree et fournir une preuve verifiable apres match.
+
+## Options envisagées
+
+| Option | Avantages | Limites |
+|---|---|---|
+| Arbitrage pur serveur avec coup en clair | Simple, peu de messages, facile a implementer en P0. | Requiert une confiance totale dans le serveur, ne produit pas de preuve publique rejouable. |
+| Commit-reveal | Engage chaque joueur avant revelation, empeche l'adaptation au coup adverse, produit un audit trail cryptographique. | Plus de transitions, timeouts et tests; UX un peu plus complexe. |
+
+## Décision
+
+Nous utilisons un protocole commit-reveal : chaque joueur envoie d'abord `SHA256(move + ":" + nonce)`, puis revele `move` et `nonce`. Le serveur verifie le hash avant de resoudre le round.
+
+L'alternative principale rejetee est l'arbitrage pur serveur avec coups en clair. Elle suffit pour une demo fonctionnelle, mais ne repond pas au niveau d'argumentation attendu sur l'anti-triche.
+
+## Conséquences
+
+- Un joueur ne peut pas changer son coup apres avoir observe l'adversaire.
+- Les `commit`, `move` et `nonce` conserves dans les rounds permettent de rejouer et verifier un match a posteriori.
+- La state machine doit gerer `WAITING_COMMITS`, `WAITING_REVEALS`, les timeouts et les forfeits sur hash invalide.
+- Les tests de state machine deviennent critiques et doivent couvrir les transitions avec timers.
+
+## Références
+
+- `docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md` sections 5.2 et 11.
+- `docs/backlog/sprint-1-game-service.md` US-035.
+- `docs/backlog/sprint-1-api.md` US-034.
+

--- a/docs/adr/004-jwt-ws-querystring.md
+++ b/docs/adr/004-jwt-ws-querystring.md
@@ -1,0 +1,44 @@
+# ADR-004 — JWT WebSocket en query string
+
+## Statut
+
+Accepte avec mitigations.
+
+## Contexte
+
+Le navigateur ne permet pas d'ajouter librement un header `Authorization` lors de l'upgrade WebSocket/Socket.io. Le Game Service doit pourtant authentifier la connexion avant d'accepter `joinQueue` ou un event de match.
+
+## Options envisagées
+
+| Option | Avantages | Limites |
+|---|---|---|
+| JWT dans la query string `?token=` | Compatible navigateur et Socket.io, authentification disponible des le handshake. | Risque de fuite dans logs, historiques ou outils proxy si mal configure. |
+| Premier message Socket.io `authenticate` | Evite le token dans l'URL. | La connexion existe deja avant authentification; il faut gerer un etat temporaire et fermer les sockets non authentifies. |
+| Ticket ephemere `POST /auth/ws-ticket` | Token usage unique court, reduit l'exposition du JWT principal. | Endpoint et stockage supplementaires; complexite non indispensable pour le sprint courant. |
+
+## Décision
+
+Nous passons le JWT en query string au handshake WebSocket, avec mitigations explicites. L'alternative principale rejetee pour l'instant est le ticket ephemere `POST /auth/ws-ticket` : plus propre a long terme, mais disproportionne pour le besoin actuel.
+
+Les six mitigations retenues sont :
+
+1. TLS obligatoire en production : `wss://`, jamais `ws://`.
+2. TTL court des access tokens : 15 minutes.
+3. Re-verification serveur a l'upgrade via `Auth.VerifyToken` et blacklist Redis.
+4. Redaction des logs applicatifs : ne jamais logger `token=`.
+5. Pas de fuite `Referer` : l'ecran de match ne navigue pas vers un domaine tiers pendant la session.
+6. Reverse proxy configure pour ne pas conserver l'URL complete dans ses access logs ou pour la reecrire.
+
+## Conséquences
+
+- L'authentification est disponible avant d'accepter les events metier.
+- Le choix reste defensible en soutenance car les risques sont identifies et controles.
+- Une evolution vers un ticket ephemere reste possible si le niveau de securite attendu augmente.
+- Toute configuration de logs ou proxy doit etre revue pour ne pas exposer la query string.
+
+## Références
+
+- `CLAUDE.md` section Securite.
+- `docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md` sections 6.2 et 7.
+- `docs/backlog/sprint-1-game-service.md` US-017.
+

--- a/docs/adr/005-match-state-redis.md
+++ b/docs/adr/005-match-state-redis.md
@@ -1,0 +1,38 @@
+# ADR-005 — Etat de match dans Redis
+
+## Statut
+
+Accepte.
+
+## Contexte
+
+Un match BO3 est un etat temps reel, ephemere et fortement mute pendant quelques secondes : coups, commits, reveals, deadlines, score courant, reconnexion possible. Le Game Service peut etre replique; l'etat ne doit donc pas rester uniquement en memoire d'une instance.
+
+## Options envisagées
+
+| Option | Avantages | Limites |
+|---|---|---|
+| Memoire locale Game Service | Tres rapide et simple. | Perdu au redemarrage; incompatible avec multi-instances et reconnexion cross-replica. |
+| PostgreSQL comme etat temps reel | Durable, transactionnel, requetable. | Latence et contention inutiles pour des rounds inferieurs a 5 s; melange etat ephemere et historique durable. |
+| Redis avec TTL | Rapide, partage entre replicas, TTL natif, locks et pub/sub disponibles. | Donnee volatile; necessite persistance finale vers PostgreSQL via job. |
+
+## Décision
+
+Nous stockons l'etat courant dans Redis sous `match:<matchId>:state` avec TTL 1 h, et nous utilisons `match:<matchId>:lock` pour serialiser les mutations. PostgreSQL reste la source durable apres fin de match, via le job `match-ended`.
+
+L'alternative principale rejetee est PostgreSQL pour l'etat temps reel : robuste pour l'historique, mais trop lourd pour orchestrer les transitions de round et les deadlines courtes.
+
+## Conséquences
+
+- N'importe quelle replica Game Service peut reprendre ou diffuser l'etat d'un match.
+- Les reconnects peuvent retrouver le match courant via Redis.
+- Les locks Redis protegent les mutations concurrentes.
+- La durabilite finale depend du job-runner; il faut publier `match-ended` et persister matches/rounds/ELO en PostgreSQL.
+- Le TTL limite les fuites d'etat si un match reste bloque.
+
+## Références
+
+- `docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md` sections 5.3 et 6.4.
+- `docs/backlog/sprint-1-game-service.md` US-020, US-036 et US-038.
+- `docs/architecture/redis-keys.md`.
+


### PR DESCRIPTION
## Summary
- Adds 5 ADRs under `docs/adr/` for the technical choices called out by US-052.
- Documents context, alternatives, decision, consequences, and references for gRPC, Biome, commit-reveal, JWT over WS query string, and Redis match state.
- Updates `docs/README.md` to list the ADR directory and available ADRs.

Closes #107

## Acceptance criteria
- [x] AC1: 5 ADR files created with the requested filenames.
- [x] AC2: each ADR follows the requested template sections.
- [x] AC3: each ADR mentions the main rejected alternative and why.
- [x] AC4: Biome ADR references professor validation through `CLAUDE.md`, `packages/biome/README.md`, and spec section 9.1.
- [x] AC5: JWT WS query string ADR documents TLS, short TTL, blacklist re-check, log redaction, no Referer leak, and reverse proxy mitigation.
- [x] AC6: `docs/README.md` lists the available ADRs.

## Validation
- [x] `git diff --cached --check`
- [x] Pre-commit hook ran; Biome/typecheck skipped because only Markdown docs files were staged.
- [x] Attempted `npx pnpm@9.15.9 biome check ...`; Biome reported the targeted Markdown paths are ignored by config.
- [x] Manual section check with `rg` for ADR headings and rejected alternatives.