### PR TITLE
Add league filtering to leaderboard and expose league summaries

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,6 +13,7 @@ COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
+COPY packages/leagues/package.json packages/leagues/package.json
 COPY packages/proto/package.json packages/proto/package.json
 COPY packages/schemas/package.json packages/schemas/package.json
 COPY packages/tsconfig/package.json packages/tsconfig/package.json

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "predev": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/schemas build",
-    "pretypecheck": "pnpm --filter @chifoumi/db typecheck && pnpm --filter @chifoumi/schemas build && pnpm --filter @chifoumi/proto build",
-    "pretest": "pnpm --filter @chifoumi/schemas build && pnpm --filter @chifoumi/proto build",
-    "pretest:e2e": "pnpm --filter @chifoumi/schemas build && pnpm --filter @chifoumi/proto build",
+    "predev": "pnpm --filter @chifoumi/leagues build && pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/schemas build",
+    "pretypecheck": "pnpm --filter @chifoumi/leagues build && pnpm --filter @chifoumi/db typecheck && pnpm --filter @chifoumi/schemas build && pnpm --filter @chifoumi/proto build",
+    "pretest": "pnpm --filter @chifoumi/leagues build && pnpm --filter @chifoumi/schemas build && pnpm --filter @chifoumi/proto build",
+    "pretest:e2e": "pnpm --filter @chifoumi/leagues build && pnpm --filter @chifoumi/schemas build && pnpm --filter @chifoumi/proto build",
     "dev": "tsx watch src/main.ts",
     "build": "tsc -p tsconfig.json",
     "prebuild": "pnpm --filter @chifoumi/proto build",
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@chifoumi/db": "workspace:*",
+    "@chifoumi/leagues": "workspace:*",
     "@chifoumi/proto": "workspace:*",
     "@chifoumi/schemas": "workspace:*",
     "@grpc/grpc-js": "^1.13.4",

