### PR TITLE
test(api): add 403 guard-wiring test for GET /users (US-053 #108)

### DIFF
--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { ForbiddenException, type INestApplication } from "@nestjs/common";
+import { type ExecutionContext, type INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import request from "supertest";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
@@ -52,14 +52,15 @@ describe("UsersController — guard wiring (AC6)", () => {
           provide: UsersService,
           useValue: { listUsers: jest.fn(), getPublicProfile: jest.fn() },
         },
+        // Real RolesGuard — the 403 comes from actual guard logic, not a stub.
+        RolesGuard,
       ],
     })
       .overrideGuard(JwtAuthGuard)
-      .useValue({ canActivate: () => true })
-      .overrideGuard(RolesGuard)
       .useValue({
-        canActivate: () => {
-          throw new ForbiddenException({ error: "FORBIDDEN" });
+        canActivate: (ctx: ExecutionContext) => {
+          ctx.switchToHttp().getRequest<{ user: unknown }>().user = { role: "player" };
+          return true;
         },
       })
       .compile();

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,7 +1,13 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ForbiddenException, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
+import { RolesGuard } from "../auth/guards/roles.guard.js";
 import { ListUsersQueryDto } from "./dto/list-users-query.dto.js";
 import { UsersController } from "./users.controller.js";
-import type { AdminUsersPage, UsersService } from "./users.service.js";
+import type { AdminUsersPage } from "./users.service.js";
+import { UsersService } from "./users.service.js";
 
 describe("UsersController", () => {
   let controller: UsersController;
@@ -32,5 +38,41 @@ describe("UsersController", () => {
       expect(result).toBe(page);
       expect(usersService.listUsers).toHaveBeenCalledWith(1, 20);
     });
+  });
+});
+
+describe("UsersController — guard wiring (AC6)", () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: { listUsers: jest.fn(), getPublicProfile: jest.fn() },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({
+        canActivate: () => {
+          throw new ForbiddenException({ error: "FORBIDDEN" });
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => app.close());
+
+  it("returns 403 when the caller is not an administrator", async () => {
+    const { status, body } = await request(app.getHttpServer()).get("/users");
+    expect(status).toBe(403);
+    expect(body).toMatchObject({ error: "FORBIDDEN" });
   });
 });


### PR DESCRIPTION
## Summary

- Adds the missing AC6 test for `GET /users` in `users.controller.spec.ts`
- Uses `Test.createTestingModule` with overridden `JwtAuthGuard` (pass) + `RolesGuard` (throw `ForbiddenException`) + supertest to verify a real HTTP 403 response
- All other AC (controller, service, DTOs, Swagger) were already implemented in the US-049 commit

Closes #108

## Test plan

- [x] `GET /users` — existing happy-path test passes
- [x] `GET /users` — new 403 guard-wiring test passes
- [x] `pnpm biome check` clean (imports sorted by auto-fix)
- [x] `pnpm -r typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)