### PR TITLE
feat(api): add GET /seasons/current endpoint (US-057)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { MetricsModule } from "./metrics/metrics.module.js";
 import { PrismaModule } from "./prisma/prisma.module.js";
 import { QueuesModule } from "./queues/queues.module.js";
 import { RedisModule } from "./redis/redis.module.js";
+import { SeasonsModule } from "./seasons/seasons.module.js";
 import { UsersModule } from "./users/users.module.js";
 
 @Module({
@@ -46,6 +47,7 @@ import { UsersModule } from "./users/users.module.js";
     LeaderboardModule,
     MatchesModule,
     MetricsModule,
+    SeasonsModule,
     JwksModule,
     GrpcModule,
   ],

--- a/apps/api/src/seasons/dto/current-season-response.dto.ts
+++ b/apps/api/src/seasons/dto/current-season-response.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CurrentSeasonDto {
+  @ApiProperty({ type: String, format: "uuid", example: "9b6f7c2a-4e8c-4b1a-9f24-5a7a7a8e6c4a" })
+  id!: string;
+
+  @ApiProperty({ type: String, example: "Saison 1" })
+  name!: string;
+
+  @ApiProperty({ type: String, format: "date-time", example: "2026-06-01T00:00:00.000Z" })
+  startedAt!: Date;
+
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    nullable: true,
+    example: "2026-07-01T00:00:00.000Z",
+  })
+  endsAt!: Date | null;
+
+  @ApiProperty({ enum: ["upcoming", "active", "closed"], example: "active" })
+  status!: "upcoming" | "active" | "closed";
+}
+
+export class CurrentSeasonLeagueDto {
+  @ApiProperty({ type: String, example: "Silver" })
+  name!: string;
+
+  @ApiProperty({ type: Number, example: 2 })
+  tier!: number;
+}
+
+export class CurrentSeasonMeDto {
+  @ApiProperty({ type: Number, example: 1150 })
+  rating!: number;
+
+  @ApiProperty({ type: () => CurrentSeasonLeagueDto })
+  league!: CurrentSeasonLeagueDto;
+
+  @ApiProperty({
+    type: Number,
+    description: "1-indexed rank in the active season ELO ranking",
+    example: 7,
+  })
+  rank!: number;
+
+  @ApiProperty({
+    type: Number,
+    description: "Progress toward the next league, in the [0..1] range",
+    example: 0.5,
+  })
+  progressToNextLeague!: number;
+}
+
+export class CurrentSeasonResponseDto {
+  @ApiProperty({ type: () => CurrentSeasonDto })
+  season!: CurrentSeasonDto;
+
+  @ApiProperty({ type: () => CurrentSeasonMeDto })
+  me!: CurrentSeasonMeDto;
+}

--- a/apps/api/src/seasons/seasons.controller.spec.ts
+++ b/apps/api/src/seasons/seasons.controller.spec.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { CurrentSeasonResponseDto } from "./dto/current-season-response.dto.js";
+import { SeasonsController } from "./seasons.controller.js";
+import type { SeasonsService } from "./seasons.service.js";
+
+describe("SeasonsController", () => {
+  let controller: SeasonsController;
+  let seasonsService: { getCurrent: ReturnType<typeof jest.fn> };
+
+  beforeEach(() => {
+    seasonsService = { getCurrent: jest.fn() };
+    controller = new SeasonsController(seasonsService as unknown as SeasonsService);
+  });
+
+  it("delegates to the service with the authenticated user id", async () => {
+    const response = { season: {}, me: {} } as CurrentSeasonResponseDto;
+    seasonsService.getCurrent.mockResolvedValue(response);
+
+    const result = await controller.getCurrent({
+      user: { id: "ryu-id", email: "ryu@example.com", displayName: "ryu", role: "player" },
+    });
+
+    expect(result).toBe(response);
+    expect(seasonsService.getCurrent).toHaveBeenCalledWith("ryu-id");
+  });
+});