--- a/apps/api/src/leaderboard/dto/leaderboard-query.dto.ts
+++ b/apps/api/src/leaderboard/dto/leaderboard-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsInt, IsOptional, Max, Min } from "class-validator";
+import { IsInt, IsOptional, IsString, Max, Min } from "class-validator";
 
 export class LeaderboardQueryDto {
   @ApiPropertyOptional({ type: Number, minimum: 1, maximum: 100, default: 50, example: 50 })
@@ -10,4 +10,9 @@ export class LeaderboardQueryDto {
   @Min(1)
   @Max(100, { message: "limit must be ≤ 100" })
   limit = 50;
+
+  @ApiPropertyOptional({ type: String, example: "gold" })
+  @IsOptional()
+  @IsString()
+  league?: string;
 }

--- a/apps/api/src/leaderboard/dto/leaderboard-response.dto.ts
+++ b/apps/api/src/leaderboard/dto/leaderboard-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { LeagueSummaryDto } from "../../leagues/dto/league-summary.dto.js";
 
 export class LeaderboardEntryDto {
   @ApiProperty({ type: Number, example: 1 })
@@ -15,6 +16,9 @@ export class LeaderboardEntryDto {
 
   @ApiProperty({ type: Number, example: 42 })
   gamesPlayed!: number;
+
+  @ApiProperty({ type: () => LeagueSummaryDto })
+  league!: LeagueSummaryDto;
 }
 
 export class LeaderboardResponseDto {

--- a/apps/api/src/leaderboard/leaderboard.controller.ts
+++ b/apps/api/src/leaderboard/leaderboard.controller.ts
@@ -14,7 +14,7 @@ import { LeaderboardResponseDto } from "./dto/leaderboard-response.dto.js";
 import { LeaderboardService } from "./leaderboard.service.js";
 
 @ApiTags("leaderboard")
-@SkipThrottle({ auth: true })
+@SkipThrottle({ auth: true, audit: true })
 @UseGuards(JwtAuthGuard)
 @Controller("leaderboard")
 export class LeaderboardController {
@@ -25,11 +25,12 @@ export class LeaderboardController {
   @Public()
   @Get()
   @ApiOperation({
-    summary: "Get global top players by rating",
+    summary: "Get top players by rating",
     description:
-      "Public leaderboard sorted by `rating DESC, gamesPlayed DESC`. Results are cached in Redis for 30 seconds.",
+      "Public leaderboard sorted by `rating DESC, gamesPlayed DESC`, optionally filtered by league. Results are cached in Redis for 30 seconds.",
   })
   @ApiQuery({ name: "limit", required: false, type: Number, example: 50, minimum: 1, maximum: 100 })
+  @ApiQuery({ name: "league", required: false, type: String, example: "gold" })
   @ApiOkResponse({
     description: "Leaderboard page",
     type: LeaderboardResponseDto,
@@ -55,7 +56,7 @@ export class LeaderboardController {
     @Query() query: LeaderboardQueryDto,
     @Res({ passthrough: true }) res: { setHeader(name: string, value: string): void },
   ): Promise<LeaderboardResponseDto> {
-    const { data, cache } = await this.leaderboardService.get(query.limit);
+    const { data, cache } = await this.leaderboardService.get(query.limit, query.league);
     res.setHeader("X-Cache", cache);
     return data;
   }

--- a/apps/api/src/leaderboard/leaderboard.service.spec.ts
+++ b/apps/api/src/leaderboard/leaderboard.service.spec.ts
@@ -36,6 +36,7 @@ describe("LeaderboardService", () => {
           displayName: "Alice",
           rating: 1500,
           gamesPlayed: 42,
+          league: { name: "Platinum", tier: 4 },
         },
       ],
     };
@@ -73,6 +74,7 @@ describe("LeaderboardService", () => {
         displayName: "Alice",
         rating: 1500,
         gamesPlayed: 42,
+        league: { name: "Platinum", tier: 4 },
       },
       {
         rank: 2,
@@ -80,6 +82,7 @@ describe("LeaderboardService", () => {
         displayName: "Bob",
         rating: 1400,
         gamesPlayed: 50,
+        league: { name: "Platinum", tier: 4 },
       },
     ]);
     expect(prisma.eloRating.findMany).toHaveBeenCalledWith(
@@ -89,9 +92,51 @@ describe("LeaderboardService", () => {
       }),
     );
     expect(redis.setex).toHaveBeenCalledWith(
-      "leaderboard:top:50",
+      "leaderboard:top:50:all",
       LEADERBOARD_CACHE_TTL_SECONDS,
       JSON.stringify(result.data),
     );
+  });
+
+  it("filters and caches by league variant", async () => {
+    redis.get.mockResolvedValue(null);
+    prisma.eloRating.findMany.mockResolvedValue([
+      {
+        rating: 1250,
+        gamesPlayed: 12,
+        user: { id: "user-1", displayName: "Alice" },
+      },
+    ]);
+
+    const result = await service.get(20, "gold");
+
+    expect(result.data.items).toEqual([
+      {
+        rank: 1,
+        userId: "user-1",
+        displayName: "Alice",
+        rating: 1250,
+        gamesPlayed: 12,
+        league: { name: "Gold", tier: 3 },
+      },
+    ]);
+    expect(prisma.eloRating.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { rating: { gte: 1200, lte: 1349 } },
+        take: 20,
+      }),
+    );
+    expect(redis.get).toHaveBeenCalledWith("leaderboard:top:20:gold");
+    expect(redis.setex).toHaveBeenCalledWith(
+      "leaderboard:top:20:gold",
+      LEADERBOARD_CACHE_TTL_SECONDS,
+      JSON.stringify(result.data),
+    );
+  });
+
+  it("rejects an unknown league", async () => {
+    await expect(service.get(20, "diamond")).rejects.toMatchObject({
+      response: { code: "UNKNOWN_LEAGUE" },
+    });
   });
 });

--- a/apps/api/src/leaderboard/leaderboard.service.ts
+++ b/apps/api/src/leaderboard/leaderboard.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable } from "@nestjs/common";
+import {
+  getLeagueSummaryForRating,
+  getReferenceLeagueByName,
+  type ReferenceLeague,
+  toLeagueSummary,
+} from "@chifoumi/leagues";
+import { BadRequestException, Inject, Injectable } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { LEADERBOARD_CACHE_KEY_PREFIX, RedisService } from "../redis/redis.service.js";
 import type { LeaderboardResponseDto } from "./dto/leaderboard-response.dto.js";
