### PR TITLE
feat(db): add Tournament, TournamentRegistration, TournamentMatch models (#120)

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -224,11 +224,15 @@ model Tournament {
   id                   String           @id @default(uuid()) @db.Uuid
   name                 String
   format               TournamentFormat
+  // must be a power of 2 (8, 16, 32, 64); enforced at the application layer
   bracketSize          Int              @map("bracket_size")
   registrationOpensAt  DateTime         @map("registration_opens_at")
   startsAt             DateTime         @map("starts_at")
+  endedAt              DateTime?        @map("ended_at")
   status               TournamentStatus @default(upcoming)
   winnerId             String?          @map("winner_id") @db.Uuid
+  createdAt            DateTime         @default(now()) @map("created_at")
+  updatedAt            DateTime         @updatedAt @map("updated_at")
 
   winner        User?                    @relation("TournamentWinner", fields: [winnerId], references: [id])
   registrations TournamentRegistration[]
@@ -247,6 +251,7 @@ model TournamentRegistration {
   user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([tournamentId, userId])
+  @@index([userId])
   @@map("tournament_registrations")
 }
 
@@ -260,13 +265,14 @@ model TournamentMatch {
   nextMatchId  String?    @map("next_match_id") @db.Uuid
   winnerSlot   WinnerSlot? @map("winner_slot")
 
-  tournament Tournament   @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
-  match      Match?        @relation(fields: [matchId], references: [id])
-  slotA      User?         @relation("SlotA", fields: [slotAId], references: [id])
-  slotB      User?         @relation("SlotB", fields: [slotBId], references: [id])
-  nextMatch  TournamentMatch?  @relation("BracketChain", fields: [nextMatchId], references: [id])
+  tournament  Tournament        @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  match       Match?            @relation(fields: [matchId], references: [id], onDelete: SetNull)
+  slotA       User?             @relation("SlotA", fields: [slotAId], references: [id], onDelete: SetNull)
+  slotB       User?             @relation("SlotB", fields: [slotBId], references: [id], onDelete: SetNull)
+  nextMatch   TournamentMatch?  @relation("BracketChain", fields: [nextMatchId], references: [id], onDelete: SetNull)
   prevMatches TournamentMatch[] @relation("BracketChain")
 
   @@index([tournamentId, round])
+  @@index([nextMatchId])
   @@map("tournament_matches")
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -35,6 +35,23 @@ enum RoundWinner {
   draw
 }
 
+enum TournamentFormat {
+  single_elim
+  double_elim
+}
+
+enum TournamentStatus {
+  upcoming
+  registration_open
+  in_progress
+  completed
+}
+
+enum WinnerSlot {
+  a
+  b
+}
+
 model User {
   id           String     @id @default(uuid()) @db.Uuid
   email        String     @unique
@@ -47,11 +64,15 @@ model User {
   eloRating           EloRating?
   refreshTokens       RefreshToken[]
   passwordResetTokens PasswordResetToken[]
-  matchesAsPlayerA    Match[]          @relation("PlayerA")
-  matchesAsPlayerB    Match[]          @relation("PlayerB")
-  matchesWon          Match[]          @relation("Winner")
+  matchesAsPlayerA    Match[]                  @relation("PlayerA")
+  matchesAsPlayerB    Match[]                  @relation("PlayerB")
+  matchesWon          Match[]                  @relation("Winner")
   eloHistory          EloHistory[]
   seasonStandings     SeasonStanding[]
+  tournamentsWon      Tournament[]             @relation("TournamentWinner")
+  tournamentRegistrations TournamentRegistration[]
+  tournamentSlotA     TournamentMatch[]        @relation("SlotA")
+  tournamentSlotB     TournamentMatch[]        @relation("SlotB")
 
   @@map("users")
 }
@@ -111,6 +132,7 @@ model Match {
   winner     User?        @relation("Winner", fields: [winnerId], references: [id])
   rounds     Round[]
   eloHistory EloHistory[]
+  tournamentMatch TournamentMatch?
 
   @@index([playerAId, endedAt(sort: Desc)])
   @@index([playerBId, endedAt(sort: Desc)])
@@ -196,4 +218,55 @@ model SeasonStanding {
   @@index([seasonId, rank])
   @@index([userId])
   @@map("season_standings")
+}
+
+model Tournament {
+  id                   String           @id @default(uuid()) @db.Uuid
+  name                 String
+  format               TournamentFormat
+  bracketSize          Int              @map("bracket_size")
+  registrationOpensAt  DateTime         @map("registration_opens_at")
+  startsAt             DateTime         @map("starts_at")
+  status               TournamentStatus @default(upcoming)
+  winnerId             String?          @map("winner_id") @db.Uuid
+
+  winner        User?                    @relation("TournamentWinner", fields: [winnerId], references: [id])
+  registrations TournamentRegistration[]
+  matches       TournamentMatch[]
+
+  @@map("tournaments")
+}
+
+model TournamentRegistration {
+  tournamentId String   @map("tournament_id") @db.Uuid
+  userId       String   @map("user_id") @db.Uuid
+  seed         Int?
+  registeredAt DateTime @default(now()) @map("registered_at")
+
+  tournament Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([tournamentId, userId])
+  @@map("tournament_registrations")
+}
+
+model TournamentMatch {
+  id           String     @id @default(uuid()) @db.Uuid
+  tournamentId String     @map("tournament_id") @db.Uuid
+  round        Int
+  matchId      String?    @unique @map("match_id") @db.Uuid
+  slotAId      String?    @map("slot_a_id") @db.Uuid
+  slotBId      String?    @map("slot_b_id") @db.Uuid
+  nextMatchId  String?    @map("next_match_id") @db.Uuid
+  winnerSlot   WinnerSlot? @map("winner_slot")
+
+  tournament Tournament   @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  match      Match?        @relation(fields: [matchId], references: [id])
+  slotA      User?         @relation("SlotA", fields: [slotAId], references: [id])
+  slotB      User?         @relation("SlotB", fields: [slotBId], references: [id])
+  nextMatch  TournamentMatch?  @relation("BracketChain", fields: [nextMatchId], references: [id])
+  prevMatches TournamentMatch[] @relation("BracketChain")
+
+  @@index([tournamentId, round])
+  @@map("tournament_matches")
 }


### PR DESCRIPTION
## Summary

Closes #120

Add the three Prisma models required by the tournament subsystem (EPIC-S3-DATA):

- `Tournament` — stores tournament metadata, format, bracket size, schedule, status and optional winner FK
- `TournamentRegistration` — join table linking a user to a tournament with optional seeding; unique composite key `(tournamentId, userId)`
- `TournamentMatch` — bracket slot with self-FK `nextMatchId` to chain rounds, optional `matchId` FK to reuse existing Match/Game Service infra, and `winnerSlot` enum

New enums: `TournamentFormat` (`single_elim | double_elim`), `TournamentStatus` (`upcoming | registration_open | in_progress | completed`), `WinnerSlot` (`a | b`).

`onDelete: Cascade` applied on `TournamentRegistration` and `TournamentMatch` when the parent `Tournament` is deleted.

## Acceptance criteria

- [x] AC1 — `Tournament` model with all required fields and enums
- [x] AC2 — `TournamentRegistration` with `@@unique([tournamentId, userId])`
- [x] AC3 — `TournamentMatch` with `@@index([tournamentId, round])` and self-FK bracket chain
- [x] AC4 — `TournamentFormat` and `TournamentStatus` enums declared, `onDelete: Cascade` on child tables
- [x] AC5 — Schema validated by `prisma validate` (migration to be run against a live DB)
- [x] AC6 — No regressions on existing models; `prisma validate` reports schema valid

## DoD checklist

- [x] Code written and pushed to feature branch
- [x] `prisma validate` green
- [ ] Migration `add_tournaments` generated on a running DB (`pnpm --filter @chifoumi/db prisma migrate dev --name add_tournaments`)
- [ ] `prisma generate` + `pnpm -r typecheck` green (requires running DB for Prisma generate)
- [ ] Reviewed by at least one team member
- [ ] CI green before merge

## Notes

The `TournamentMatch.matchId` FK is nullable (match not yet created until that bracket slot is played), consistent with the spec ("réutilise Game Service"). `prisma validate` confirms the schema — migration generation requires a live PostgreSQL instance.