--- a/apps/api/src/seasons/seasons.controller.ts
+++ b/apps/api/src/seasons/seasons.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Inject, Req, UseGuards } from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
+import { SWAGGER_BEARER_AUTH } from "../swagger.js";
+import type { SafeUser } from "../users/users.service.js";
+import { CurrentSeasonResponseDto } from "./dto/current-season-response.dto.js";
+import { SeasonsService } from "./seasons.service.js";
+
+type AuthenticatedRequest = { user: SafeUser };
+
+@ApiTags("seasons")
+@ApiBearerAuth(SWAGGER_BEARER_AUTH)
+@UseGuards(JwtAuthGuard)
+@Controller("seasons")
+export class SeasonsController {
+  constructor(@Inject(SeasonsService) private readonly seasonsService: SeasonsService) {}
+
+  @Get("current")
+  @ApiOperation({
+    summary: "Get the active season and the player's standing",
+    description:
+      "Returns the active season together with the authenticated player's rating, league, 1-indexed ELO rank and progress toward the next league.",
+  })
+  @ApiOkResponse({
+    description: "Active season and player standing",
+    type: CurrentSeasonResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked access token",
+    schema: { example: { statusCode: 401, message: "Unauthorized" } },
+  })
+  @ApiNotFoundResponse({
+    description: "No active season",
+    schema: { example: { code: "NO_ACTIVE_SEASON" } },
+  })
+  getCurrent(@Req() req: AuthenticatedRequest): Promise<CurrentSeasonResponseDto> {
+    return this.seasonsService.getCurrent(req.user.id);
+  }
+}

--- a/apps/api/src/seasons/seasons.module.spec.ts
+++ b/apps/api/src/seasons/seasons.module.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 import { Test } from "@nestjs/testing";
+import { AppConfigModule } from "../config/config.module.js";
 import { PrismaModule } from "../prisma/prisma.module.js";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { QueuesModule } from "../queues/queues.module.js";