@@ -19,8 +25,9 @@ export class LeaderboardService {
     @Inject(RedisService) private readonly redis: RedisService,
   ) {}
 
-  async get(limit: number): Promise<LeaderboardResult> {
-    const cacheKey = `${LEADERBOARD_CACHE_KEY_PREFIX}${limit}`;
+  async get(limit: number, leagueName?: string): Promise<LeaderboardResult> {
+    const league = this.resolveLeague(leagueName);
+    const cacheKey = `${LEADERBOARD_CACHE_KEY_PREFIX}${limit}:${league?.name.toLowerCase() ?? "all"}`;
     const cached = await this.redis.get(cacheKey);
 
     if (cached) {
@@ -30,14 +37,18 @@ export class LeaderboardService {
       };
     }
 
-    const data = await this.fetchFromDatabase(limit);
+    const data = await this.fetchFromDatabase(limit, league);
     await this.redis.setex(cacheKey, LEADERBOARD_CACHE_TTL_SECONDS, JSON.stringify(data));
 
     return { data, cache: "MISS" };
   }
 
-  private async fetchFromDatabase(limit: number): Promise<LeaderboardResponseDto> {
+  private async fetchFromDatabase(
+    limit: number,
+    league: ReferenceLeague | null,
+  ): Promise<LeaderboardResponseDto> {
     const rows = await this.prisma.eloRating.findMany({
+      where: league ? this.toRatingWhere(league) : undefined,
       orderBy: [{ rating: "desc" }, { gamesPlayed: "desc" }],
       take: Math.trunc(Number(limit)),
       include: {
@@ -57,7 +68,30 @@ export class LeaderboardService {
         displayName: row.user.displayName,
         rating: row.rating,
         gamesPlayed: row.gamesPlayed,
+        league: league ? toLeagueSummary(league) : getLeagueSummaryForRating(row.rating),
       })),
+    };
+  }
+
+  private resolveLeague(leagueName: string | undefined): ReferenceLeague | null {
+    if (!leagueName) {
+      return null;
+    }
+
+    const league = getReferenceLeagueByName(leagueName);
+    if (!league) {
+      throw new BadRequestException({ code: "UNKNOWN_LEAGUE" });
+    }
+
+    return league;
+  }
+
+  private toRatingWhere(league: ReferenceLeague): { rating: { gte: number; lte?: number } } {
+    return {
+      rating: {
+        gte: league.minRating,
+        ...(league.maxRating === null ? {} : { lte: league.maxRating }),
+      },
     };
   }
 }

--- a/apps/api/src/leagues/dto/league-summary.dto.ts
+++ b/apps/api/src/leagues/dto/league-summary.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class LeagueSummaryDto {
+  @ApiProperty({ type: String, example: "Gold" })
+  name!: string;
+
+  @ApiProperty({ type: Number, example: 3 })
+  tier!: number;
+}

--- a/apps/api/src/me/dto/me-profile.dto.ts
+++ b/apps/api/src/me/dto/me-profile.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { LeagueSummaryDto } from "../../leagues/dto/league-summary.dto.js";
 
 export class MeProfileDto {
   @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
@@ -18,6 +19,9 @@ export class MeProfileDto {
 
   @ApiProperty({ type: Number, example: 0 })
   gamesPlayed!: number;
+
+  @ApiProperty({ type: () => LeagueSummaryDto })
+  league!: LeagueSummaryDto;
 
   @ApiProperty({ type: Date, format: "date-time", example: "2026-06-08T12:00:00.000Z" })
   createdAt!: Date;

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -1,3 +1,4 @@
+import { getLeagueSummaryForRating, type LeagueSummary } from "@chifoumi/leagues";
 import { Inject, Injectable, UnauthorizedException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 
@@ -8,6 +9,7 @@ export type MeProfile = {
   role: "player" | "admin";
   rating: number;
   gamesPlayed: number;
+  league: LeagueSummary;
   createdAt: Date;
 };
 
@@ -25,13 +27,16 @@ export class MeService {
       throw new UnauthorizedException();
     }
 
+    const rating = user.eloRating?.rating ?? 1000;
+
     return {
       id: user.id,
       email: user.email,
       displayName: user.displayName,
       role: user.role === "admin" ? "admin" : "player",
-      rating: user.eloRating?.rating ?? 1000,
+      rating,
       gamesPlayed: user.eloRating?.gamesPlayed ?? 0,
+      league: getLeagueSummaryForRating(rating),
       createdAt: user.createdAt,
     };
   }

--- a/apps/api/src/users/dto/public-profile.dto.ts
+++ b/apps/api/src/users/dto/public-profile.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { LeagueSummaryDto } from "../../leagues/dto/league-summary.dto.js";
 
 export class PublicProfileDto {
   @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
@@ -12,6 +13,9 @@ export class PublicProfileDto {
 
   @ApiProperty({ type: Number, example: 0 })
   gamesPlayed!: number;
+
+  @ApiProperty({ type: () => LeagueSummaryDto })
+  league!: LeagueSummaryDto;
 
   @ApiProperty({
     type: Number,

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -7,13 +7,19 @@ describe("UsersService.listUsers", () => {
   let service: UsersService;
   let prisma: {
     $transaction: ReturnType<typeof jest.fn>;
-    user: { findMany: ReturnType<typeof jest.fn>; count: ReturnType<typeof jest.fn> };
+    $queryRaw: ReturnType<typeof jest.fn>;
+    user: {
+      findMany: ReturnType<typeof jest.fn>;
+      findUnique: ReturnType<typeof jest.fn>;
+      count: ReturnType<typeof jest.fn>;
+    };
   };
 
   beforeEach(() => {
     prisma = {
       $transaction: jest.fn(),
-      user: { findMany: jest.fn(), count: jest.fn() },
+      $queryRaw: jest.fn(),
+      user: { findMany: jest.fn(), findUnique: jest.fn(), count: jest.fn() },
     };
     service = new UsersService(prisma as unknown as PrismaService);
   });
@@ -70,5 +76,27 @@ describe("UsersService.listUsers", () => {
     expect(prisma.user.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ skip: 20, take: 10, orderBy: { createdAt: "desc" } }),
     );
+  });
+
+  it("adds the current league to public profiles", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      displayName: "gold-player",
+      createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      eloRating: { rating: 1250, gamesPlayed: 10 },
+    });
+    prisma.$queryRaw.mockResolvedValue([{ wins: 4 }]);
+
+    const result = await service.getPublicProfile("user-1");
+
+    expect(result).toEqual({
+      id: "user-1",
+      displayName: "gold-player",
+      rating: 1250,
+      gamesPlayed: 10,
+      league: { name: "Gold", tier: 3 },
+      winRate: 0.4,
+      createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    });
   });
 });

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,4 +1,5 @@
 import { Prisma, type User, UserRole } from "@chifoumi/db";
+import { getLeagueSummaryForRating } from "@chifoumi/leagues";
 import { Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import type { PublicProfileDto } from "./dto/public-profile.dto.js";
@@ -70,13 +71,15 @@ export class UsersService {
     }
 
     const gamesPlayed = user.eloRating?.gamesPlayed ?? 0;
+    const rating = user.eloRating?.rating ?? 1000;
     const wins = gamesPlayed === 0 ? 0 : await this.countWins(userId);
 
     return {
       id: user.id,
       displayName: user.displayName,
-      rating: user.eloRating?.rating ?? 1000,
+      rating,
       gamesPlayed,
+      league: getLeagueSummaryForRating(rating),
       winRate: this.calculateWinRate(wins, gamesPlayed),
       createdAt: user.createdAt,
     };

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -103,6 +103,7 @@ describe("Auth (e2e)", () => {
       role: "player",
       rating: 1000,
       gamesPlayed: 0,
+      league: { name: "Bronze", tier: 1 },
       createdAt: expect.any(String),
     });
 
@@ -116,6 +117,7 @@ describe("Auth (e2e)", () => {
       displayName: "player1",
       rating: 1000,
       gamesPlayed: 0,
+      league: { name: "Bronze", tier: 1 },
       winRate: 0,
       createdAt: expect.any(String),
     });

--- a/apps/api/test/leaderboard.e2e-spec.ts
+++ b/apps/api/test/leaderboard.e2e-spec.ts
@@ -97,19 +97,66 @@ describe("GET /leaderboard (e2e)", () => {
       displayName: "top",
       rating: 1600,
       gamesPlayed: 10,
+      league: { name: "Platinum", tier: 4 },
     });
     expect(res.body.items[1]).toMatchObject({
       rank: 2,
       displayName: "tie-rating-b",
       rating: 1500,
       gamesPlayed: 50,
+      league: { name: "Platinum", tier: 4 },
     });
     expect(res.body.items[2]).toMatchObject({
       rank: 3,
       displayName: "tie-rating-a",
       rating: 1500,
       gamesPlayed: 30,
+      league: { name: "Platinum", tier: 4 },
     });
+  });
+
+  it("filters players by league and keeps cache variants isolated", async () => {
+    await seedPlayer("bronze", 1099, 4);
+    await seedPlayer("gold-top", 1349, 8);
+    await seedPlayer("gold-low", 1200, 12);
+    await seedPlayer("platinum", 1350, 2);
+
+    const gold = await request(app.getHttpServer())
+      .get("/leaderboard?limit=10&league=gold")
+      .expect(200);
+    const all = await request(app.getHttpServer()).get("/leaderboard?limit=10").expect(200);
+    const goldCached = await request(app.getHttpServer())
+      .get("/leaderboard?limit=10&league=gold")
+      .expect(200);
+
+    expect(gold.headers["x-cache"]).toBe("MISS");
+    expect(all.headers["x-cache"]).toBe("MISS");
+    expect(goldCached.headers["x-cache"]).toBe("HIT");
+    expect(gold.body.items.map((item: { displayName: string }) => item.displayName)).toEqual([
+      "gold-top",
+      "gold-low",
+    ]);
+    expect(
+      gold.body.items.every(
+        (item: { rating: number; league: { name: string; tier: number } }) =>
+          item.rating >= 1200 &&
+          item.rating <= 1349 &&
+          item.league.name === "Gold" &&
+          item.league.tier === 3,
+      ),
+    ).toBe(true);
+    expect(all.body.items.map((item: { displayName: string }) => item.displayName)).toEqual([
+      "platinum",
+      "gold-top",
+      "gold-low",
+      "bronze",
+    ]);
+  });
+
+  it("rejects an unknown league", async () => {
+    const res = await request(app.getHttpServer()).get("/leaderboard?league=diamond").expect(400);
+
+    expect(res.body).toEqual({ code: "UNKNOWN_LEAGUE" });
   });
 
   it("serves subsequent requests from Redis cache", async () => {

--- a/apps/front/Dockerfile
+++ b/apps/front/Dockerfile
@@ -13,6 +13,7 @@ COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
+COPY packages/leagues/package.json packages/leagues/package.json
 COPY packages/proto/package.json packages/proto/package.json
 COPY packages/schemas/package.json packages/schemas/package.json
 COPY packages/tsconfig/package.json packages/tsconfig/package.json

--- a/apps/front/src/api/types.ts
+++ b/apps/front/src/api/types.ts
@@ -19,6 +19,11 @@ export type RefreshResponse = {
   tokens: AuthTokens;
 };
 
+export type LeagueSummary = {
+  name: string;
+  tier: number;
+};
+
 export type MeProfile = {
   id: string;
   email: string;
@@ -26,6 +31,7 @@ export type MeProfile = {
   role: "player" | "admin";
   rating: number;
   gamesPlayed: number;
+  league: LeagueSummary;
   createdAt: string;
 };
 
@@ -34,6 +40,7 @@ export type PublicProfile = {
   displayName: string;
   rating: number;
   gamesPlayed: number;
+  league: LeagueSummary;
   winRate: number;
   createdAt: string;
 };
@@ -44,6 +51,7 @@ export type LeaderboardEntry = {
   displayName: string;
   rating: number;
   gamesPlayed: number;
+  league: LeagueSummary;
 };
 
 export type LeaderboardResponse = {

--- a/apps/front/src/components/LeaderboardTable.tsx
+++ b/apps/front/src/components/LeaderboardTable.tsx
@@ -14,6 +14,7 @@ export function LeaderboardTable({ items }: LeaderboardTableProps) {
             <th scope="col">Rang</th>
             <th scope="col">Joueur</th>
             <th scope="col">Rating</th>
+            <th scope="col">Ligue</th>
             <th scope="col">Matchs joués</th>
           </tr>
         </thead>
@@ -27,6 +28,7 @@ export function LeaderboardTable({ items }: LeaderboardTableProps) {
                 </Link>
               </td>
               <td>{entry.rating}</td>
+              <td>{entry.league.name}</td>
               <td>{entry.gamesPlayed}</td>
             </tr>
           ))}

--- a/apps/front/src/components/ProfileHeader.tsx
+++ b/apps/front/src/components/ProfileHeader.tsx
@@ -33,6 +33,8 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
         ) : null}
         <dt>Rating</dt>
         <dd>{stats.rating}</dd>
+        <dt>Ligue</dt>
+        <dd>{stats.league.name}</dd>
         <dt>Matchs joués</dt>
         <dd>{stats.gamesPlayed}</dd>
         <dt>Taux de victoire</dt>

--- a/apps/game-service/Dockerfile
+++ b/apps/game-service/Dockerfile
@@ -13,6 +13,7 @@ COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
+COPY packages/leagues/package.json packages/leagues/package.json
 COPY packages/proto/package.json packages/proto/package.json
 COPY packages/schemas/package.json packages/schemas/package.json
 COPY packages/tsconfig/package.json packages/tsconfig/package.json

--- a/apps/job-runner/Dockerfile
+++ b/apps/job-runner/Dockerfile
@@ -13,6 +13,7 @@ COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
+COPY packages/leagues/package.json packages/leagues/package.json
 COPY packages/proto/package.json packages/proto/package.json
 COPY packages/schemas/package.json packages/schemas/package.json
 COPY packages/tsconfig/package.json packages/tsconfig/package.json

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,7 +10,9 @@
     "generate": "prisma generate",
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
+    "prebuild": "pnpm --filter @chifoumi/leagues build",
     "build": "prisma generate && tsc -p tsconfig.json",
+    "pretypecheck": "pnpm --filter @chifoumi/leagues build",
     "typecheck": "prisma generate && tsc -p tsconfig.json",
     "seed": "tsx prisma/seed.ts",
     "seed:bench": "tsx scripts/seed-bench.ts",
@@ -24,6 +26,9 @@
   "peerDependencies": {
     "@prisma/client": "*",
     "prisma": "*"
+  },
+  "dependencies": {
+    "@chifoumi/leagues": "workspace:*"
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/packages/db/src/seed/leagues.ts
+++ b/packages/db/src/seed/leagues.ts
@@ -1,13 +1,8 @@
+import { REFERENCE_LEAGUES } from "@chifoumi/leagues";
 import { type PrismaClient, SeasonStatus } from "@prisma/client";
 
 const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000;
-
-export const REFERENCE_LEAGUES = [
-  { name: "Bronze", tier: 1, minRating: 0, maxRating: 1099 },
-  { name: "Silver", tier: 2, minRating: 1100, maxRating: 1199 },
-  { name: "Gold", tier: 3, minRating: 1200, maxRating: 1349 },
-  { name: "Platinum", tier: 4, minRating: 1350, maxRating: null },
-] as const;
+export { REFERENCE_LEAGUES };
 
 export async function seedLeaguesAndActiveSeason(
   prisma: PrismaClient,

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -7,5 +7,6 @@
     "declarationMap": true,
     "composite": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
 }

--- a/packages/leagues/package.json
+++ b/packages/leagues/package.json
@@ -5,10 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json",
-    "pretest": "tsc -p tsconfig.json",
+    "pretest": "tsc -p tsconfig.spec.json",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
   },
   "devDependencies": {

--- a/packages/leagues/src/index.ts
+++ b/packages/leagues/src/index.ts
@@ -1,4 +1,10 @@
 export { getLeagueForRating } from "./getLeagueForRating.js";
 export { getLeagueProgress } from "./getLeagueProgress.js";
 export { LeagueError, type LeagueErrorCode } from "./league-error.js";
-export type { League } from "./types.js";
+export {
+  getLeagueSummaryForRating,
+  getReferenceLeagueByName,
+  REFERENCE_LEAGUES,
+  toLeagueSummary,
+} from "./reference-leagues.js";
+export type { League, LeagueSummary, ReferenceLeague } from "./types.js";

--- a/packages/leagues/src/reference-leagues.spec.ts
+++ b/packages/leagues/src/reference-leagues.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getLeagueSummaryForRating,
+  getReferenceLeagueByName,
+  REFERENCE_LEAGUES,
+  toLeagueSummary,
+} from "./reference-leagues.js";
+
+describe("reference leagues", () => {
+  it("looks up leagues by case-insensitive name", () => {
+    expect(getReferenceLeagueByName("gold")).toEqual(REFERENCE_LEAGUES[2]);
+    expect(getReferenceLeagueByName(" Platinum ")).toEqual(REFERENCE_LEAGUES[3]);
+    expect(getReferenceLeagueByName("diamond")).toBeNull();
+  });
+
+  it("returns a public summary for a rating", () => {
+    expect(getLeagueSummaryForRating(1200)).toEqual({ name: "Gold", tier: 3 });
+  });
+
+  it("projects a reference league to its API summary", () => {
+    expect(toLeagueSummary(REFERENCE_LEAGUES[0])).toEqual({ name: "Bronze", tier: 1 });
+  });
+});

--- a/packages/leagues/src/reference-leagues.ts
+++ b/packages/leagues/src/reference-leagues.ts
@@ -1,0 +1,26 @@
+import { getLeagueForRating } from "./getLeagueForRating.js";
+import type { LeagueSummary, ReferenceLeague } from "./types.js";
+
+export const REFERENCE_LEAGUES = [
+  { name: "Bronze", tier: 1, minRating: 0, maxRating: 1099 },
+  { name: "Silver", tier: 2, minRating: 1100, maxRating: 1199 },
+  { name: "Gold", tier: 3, minRating: 1200, maxRating: 1349 },
+  { name: "Platinum", tier: 4, minRating: 1350, maxRating: null },
+] as const satisfies readonly ReferenceLeague[];
+
+export function getReferenceLeagueByName(name: string): ReferenceLeague | null {
+  const normalizedName = name.trim().toLowerCase();
+  return REFERENCE_LEAGUES.find((league) => league.name.toLowerCase() === normalizedName) ?? null;
+}
+
+export function getLeagueSummaryForRating(rating: number): LeagueSummary {
+  const league = getLeagueForRating(rating, REFERENCE_LEAGUES);
+  return toLeagueSummary(league);
+}
+
+export function toLeagueSummary(league: ReferenceLeague): LeagueSummary {
+  return {
+    name: league.name,
+    tier: league.tier,
+  };
+}

--- a/packages/leagues/src/types.ts
+++ b/packages/leagues/src/types.ts
@@ -2,3 +2,13 @@ export type League = {
   minRating: number;
   maxRating: number | null;
 };
+
+export type ReferenceLeague = League & {
+  name: string;
+  tier: number;
+};
+
+export type LeagueSummary = {
+  name: string;
+  tier: number;
+};

--- a/packages/leagues/tsconfig.json
+++ b/packages/leagues/tsconfig.json
@@ -7,5 +7,6 @@
     "declarationMap": true,
     "composite": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@chifoumi/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@chifoumi/leagues':
+        specifier: workspace:*
+        version: link:../../packages/leagues
       '@chifoumi/proto':
         specifier: workspace:*
         version: link:../../packages/proto
@@ -401,6 +404,10 @@ importers:
         version: 5.7.3
 
   packages/db:
+    dependencies:
+      '@chifoumi/leagues':
+        specifier: workspace:*
+        version: link:../leagues
     devDependencies:
       '@jest/globals':
         specifier: 29.7.0


### PR DESCRIPTION
## Summary
- Add optional `league` filtering to the leaderboard API and isolate Redis cache keys per league variant
- Expose league summaries in leaderboard, profile, and public profile responses
- Reuse shared league metadata from `@chifoumi/leagues` across API and DB seed data
- Update the frontend leaderboard and profile views to display each player’s league

## Testing
- Added unit coverage for leaderboard filtering, cache key variants, and unknown league validation
- Added service coverage for league mapping in user profile responses
- Added e2e coverage for filtered leaderboard results, cache isolation, and league validation
- Not run (not requested)