@@ -11,22 +12,28 @@ import { SeasonsService } from "./seasons.service.js";
 // because the @Global QueuesModule now *exports* the queue service — otherwise
 // Nest fails to build the graph at NestFactory.create (the e2e boot crash).
 describe("SeasonsModule wiring", () => {
+  const previousPrivateKey = process.env.JWT_PRIVATE_KEY;
+  const previousPublicKey = process.env.JWT_PUBLIC_KEY;
   const previousRedisUrl = process.env.REDIS_URL;
   const previousSkip = process.env.SKIP_REDIS_CONNECT;
 
   beforeAll(() => {
+    process.env.JWT_PRIVATE_KEY = "-----BEGIN TEST PRIVATE KEY-----";
+    process.env.JWT_PUBLIC_KEY = "-----BEGIN TEST PUBLIC KEY-----";
     process.env.REDIS_URL = "redis://localhost:6379";
     process.env.SKIP_REDIS_CONNECT = "true";
   });
 
   afterAll(() => {
+    process.env.JWT_PRIVATE_KEY = previousPrivateKey;
+    process.env.JWT_PUBLIC_KEY = previousPublicKey;
     process.env.REDIS_URL = previousRedisUrl;
     process.env.SKIP_REDIS_CONNECT = previousSkip;
   });
 
   it("resolves SeasonsService with its queue dependency from the global QueuesModule", async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [PrismaModule, QueuesModule, SeasonsModule],
+      imports: [AppConfigModule, PrismaModule, QueuesModule, SeasonsModule],
     })
       .overrideProvider(PrismaService)
       .useValue({})

--- a/apps/api/src/seasons/seasons.module.ts
+++ b/apps/api/src/seasons/seasons.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module.js";
+import { PrismaModule } from "../prisma/prisma.module.js";
+import { SeasonsController } from "./seasons.controller.js";
+import { SeasonsService } from "./seasons.service.js";
+
+@Module({
+  imports: [AuthModule, PrismaModule],
+  controllers: [SeasonsController],
+  providers: [SeasonsService],
+})
+export class SeasonsModule {}

--- a/apps/api/src/seasons/seasons.service.spec.ts
+++ b/apps/api/src/seasons/seasons.service.spec.ts
@@ -1,0 +1,99 @@
+import { SeasonStatus } from "@chifoumi/db";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { NotFoundException } from "@nestjs/common";
+import type { PrismaService } from "../prisma/prisma.service.js";
+import { SeasonsService } from "./seasons.service.js";
+
+// Mirrors the reference leagues seeded in the database (tier-ordered).
+const DB_LEAGUES = [
+  { id: "l1", name: "Bronze", tier: 1, minRating: 0, maxRating: 1099 },
+  { id: "l2", name: "Silver", tier: 2, minRating: 1100, maxRating: 1199 },
+  { id: "l3", name: "Gold", tier: 3, minRating: 1200, maxRating: 1349 },
+  { id: "l4", name: "Platinum", tier: 4, minRating: 1350, maxRating: null },
+];
+
+const ACTIVE_SEASON = {
+  id: "season-1",
+  name: "Saison 1",
+  startedAt: new Date("2026-06-01T00:00:00.000Z"),
+  endsAt: new Date("2026-07-01T00:00:00.000Z"),
+  status: SeasonStatus.active,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+};
+
+describe("SeasonsService.getCurrent", () => {
+  let service: SeasonsService;
+  let prisma: {
+    season: { findFirst: ReturnType<typeof jest.fn> };
+    eloRating: { findUnique: ReturnType<typeof jest.fn>; count: ReturnType<typeof jest.fn> };
+    league: { findMany: ReturnType<typeof jest.fn> };
+  };
+
+  beforeEach(() => {
+    prisma = {
+      season: { findFirst: jest.fn() },
+      eloRating: { findUnique: jest.fn(), count: jest.fn() },
+      league: { findMany: jest.fn() },
+    };
+    prisma.league.findMany.mockResolvedValue(DB_LEAGUES);
+    service = new SeasonsService(prisma as unknown as PrismaService);
+  });
+
+  it("returns the active season with the player's league, rank and progress (ryu → Silver)", async () => {
+    prisma.season.findFirst.mockResolvedValue(ACTIVE_SEASON);
+    prisma.eloRating.findUnique.mockResolvedValue({ rating: 1150, gamesPlayed: 12 });
+    prisma.eloRating.count.mockResolvedValue(6); // 6 players strictly ahead
+
+    const result = await service.getCurrent("ryu-id");
+
+    expect(result.season).toEqual({
+      id: "season-1",
+      name: "Saison 1",
+      startedAt: ACTIVE_SEASON.startedAt,
+      endsAt: ACTIVE_SEASON.endsAt,
+      status: "active",
+    });
+    expect(result.me.rating).toBe(1150);
+    expect(result.me.league).toEqual({ name: "Silver", tier: 2 });
+    expect(result.me.rank).toBe(7); // 6 ahead + 1
+    // (1150 - 1100) / (1199 - 1100) ≈ 0.505
+    expect(result.me.progressToNextLeague).toBeCloseTo(0.505, 3);
+  });
+
+  it("ranks using rating DESC then gamesPlayed DESC (competition rank)", async () => {
+    prisma.season.findFirst.mockResolvedValue(ACTIVE_SEASON);
+    prisma.eloRating.findUnique.mockResolvedValue({ rating: 1150, gamesPlayed: 12 });
+    prisma.eloRating.count.mockResolvedValue(0);
+
+    const result = await service.getCurrent("ryu-id");
+
+    expect(prisma.eloRating.count).toHaveBeenCalledWith({
+      where: {
+        OR: [{ rating: { gt: 1150 } }, { rating: 1150, gamesPlayed: { gt: 12 } }],
+      },
+    });
+    expect(result.me.rank).toBe(1);
+  });
+
+  it("falls back to the starting rating when the player has no elo row", async () => {
+    prisma.season.findFirst.mockResolvedValue(ACTIVE_SEASON);
+    prisma.eloRating.findUnique.mockResolvedValue(null);
+    prisma.eloRating.count.mockResolvedValue(3);
+
+    const result = await service.getCurrent("new-player");
+
+    expect(result.me.rating).toBe(1000);
+    expect(result.me.league).toEqual({ name: "Bronze", tier: 1 });
+  });
+
+  it("throws 404 NO_ACTIVE_SEASON when no season is active", async () => {
+    prisma.season.findFirst.mockResolvedValue(null);
+
+    await expect(service.getCurrent("ryu-id")).rejects.toBeInstanceOf(NotFoundException);
+    await expect(service.getCurrent("ryu-id")).rejects.toMatchObject({
+      response: { code: "NO_ACTIVE_SEASON" },
+    });
+    expect(prisma.eloRating.count).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/seasons/seasons.service.ts
+++ b/apps/api/src/seasons/seasons.service.ts
@@ -1,0 +1,65 @@
+import { SeasonStatus } from "@chifoumi/db";
+import { getLeagueForRating, getLeagueProgress } from "@chifoumi/leagues";
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { PrismaService } from "../prisma/prisma.service.js";
+import type { CurrentSeasonResponseDto } from "./dto/current-season-response.dto.js";
+
+// Players always have an elo rating row created at registration, but fall back
+// to the platform starting rating defensively (mirrors UsersService).
+const STARTING_RATING = 1000;
+
+@Injectable()
+export class SeasonsService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async getCurrent(userId: string): Promise<CurrentSeasonResponseDto> {
+    const season = await this.prisma.season.findFirst({
+      where: { status: SeasonStatus.active },
+    });
+
+    if (!season) {
+      throw new NotFoundException({ code: "NO_ACTIVE_SEASON" });
+    }
+
+    const eloRating = await this.prisma.eloRating.findUnique({ where: { userId } });
+    const rating = eloRating?.rating ?? STARTING_RATING;
+    const gamesPlayed = eloRating?.gamesPlayed ?? 0;
+
+    const leagues = await this.prisma.league.findMany({ orderBy: { tier: "asc" } });
+    const league = getLeagueForRating(rating, leagues);
+    const progressToNextLeague = getLeagueProgress(rating, league);
+
+    const rank = await this.computeRank(rating, gamesPlayed);
+
+    return {
+      season: {
+        id: season.id,
+        name: season.name,
+        startedAt: season.startedAt,
+        endsAt: season.endsAt,
+        status: season.status,
+      },
+      me: {
+        rating,
+        league: { name: league.name, tier: league.tier },
+        rank,
+        progressToNextLeague,
+      },
+    };
+  }
+
+  /**
+   * 1-indexed competition rank using the same ordering as the leaderboard
+   * (`rating DESC, gamesPlayed DESC`): the number of players strictly ahead
+   * plus one.
+   */
+  private async computeRank(rating: number, gamesPlayed: number): Promise<number> {
+    const ahead = await this.prisma.eloRating.count({
+      where: {
+        OR: [{ rating: { gt: rating } }, { rating, gamesPlayed: { gt: gamesPlayed } }],
+      },
+    });
+
+    return ahead + 1;
+  }
+}

--- a/apps/api/src/testing/chifoumi-db.mock.ts
+++ b/apps/api/src/testing/chifoumi-db.mock.ts
@@ -9,6 +9,12 @@ export const MatchStatus = {
   aborted: "aborted",
 } as const;
 
+export const SeasonStatus = {
+  upcoming: "upcoming",
+  active: "active",
+  closed: "closed",
+} as const;
+
 export type User = {
   id: string;
   email: string;
@@ -17,9 +23,21 @@ export type User = {
   role: keyof typeof UserRole;
 };
 
+export type Season = {
+  id: string;
+  name: string;
+  startedAt: Date;
+  endsAt: Date | null;
+  status: keyof typeof SeasonStatus;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 type PrismaDelegate = {
+  count: (...args: unknown[]) => Promise<number>;
   create: (...args: unknown[]) => Promise<unknown>;
   delete: (...args: unknown[]) => Promise<unknown>;
+  findFirst: (...args: unknown[]) => Promise<unknown>;
   findMany: (...args: unknown[]) => Promise<unknown[]>;
   findUnique: (...args: unknown[]) => Promise<unknown>;
   update: (...args: unknown[]) => Promise<unknown>;
@@ -30,9 +48,11 @@ const delegate = {} as PrismaDelegate;
 
 export class PrismaClient {
   readonly eloRating = delegate;
+  readonly league = delegate;
   readonly match = delegate;
   readonly passwordResetToken = delegate;
   readonly refreshToken = delegate;
+  readonly season = delegate;
   readonly user = delegate;
 
   async $queryRaw<T = unknown>(..._args: unknown[]): Promise<T> {


### PR DESCRIPTION
## Summary
Add the public entry point of the seasonal subsystem (US-057): an authenticated `GET /seasons/current` endpoint that returns the active season together with the player's standing (rating, league, rank, progress).

- **`GET /seasons/current`** (`@UseGuards(JwtAuthGuard)`) returns `{ season: { id, name, startedAt, endsAt, status }, me: { rating, league: { name, tier }, rank, progressToNextLeague } }`.
- **Active season**: loaded via `season.findFirst({ where: { status: active } })`; when none exists → `404 { code: "NO_ACTIVE_SEASON" }`.
- **League** computed with `@chifoumi/leagues.getLeagueForRating(rating, leagues)` from the **database** leagues (`league.findMany`, tier-ordered), not the hardcoded reference set — so it follows whatever is seeded.
- **progressToNextLeague** computed with `getLeagueProgress` (clamped to `[0..1]`).
- **rank**: 1-indexed competition rank using the same ordering as the leaderboard (`rating DESC, gamesPlayed DESC`) — the number of players strictly ahead plus one, via a single `eloRating.count` with an `OR` predicate (no full table scan / sort).
- Player with no elo row falls back to the platform starting rating (1000), mirroring `UsersService`.
- Swagger: `@ApiTags("seasons")`, `@ApiOperation`, `@ApiOkResponse` typed with `CurrentSeasonResponseDto`, `@ApiUnauthorizedResponse`, `@ApiNotFoundResponse`.
- New `SeasonsModule` (controller + service + `CurrentSeasonResponseDto`) wired into `AppModule`. Extended the `@chifoumi/db` test double with `SeasonStatus`, the `Season` type, and the `season`/`league` delegates.

`@chifoumi/leagues` was already an API dependency (added with the leaderboard work), so no new wiring was needed there.

## Test plan
- [x] `pnpm biome check` on the changed files — green
- [x] `pnpm --filter @chifoumi/api typecheck` — green
- [x] `pnpm --filter @chifoumi/api test` — 18 suites / 67 tests pass; `seasons.service.ts` at 100% coverage, global above thresholds (lines 89%, branches 76%, functions 87%)
- [ ] Manual smoke (Swagger): authenticate as the demo account `ryu` → `GET /seasons/current` returns the active season with `me.league = { name: "Silver", tier: 2 }`
- [ ] Manual smoke: with no active season in DB → `404 { code: "NO_ACTIVE_SEASON" }`

## Acceptance criteria covered
- AC1: `GET /seasons/current` (JwtAuthGuard) returns the documented `{ season, me }` shape
- AC2: `rank` = 1-indexed position in the active-season global ELO ranking
- AC3: `league` computed via `getLeagueForRating` from the DB leagues
- AC4: `progressToNextLeague` via `getLeagueProgress` ([0..1])
- AC5: no active season → `404 NO_ACTIVE_SEASON`
- AC6: documented in Swagger (`@ApiTags('seasons')`, `@ApiOperation`, typed `@ApiOkResponse`, `@ApiNotFoundResponse`)

## Notes / merge ordering
- This branch was cut from a `develop` that does **not** yet contain US-059 (admin season endpoints). Both US create `apps/api/src/seasons/` and touch `app.module.ts` + the `@chifoumi/db` test double, so the **second** of the two to merge will need a small reconciliation: a single `SeasonsModule` (`controllers: [SeasonsController, AdminSeasonsController]`, `providers: [SeasonsService, SeasonsQueueService]`) and a merged `SeasonsService` (`getCurrent` + `createSeason`/`closeSeason`). No logic conflict, only file overlap.

Closes #113 