### PR TITLE
feat(job-runner): implement season-reset processor (#116)

### DIFF
--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json && node scripts/copy-notification-templates.mjs",
     "start": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "pretest": "pnpm --filter @chifoumi/elo build",
+    "pretest": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "preintegration": "pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/db build",
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./jest-e2e.config.cjs --runInBand"
@@ -27,6 +27,7 @@
   "dependencies": {
     "@chifoumi/db": "workspace:*",
     "@chifoumi/elo": "workspace:*",
+    "@chifoumi/leagues": "workspace:*",
     "@nestjs/common": "^11.1.21",
     "@nestjs/core": "^11.1.21",
     "@nestjs/platform-express": "^11.1.21",

--- a/apps/job-runner/src/app.module.ts
+++ b/apps/job-runner/src/app.module.ts
@@ -8,8 +8,11 @@ import { MailService } from "./notifications/mail.service.js";
 import { TemplateService } from "./notifications/template.service.js";
 import { MatchPersistenceService } from "./persistence/match-persistence.service.js";
 import { PrismaModule } from "./prisma/prisma.module.js";
+import { NotificationsQueueService } from "./queues/notifications-queue.service.js";
 import { RedisInvalidationService } from "./redis/redis-invalidation.service.js";
 import { RunnerService } from "./runner.service.js";
+import { SeasonResetService } from "./seasons/season-reset.service.js";
+import { SeasonResetLockService } from "./seasons/season-reset-lock.service.js";
 import { WorkerFactory } from "./workers/worker-factory.js";
 
 @Module({
@@ -29,6 +32,9 @@ import { WorkerFactory } from "./workers/worker-factory.js";
     MailService,
     MatchPersistenceService,
     RedisInvalidationService,
+    NotificationsQueueService,
+    SeasonResetLockService,
+    SeasonResetService,
     WorkerFactory,
     CronSchedulerService,
     RunnerService,

--- a/apps/job-runner/src/notifications/template.service.ts
+++ b/apps/job-runner/src/notifications/template.service.ts
@@ -12,6 +12,7 @@ export type RenderedMail = {
 const TEMPLATE_SUBJECTS: Record<string, string> = {
   welcome: "Bienvenue sur Chifoumi",
   "reset-password": "Réinitialisation de votre mot de passe Chifoumi",
+  "season-reward": "Fin de saison Chifoumi — tes résultats",
 };
 
 @Injectable()

--- a/apps/job-runner/src/notifications/templates/season-reward.html
+++ b/apps/job-runner/src/notifications/templates/season-reward.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Fin de saison Chifoumi</title>
+  </head>
+  <body>
+    <h1>Bravo __DISPLAY_NAME__ !</h1>
+    <p>
+      La saison <strong>__SEASON_NAME__</strong> est terminée. Tu as terminé
+      <strong>#__RANK__</strong> en ligue <strong>__LEAGUE_NAME__</strong>.
+    </p>
+    <p>Tes récompenses seront bientôt disponibles. Bonne chance pour la prochaine saison !</p>
+  </body>
+</html>

--- a/apps/job-runner/src/notifications/templates/season-reward.txt
+++ b/apps/job-runner/src/notifications/templates/season-reward.txt
@@ -1,0 +1,5 @@
+Bravo __DISPLAY_NAME__ !
+
+La saison __SEASON_NAME__ est terminée. Tu as terminé #__RANK__ en ligue __LEAGUE_NAME__.
+
+Tes récompenses seront bientôt disponibles. Bonne chance pour la prochaine saison !

--- a/apps/job-runner/src/queues/notifications-queue.service.spec.ts
+++ b/apps/job-runner/src/queues/notifications-queue.service.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+import { NotificationsQueueService } from "./notifications-queue.service.js";
+
+describe("NotificationsQueueService", () => {
+  afterEach(() => {
+    delete process.env.SKIP_REDIS_CONNECT;
+  });
+
+  it("throws when enqueue is called without a connected queue", async () => {
+    process.env.SKIP_REDIS_CONNECT = "true";
+    const service = new NotificationsQueueService({
+      REDIS_URL: "redis://localhost:6379",
+      BULLMQ_PREFIX: "rps",
+    } as never);
+    service.onModuleInit();
+
+    await expect(
+      service.enqueueSeasonRewardMail({
+        to: "player@test.com",
+        displayName: "alice",
+        seasonName: "Season 1",
+        rank: "3",
+        leagueName: "Gold",
+      }),
+    ).rejects.toThrow("Notifications queue is not connected");
+  });
+});

--- a/apps/job-runner/src/queues/notifications-queue.service.ts
+++ b/apps/job-runner/src/queues/notifications-queue.service.ts
@@ -1,0 +1,67 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+import type { SendMailJobPayload } from "../notifications/send-mail.types.js";
+
+const NOTIFICATIONS_QUEUE_NAME = "notifications";
+const SEND_MAIL_JOB_NAME = "send-mail";
+
+const SEND_MAIL_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: {
+    type: "exponential" as const,
+    delay: 1000,
+  },
+};
+
+@Injectable()
+export class NotificationsQueueService implements OnModuleInit, OnModuleDestroy {
+  private queue: Queue | null = null;
+
+  constructor(@Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.queue = new Queue(NOTIFICATIONS_QUEUE_NAME, {
+      connection: { url: this.config.REDIS_URL },
+      prefix: this.config.BULLMQ_PREFIX,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.queue?.close();
+    this.queue = null;
+  }
+
+  async enqueueSeasonRewardMail(input: {
+    to: string;
+    displayName: string;
+    seasonName: string;
+    rank: string;
+    leagueName: string;
+  }): Promise<void> {
+    const payload: SendMailJobPayload = {
+      to: input.to,
+      template: "season-reward",
+      data: {
+        displayName: input.displayName,
+        seasonName: input.seasonName,
+        rank: input.rank,
+        leagueName: input.leagueName,
+      },
+    };
+
+    await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, SEND_MAIL_JOB_OPTIONS);
+  }
+
+  private requireQueue(): Queue {
+    if (!this.queue) {
+      throw new Error("Notifications queue is not connected");
+    }
+
+    return this.queue;
+  }
+}

--- a/apps/job-runner/src/seasons/season-reset-lock.service.spec.ts
+++ b/apps/job-runner/src/seasons/season-reset-lock.service.spec.ts
@@ -16,7 +16,7 @@ describe("SeasonResetLockService", () => {
   it("acquires and releases the distributed lock", async () => {
     const redis = {
       set: jest.fn(async () => "OK"),
-      del: jest.fn(async () => 1),
+      eval: jest.fn(async () => 1),
       quit: jest.fn(async () => "OK"),
     };
     const service = new SeasonResetLockService({
@@ -26,16 +26,37 @@ describe("SeasonResetLockService", () => {
     } as never);
     (service as never as { redis: typeof redis }).redis = redis;
 
-    await expect(service.acquire("season-id")).resolves.toBe(true);
-    await service.release("season-id");
+    const token = await service.acquire("season-id");
+    expect(token).toEqual(expect.stringMatching(/^cron:/));
+
+    await service.release("season-id", token ?? "missing-token");
 
     expect(redis.set).toHaveBeenCalledWith(
       "rps:lock:season-reset:season-id",
-      "cron",
+      token,
       "EX",
       600,
       "NX",
     );
-    expect(redis.del).toHaveBeenCalledWith("rps:lock:season-reset:season-id");
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call("GET", KEYS[1]) == ARGV[1]'),
+      1,
+      "rps:lock:season-reset:season-id",
+      token,
+    );
+  });
+
+  it("returns null when the distributed lock is already held", async () => {
+    const redis = {
+      set: jest.fn(async () => null),
+    };
+    const service = new SeasonResetLockService({
+      BULLMQ_PREFIX: "rps",
+      WORKER_ROLE: "cron",
+      REDIS_URL: "redis://localhost:6379",
+    } as never);
+    (service as never as { redis: typeof redis }).redis = redis;
+
+    await expect(service.acquire("season-id")).resolves.toBeNull();
   });
 });

--- a/apps/job-runner/src/seasons/season-reset-lock.service.spec.ts
+++ b/apps/job-runner/src/seasons/season-reset-lock.service.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { SeasonResetLockService } from "./season-reset-lock.service.js";
+
+describe("SeasonResetLockService", () => {
+  it("builds a namespaced lock key per season", () => {
+    const service = new SeasonResetLockService({
+      BULLMQ_PREFIX: "rps",
+      WORKER_ROLE: "cron",
+    } as never);
+
+    expect(service.lockKey("33333333-3333-4333-8333-333333333333")).toBe(
+      "rps:lock:season-reset:33333333-3333-4333-8333-333333333333",
+    );
+  });
+
+  it("acquires and releases the distributed lock", async () => {
+    const redis = {
+      set: jest.fn(async () => "OK"),
+      del: jest.fn(async () => 1),
+      quit: jest.fn(async () => "OK"),
+    };
+    const service = new SeasonResetLockService({
+      BULLMQ_PREFIX: "rps",
+      WORKER_ROLE: "cron",
+      REDIS_URL: "redis://localhost:6379",
+    } as never);
+    (service as never as { redis: typeof redis }).redis = redis;
+
+    await expect(service.acquire("season-id")).resolves.toBe(true);
+    await service.release("season-id");
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "rps:lock:season-reset:season-id",
+      "cron",
+      "EX",
+      600,
+      "NX",
+    );
+    expect(redis.del).toHaveBeenCalledWith("rps:lock:season-reset:season-id");
+  });
+});

--- a/apps/job-runner/src/seasons/season-reset-lock.service.ts
+++ b/apps/job-runner/src/seasons/season-reset-lock.service.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Redis } from "ioredis";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+
+const SEASON_RESET_LOCK_TTL_SECONDS = 600;
+
+@Injectable()
+export class SeasonResetLockService implements OnModuleInit, OnModuleDestroy {
+  private redis: Redis | null = null;
+
+  constructor(@Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig) {}
+
+  onModuleInit(): void {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.redis = new Redis(this.config.REDIS_URL);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis?.quit();
+    this.redis = null;
+  }
+
+  lockKey(seasonId: string): string {
+    return `${this.config.BULLMQ_PREFIX}:lock:season-reset:${seasonId}`;
+  }
+
+  async acquire(seasonId: string): Promise<boolean> {
+    const result = await this.requireRedis().set(
+      this.lockKey(seasonId),
+      this.config.WORKER_ROLE,
+      "EX",
+      SEASON_RESET_LOCK_TTL_SECONDS,
+      "NX",
+    );
+
+    return result === "OK";
+  }
+
+  async release(seasonId: string): Promise<void> {
+    await this.requireRedis().del(this.lockKey(seasonId));
+  }
+
+  private requireRedis(): Redis {
+    if (!this.redis) {
+      throw new Error("Redis client is not connected");
+    }
+
+    return this.redis;
+  }
+}

--- a/apps/job-runner/src/seasons/season-reset-lock.service.ts
+++ b/apps/job-runner/src/seasons/season-reset-lock.service.ts
@@ -1,8 +1,15 @@
+import { randomUUID } from "node:crypto";
 import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import { Redis } from "ioredis";
 import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
 
 const SEASON_RESET_LOCK_TTL_SECONDS = 600;
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
 
 @Injectable()
 export class SeasonResetLockService implements OnModuleInit, OnModuleDestroy {
@@ -27,20 +34,21 @@ export class SeasonResetLockService implements OnModuleInit, OnModuleDestroy {
     return `${this.config.BULLMQ_PREFIX}:lock:season-reset:${seasonId}`;
   }
 
-  async acquire(seasonId: string): Promise<boolean> {
+  async acquire(seasonId: string): Promise<string | null> {
+    const token = `${this.config.WORKER_ROLE}:${randomUUID()}`;
     const result = await this.requireRedis().set(
       this.lockKey(seasonId),
-      this.config.WORKER_ROLE,
+      token,
       "EX",
       SEASON_RESET_LOCK_TTL_SECONDS,
       "NX",
     );
 
-    return result === "OK";
+    return result === "OK" ? token : null;
   }
 
-  async release(seasonId: string): Promise<void> {
-    await this.requireRedis().del(this.lockKey(seasonId));
+  async release(seasonId: string, token: string): Promise<void> {
+    await this.requireRedis().eval(RELEASE_LOCK_SCRIPT, 1, this.lockKey(seasonId), token);
   }
 
   private requireRedis(): Redis {

--- a/apps/job-runner/src/seasons/season-reset.processor.spec.ts
+++ b/apps/job-runner/src/seasons/season-reset.processor.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { type Job, UnrecoverableError } from "bullmq";
+import { createSeasonResetProcessor } from "./season-reset.processor.js";
+
+const validPayload = {
+  seasonId: "33333333-3333-4333-8333-333333333333",
+  source: "admin" as const,
+};
+
+function createJob(overrides: Partial<Job> = {}): Job {
+  return {
+    name: "season-reset",
+    data: validPayload,
+    ...overrides,
+  } as Job;
+}
+
+describe("createSeasonResetProcessor", () => {
+  it("processes valid season-reset jobs and invalidates the leaderboard", async () => {
+    const seasonReset = {
+      processSeasonReset: jest.fn(async () => "processed"),
+    };
+    const redisInvalidation = {
+      invalidateLeaderboard: jest.fn(async () => undefined),
+    };
+    const processor = createSeasonResetProcessor({
+      seasonReset: seasonReset as never,
+      redisInvalidation: redisInvalidation as never,
+    });
+
+    await processor(createJob());
+
+    expect(seasonReset.processSeasonReset).toHaveBeenCalledWith(validPayload);
+    expect(redisInvalidation.invalidateLeaderboard).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates leaderboard for idempotent replays", async () => {
+    const seasonReset = {
+      processSeasonReset: jest.fn(async () => "already_processed"),
+    };
+    const redisInvalidation = {
+      invalidateLeaderboard: jest.fn(async () => undefined),
+    };
+    const processor = createSeasonResetProcessor({
+      seasonReset: seasonReset as never,
+      redisInvalidation: redisInvalidation as never,
+    });
+
+    await processor(createJob());
+
+    expect(redisInvalidation.invalidateLeaderboard).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips leaderboard invalidation when no season needs processing", async () => {
+    const seasonReset = {
+      processSeasonReset: jest.fn(async () => "noop"),
+    };
+    const redisInvalidation = {
+      invalidateLeaderboard: jest.fn(async () => undefined),
+    };
+    const processor = createSeasonResetProcessor({
+      seasonReset: seasonReset as never,
+      redisInvalidation: redisInvalidation as never,
+    });
+
+    await processor(createJob({ data: { source: "cron-scheduler" } }));
+
+    expect(redisInvalidation.invalidateLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid payloads without retry", async () => {
+    const processor = createSeasonResetProcessor({
+      seasonReset: { processSeasonReset: jest.fn() } as never,
+      redisInvalidation: { invalidateLeaderboard: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob({ data: { invalid: true } }))).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+
+  it("rejects unsupported job names without retry", async () => {
+    const processor = createSeasonResetProcessor({
+      seasonReset: { processSeasonReset: jest.fn() } as never,
+      redisInvalidation: { invalidateLeaderboard: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob({ name: "other-job" }))).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+
+  it("propagates service failures so BullMQ can retry", async () => {
+    const error = new Error("database unavailable");
+    const processor = createSeasonResetProcessor({
+      seasonReset: {
+        processSeasonReset: jest.fn(async () => {
+          throw error;
+        }),
+      } as never,
+      redisInvalidation: { invalidateLeaderboard: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob())).rejects.toBe(error);
+  });
+});

--- a/apps/job-runner/src/seasons/season-reset.processor.ts
+++ b/apps/job-runner/src/seasons/season-reset.processor.ts
@@ -1,0 +1,32 @@
+import { type Job, UnrecoverableError } from "bullmq";
+import type { RedisInvalidationService } from "../redis/redis-invalidation.service.js";
+import type { WorkerProcessor } from "../workers/worker-processors.js";
+import type { SeasonResetService } from "./season-reset.service.js";
+import { seasonResetPayloadSchema } from "./season-reset.types.js";
+
+export type SeasonResetProcessorDependencies = {
+  seasonReset: SeasonResetService;
+  redisInvalidation: RedisInvalidationService;
+};
+
+export function createSeasonResetProcessor(
+  deps: SeasonResetProcessorDependencies,
+): WorkerProcessor {
+  return async (job: Job) => {
+    if (job.name !== "season-reset") {
+      throw new UnrecoverableError(`Unsupported job name on seasons: ${job.name}`);
+    }
+
+    const parsed = seasonResetPayloadSchema.safeParse(job.data);
+    if (!parsed.success) {
+      throw new UnrecoverableError("Invalid season-reset job payload");
+    }
+
+    const result = await deps.seasonReset.processSeasonReset(parsed.data);
+    if (result === "noop") {
+      return;
+    }
+
+    await deps.redisInvalidation.invalidateLeaderboard();
+  };
+}

--- a/apps/job-runner/src/seasons/season-reset.service.spec.ts
+++ b/apps/job-runner/src/seasons/season-reset.service.spec.ts
@@ -81,7 +81,7 @@ describe("SeasonResetService", () => {
     };
 
     const seasonResetLock = {
-      acquire: jest.fn(async () => true),
+      acquire: jest.fn(async () => "lock-token"),
       release: jest.fn(async () => undefined),
     };
     const notificationsQueue = {
@@ -116,7 +116,7 @@ describe("SeasonResetService", () => {
       data: { rating: softResetRating(1200), gamesPlayed: 0 },
     });
     expect(notificationsQueue.enqueueSeasonRewardMail).toHaveBeenCalledTimes(2);
-    expect(seasonResetLock.release).toHaveBeenCalledWith(seasonId);
+    expect(seasonResetLock.release).toHaveBeenCalledWith(seasonId, "lock-token");
   });
 
   it("is idempotent when standings already exist", async () => {
@@ -144,7 +144,7 @@ describe("SeasonResetService", () => {
     const service = createService({
       prisma,
       seasonResetLock: {
-        acquire: jest.fn(async () => true),
+        acquire: jest.fn(async () => "lock-token"),
         release: jest.fn(async () => undefined),
       },
       notificationsQueue: {
@@ -157,6 +157,72 @@ describe("SeasonResetService", () => {
     expect(result).toBe("already_processed");
     expect(prisma.$transaction).not.toHaveBeenCalled();
     expect(prisma.eloRating.update).not.toHaveBeenCalled();
+  });
+
+  it("resumes pending rewards for cron retries after standings were archived", async () => {
+    const closedSeason = {
+      id: seasonId,
+      name: "Season 1",
+      status: SeasonStatus.closed,
+    };
+    const prisma = {
+      season: {
+        findFirst: jest.fn(async (args: { where: unknown }) =>
+          "OR" in (args.where as { OR?: unknown }) ? closedSeason : null,
+        ),
+        count: jest.fn(async () => 0),
+        findUnique: jest.fn(async () => closedSeason),
+      },
+      seasonStanding: {
+        count: jest.fn(async () => 2),
+        findMany: jest.fn(async () => [
+          {
+            id: "standing-a",
+            rank: 1,
+            rewardsDistributed: false,
+            user: { email: "alice@test.com", displayName: "alice" },
+            finalLeague: { name: "Gold" },
+          },
+        ]),
+        update: jest.fn(async () => ({})),
+      },
+      league: { findMany: jest.fn() },
+      eloRating: { findMany: jest.fn(), update: jest.fn() },
+      $transaction: jest.fn(),
+    };
+    const notificationsQueue = {
+      enqueueSeasonRewardMail: jest.fn(async () => undefined),
+    };
+
+    const result = await createService({
+      prisma,
+      seasonResetLock: {
+        acquire: jest.fn(async () => "lock-token"),
+        release: jest.fn(async () => undefined),
+      },
+      notificationsQueue,
+    }).processSeasonReset({ source: "cron-scheduler" });
+
+    expect(result).toBe("already_processed");
+    expect(prisma.season.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: SeasonStatus.closed,
+        OR: [{ standings: { none: {} } }, { standings: { some: { rewardsDistributed: false } } }],
+      },
+      orderBy: { updatedAt: "asc" },
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(notificationsQueue.enqueueSeasonRewardMail).toHaveBeenCalledWith({
+      to: "alice@test.com",
+      displayName: "alice",
+      seasonName: "Season 1",
+      rank: "1",
+      leagueName: "Gold",
+    });
+    expect(prisma.seasonStanding.update).toHaveBeenCalledWith({
+      where: { id: "standing-a" },
+      data: { rewardsDistributed: true },
+    });
   });
 
   it("returns noop when cron finds no eligible season", async () => {
@@ -193,7 +259,7 @@ describe("SeasonResetService", () => {
         },
       },
       seasonResetLock: {
-        acquire: jest.fn(async () => false),
+        acquire: jest.fn(async () => null),
         release: jest.fn(),
       },
       notificationsQueue: {

--- a/apps/job-runner/src/seasons/season-reset.service.spec.ts
+++ b/apps/job-runner/src/seasons/season-reset.service.spec.ts
@@ -1,0 +1,208 @@
+import { SeasonStatus } from "@chifoumi/db";
+import { softResetRating } from "@chifoumi/elo";
+import { describe, expect, it, jest } from "@jest/globals";
+import { SeasonResetService } from "./season-reset.service.js";
+
+const seasonId = "33333333-3333-4333-8333-333333333333";
+const userAId = "11111111-1111-4111-8111-111111111111";
+const userBId = "22222222-2222-4222-8222-222222222222";
+const upcomingSeasonId = "55555555-5555-4555-8555-555555555555";
+
+function createService(overrides: {
+  prisma?: Record<string, unknown>;
+  seasonResetLock?: Record<string, unknown>;
+  notificationsQueue?: Record<string, unknown>;
+}) {
+  return new SeasonResetService(
+    overrides.prisma as never,
+    overrides.seasonResetLock as never,
+    overrides.notificationsQueue as never,
+  );
+}
+
+describe("SeasonResetService", () => {
+  it("archives standings, soft-resets ratings, activates next season and enqueues rewards", async () => {
+    const closedSeason = {
+      id: seasonId,
+      name: "Season 1",
+      status: SeasonStatus.closed,
+      startedAt: new Date("2026-01-01T00:00:00.000Z"),
+      endsAt: new Date("2026-06-01T00:00:00.000Z"),
+    };
+    const bronzeLeagueId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const goldLeagueId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const leagues = [
+      { id: bronzeLeagueId, name: "Bronze", tier: 1, minRating: 0, maxRating: 1099 },
+      { id: goldLeagueId, name: "Gold", tier: 3, minRating: 1200, maxRating: 1349 },
+    ];
+    const ratings = [
+      { userId: userAId, rating: 1200, gamesPlayed: 10, user: { id: userAId } },
+      { userId: userBId, rating: 1000, gamesPlayed: 5, user: { id: userBId } },
+    ];
+
+    const prisma = {
+      season: {
+        findUnique: jest.fn(async () => closedSeason),
+        count: jest.fn(async () => 0),
+        findFirst: jest.fn(async () => ({ id: upcomingSeasonId, status: SeasonStatus.upcoming })),
+        update: jest.fn(async () => ({ id: upcomingSeasonId, status: SeasonStatus.active })),
+      },
+      seasonStanding: {
+        count: jest.fn(async () => 0),
+        createMany: jest.fn(async () => ({ count: 2 })),
+        findMany: jest.fn(async () => [
+          {
+            id: "standing-a",
+            rank: 1,
+            rewardsDistributed: false,
+            user: { email: "alice@test.com", displayName: "alice" },
+            finalLeague: { name: "Silver" },
+          },
+          {
+            id: "standing-b",
+            rank: 2,
+            rewardsDistributed: false,
+            user: { email: "bob@test.com", displayName: "bob" },
+            finalLeague: { name: "Bronze" },
+          },
+        ]),
+        update: jest.fn(async () => ({})),
+      },
+      league: {
+        findMany: jest.fn(async () => leagues),
+      },
+      eloRating: {
+        findMany: jest.fn(async () => ratings),
+        update: jest.fn(async () => ({})),
+      },
+      $transaction: jest.fn(async (callback: (tx: typeof prisma) => Promise<void>) => {
+        await callback(prisma);
+      }),
+    };
+
+    const seasonResetLock = {
+      acquire: jest.fn(async () => true),
+      release: jest.fn(async () => undefined),
+    };
+    const notificationsQueue = {
+      enqueueSeasonRewardMail: jest.fn(async () => undefined),
+    };
+
+    const service = createService({ prisma, seasonResetLock, notificationsQueue });
+    const result = await service.processSeasonReset({ seasonId, source: "admin" });
+
+    expect(result).toBe("processed");
+    expect(seasonResetLock.acquire).toHaveBeenCalledWith(seasonId);
+    expect(prisma.seasonStanding.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          seasonId,
+          userId: userAId,
+          finalRating: 1200,
+          finalLeagueId: goldLeagueId,
+          rank: 1,
+        },
+        {
+          seasonId,
+          userId: userBId,
+          finalRating: 1000,
+          finalLeagueId: bronzeLeagueId,
+          rank: 2,
+        },
+      ],
+    });
+    expect(prisma.eloRating.update).toHaveBeenCalledWith({
+      where: { userId: userAId },
+      data: { rating: softResetRating(1200), gamesPlayed: 0 },
+    });
+    expect(notificationsQueue.enqueueSeasonRewardMail).toHaveBeenCalledTimes(2);
+    expect(seasonResetLock.release).toHaveBeenCalledWith(seasonId);
+  });
+
+  it("is idempotent when standings already exist", async () => {
+    const closedSeason = {
+      id: seasonId,
+      name: "Season 1",
+      status: SeasonStatus.closed,
+    };
+
+    const prisma = {
+      season: {
+        findUnique: jest.fn(async () => closedSeason),
+        count: jest.fn(async () => 0),
+        findFirst: jest.fn(async () => null),
+      },
+      seasonStanding: {
+        count: jest.fn(async () => 2),
+        findMany: jest.fn(async () => []),
+      },
+      league: { findMany: jest.fn() },
+      eloRating: { findMany: jest.fn(), update: jest.fn() },
+      $transaction: jest.fn(),
+    };
+
+    const service = createService({
+      prisma,
+      seasonResetLock: {
+        acquire: jest.fn(async () => true),
+        release: jest.fn(async () => undefined),
+      },
+      notificationsQueue: {
+        enqueueSeasonRewardMail: jest.fn(),
+      },
+    });
+
+    const result = await service.processSeasonReset({ seasonId, source: "admin" });
+
+    expect(result).toBe("already_processed");
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.eloRating.update).not.toHaveBeenCalled();
+  });
+
+  it("returns noop when cron finds no eligible season", async () => {
+    const prisma = {
+      season: {
+        findFirst: jest.fn(async () => null),
+      },
+    };
+
+    const service = createService({
+      prisma,
+      seasonResetLock: { acquire: jest.fn(), release: jest.fn() },
+      notificationsQueue: { enqueueSeasonRewardMail: jest.fn() },
+    });
+
+    const result = await service.processSeasonReset({ source: "cron-scheduler" });
+
+    expect(result).toBe("noop");
+  });
+
+  it("retries when the distributed lock is not acquired", async () => {
+    const closedSeason = {
+      id: seasonId,
+      status: SeasonStatus.closed,
+    };
+
+    const service = createService({
+      prisma: {
+        season: {
+          findUnique: jest.fn(async () => closedSeason),
+        },
+        seasonStanding: {
+          count: jest.fn(async () => 0),
+        },
+      },
+      seasonResetLock: {
+        acquire: jest.fn(async () => false),
+        release: jest.fn(),
+      },
+      notificationsQueue: {
+        enqueueSeasonRewardMail: jest.fn(),
+      },
+    });
+
+    await expect(service.processSeasonReset({ seasonId, source: "admin" })).rejects.toThrow(
+      "Season reset lock not acquired",
+    );
+  });
+});

--- a/apps/job-runner/src/seasons/season-reset.service.ts
+++ b/apps/job-runner/src/seasons/season-reset.service.ts
@@ -1,0 +1,202 @@
+import { type Season, SeasonStatus } from "@chifoumi/db";
+import { softResetRating } from "@chifoumi/elo";
+import { getLeagueForRating } from "@chifoumi/leagues";
+import { Inject, Injectable } from "@nestjs/common";
+import { UnrecoverableError } from "bullmq";
+import { PrismaService } from "../prisma/prisma.service.js";
+import { NotificationsQueueService } from "../queues/notifications-queue.service.js";
+import type { SeasonResetPayload, SeasonResetResult } from "./season-reset.types.js";
+import { SeasonResetLockService } from "./season-reset-lock.service.js";
+
+@Injectable()
+export class SeasonResetService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly seasonResetLock: SeasonResetLockService,
+    @Inject(NotificationsQueueService)
+    private readonly notificationsQueue: NotificationsQueueService,
+  ) {}
+
+  async processSeasonReset(payload: SeasonResetPayload): Promise<SeasonResetResult> {
+    const season = await this.resolveSeason(payload);
+    if (!season) {
+      return "noop";
+    }
+
+    if (season.status !== SeasonStatus.closed) {
+      throw new UnrecoverableError(`Season ${season.id} is not closed`);
+    }
+
+    const lockAcquired = await this.seasonResetLock.acquire(season.id);
+    if (!lockAcquired) {
+      throw new Error(`Season reset lock not acquired for ${season.id}`);
+    }
+
+    try {
+      const existingStandings = await this.prisma.seasonStanding.count({
+        where: { seasonId: season.id },
+      });
+
+      if (existingStandings > 0) {
+        await this.activateNextSeasonIfNeeded();
+        await this.enqueuePendingRewardMails(season.id);
+        return "already_processed";
+      }
+
+      await this.archiveStandingsAndSoftReset(season);
+      await this.activateNextSeasonIfNeeded();
+      await this.enqueuePendingRewardMails(season.id);
+      return "processed";
+    } finally {
+      await this.seasonResetLock.release(season.id);
+    }
+  }
+
+  private async resolveSeason(payload: SeasonResetPayload): Promise<Season | null> {
+    if (payload.seasonId) {
+      return this.prisma.season.findUnique({ where: { id: payload.seasonId } });
+    }
+
+    const closedPendingReset = await this.prisma.season.findFirst({
+      where: {
+        status: SeasonStatus.closed,
+        standings: { none: {} },
+      },
+      orderBy: { updatedAt: "asc" },
+    });
+    if (closedPendingReset) {
+      return closedPendingReset;
+    }
+
+    const expiredActive = await this.prisma.season.findFirst({
+      where: {
+        status: SeasonStatus.active,
+        endsAt: { lte: new Date() },
+      },
+    });
+    if (!expiredActive) {
+      return null;
+    }
+
+    const closeResult = await this.prisma.season.updateMany({
+      where: { id: expiredActive.id, status: SeasonStatus.active },
+      data: { status: SeasonStatus.closed },
+    });
+
+    if (closeResult.count === 0) {
+      return this.prisma.season.findUnique({ where: { id: expiredActive.id } });
+    }
+
+    return { ...expiredActive, status: SeasonStatus.closed };
+  }
+
+  private async archiveStandingsAndSoftReset(season: Season): Promise<void> {
+    const leagues = await this.prisma.league.findMany({ orderBy: { tier: "asc" } });
+    type LeagueRow = (typeof leagues)[number];
+    const ratings = await this.prisma.eloRating.findMany({
+      orderBy: [{ rating: "desc" }, { gamesPlayed: "desc" }],
+      include: {
+        user: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+
+    await this.prisma.$transaction(async (tx) => {
+      if (ratings.length > 0) {
+        await tx.seasonStanding.createMany({
+          data: ratings.map((entry, index) => {
+            const league = getLeagueForRating<LeagueRow>(entry.rating, leagues);
+            return {
+              seasonId: season.id,
+              userId: entry.userId,
+              finalRating: entry.rating,
+              finalLeagueId: league.id,
+              rank: index + 1,
+            };
+          }),
+        });
+      }
+
+      for (const entry of ratings) {
+        await tx.eloRating.update({
+          where: { userId: entry.userId },
+          data: {
+            rating: softResetRating(entry.rating),
+            gamesPlayed: 0,
+          },
+        });
+      }
+    });
+  }
+
+  private async activateNextSeasonIfNeeded(): Promise<void> {
+    const activeCount = await this.prisma.season.count({
+      where: { status: SeasonStatus.active },
+    });
+    if (activeCount > 0) {
+      return;
+    }
+
+    const upcoming = await this.prisma.season.findFirst({
+      where: { status: SeasonStatus.upcoming },
+      orderBy: { createdAt: "asc" },
+    });
+    if (!upcoming) {
+      return;
+    }
+
+    await this.prisma.season.update({
+      where: { id: upcoming.id },
+      data: {
+        status: SeasonStatus.active,
+        startedAt: new Date(),
+      },
+    });
+  }
+
+  private async enqueuePendingRewardMails(seasonId: string): Promise<void> {
+    const season = await this.prisma.season.findUnique({ where: { id: seasonId } });
+    if (!season) {
+      return;
+    }
+
+    const pendingRewards = await this.prisma.seasonStanding.findMany({
+      where: {
+        seasonId,
+        rewardsDistributed: false,
+      },
+      include: {
+        user: {
+          select: {
+            email: true,
+            displayName: true,
+          },
+        },
+        finalLeague: {
+          select: {
+            name: true,
+          },
+        },
+      },
+      orderBy: { rank: "asc" },
+    });
+
+    for (const standing of pendingRewards) {
+      await this.notificationsQueue.enqueueSeasonRewardMail({
+        to: standing.user.email,
+        displayName: standing.user.displayName,
+        seasonName: season.name,
+        rank: String(standing.rank),
+        leagueName: standing.finalLeague.name,
+      });
+
+      await this.prisma.seasonStanding.update({
+        where: { id: standing.id },
+        data: { rewardsDistributed: true },
+      });
+    }
+  }
+}

--- a/apps/job-runner/src/seasons/season-reset.service.ts
+++ b/apps/job-runner/src/seasons/season-reset.service.ts
@@ -27,8 +27,8 @@ export class SeasonResetService {
       throw new UnrecoverableError(`Season ${season.id} is not closed`);
     }
 
-    const lockAcquired = await this.seasonResetLock.acquire(season.id);
-    if (!lockAcquired) {
+    const lockToken = await this.seasonResetLock.acquire(season.id);
+    if (!lockToken) {
       throw new Error(`Season reset lock not acquired for ${season.id}`);
     }
 
@@ -48,7 +48,7 @@ export class SeasonResetService {
       await this.enqueuePendingRewardMails(season.id);
       return "processed";
     } finally {
-      await this.seasonResetLock.release(season.id);
+      await this.seasonResetLock.release(season.id, lockToken);
     }
   }
 
@@ -60,7 +60,7 @@ export class SeasonResetService {
     const closedPendingReset = await this.prisma.season.findFirst({
       where: {
         status: SeasonStatus.closed,
-        standings: { none: {} },
+        OR: [{ standings: { none: {} } }, { standings: { some: { rewardsDistributed: false } } }],
       },
       orderBy: { updatedAt: "asc" },
     });

--- a/apps/job-runner/src/seasons/season-reset.types.ts
+++ b/apps/job-runner/src/seasons/season-reset.types.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const seasonResetPayloadSchema = z.object({
+  seasonId: z.string().uuid().optional(),
+  source: z.enum(["admin", "cron-scheduler"]),
+});
+
+export type SeasonResetPayload = z.infer<typeof seasonResetPayloadSchema>;
+
+export type SeasonResetResult = "processed" | "already_processed" | "noop";

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -10,6 +10,7 @@ class MockUnrecoverableError extends Error {}
 jest.unstable_mockModule("bullmq", () => ({
   UnrecoverableError: MockUnrecoverableError,
   Worker: workerCtor,
+  Queue: jest.fn(),
 }));
 
 const { WorkerFactory: WorkerFactoryClass } = await import("./worker-factory.js");
@@ -43,6 +44,12 @@ function createRedisInvalidation(): { invalidateLeaderboard: () => Promise<void>
   };
 }
 
+function createSeasonReset(): { processSeasonReset: () => Promise<"noop"> } {
+  return {
+    processSeasonReset: jest.fn(async (): Promise<"noop"> => "noop"),
+  };
+}
+
 function createMailService(): { send: () => Promise<void> } {
   return {
     send: jest.fn(async () => undefined),
@@ -67,6 +74,7 @@ describe("WorkerFactory", () => {
       metrics,
       createMatchPersistence() as never,
       createRedisInvalidation() as never,
+      createSeasonReset() as never,
       createMailService() as never,
       logger,
     );
@@ -111,6 +119,7 @@ describe("WorkerFactory", () => {
       metrics,
       createMatchPersistence() as never,
       createRedisInvalidation() as never,
+      createSeasonReset() as never,
       createMailService() as never,
       { log: jest.fn(), error: jest.fn() } as unknown as Logger,
     );
@@ -154,6 +163,7 @@ describe("WorkerFactory", () => {
       metrics,
       createMatchPersistence() as never,
       createRedisInvalidation() as never,
+      createSeasonReset() as never,
       createMailService() as never,
       logger,
     );

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -6,6 +6,7 @@ import { WorkerMetricsService } from "../metrics/worker-metrics.service.js";
 import { MailService } from "../notifications/mail.service.js";
 import { MatchPersistenceService } from "../persistence/match-persistence.service.js";
 import { RedisInvalidationService } from "../redis/redis-invalidation.service.js";
+import { SeasonResetService } from "../seasons/season-reset.service.js";
 import { getProcessorForQueue } from "./worker-processors.js";
 
 export type ManagedWorker = {
@@ -20,6 +21,7 @@ export class WorkerFactory {
     private readonly metrics: WorkerMetricsService,
     private readonly matchPersistence: MatchPersistenceService,
     private readonly redisInvalidation: RedisInvalidationService,
+    private readonly seasonReset: SeasonResetService,
     private readonly mailService: MailService,
     private readonly logger: Logger,
   ) {}
@@ -38,6 +40,7 @@ export class WorkerFactory {
     const processor = getProcessorForQueue(queue, {
       matchPersistence: this.matchPersistence,
       redisInvalidation: this.redisInvalidation,
+      seasonReset: this.seasonReset,
       mailService: this.mailService,
     });
 

--- a/apps/job-runner/src/workers/worker-processors.ts
+++ b/apps/job-runner/src/workers/worker-processors.ts
@@ -6,21 +6,21 @@ import {
 } from "../match-events/match-ended.processor.js";
 import type { MailService } from "../notifications/mail.service.js";
 import { createNotificationsProcessor } from "../notifications/notifications.processor.js";
+import {
+  createSeasonResetProcessor,
+  type SeasonResetProcessorDependencies,
+} from "../seasons/season-reset.processor.js";
 
 export type WorkerProcessor = (job: Job) => Promise<void>;
-export type ProcessorDependencies = MatchEventsProcessorDependencies & {
-  mailService: MailService;
-};
+export type ProcessorDependencies = MatchEventsProcessorDependencies &
+  SeasonResetProcessorDependencies & {
+    mailService: MailService;
+  };
 
 const STUB_PROCESSORS: Record<
-  Exclude<WorkerQueueName, "match-events" | "notifications">,
+  Exclude<WorkerQueueName, "match-events" | "notifications" | "seasons">,
   WorkerProcessor
 > = {
-  seasons: async (job) => {
-    if (job.name !== "season-reset") {
-      throw new Error(`Unsupported job name on seasons: ${job.name}`);
-    }
-  },
   tournaments: async (job) => {
     if (job.name !== "generate-bracket") {
       throw new Error(`Unsupported job name on tournaments: ${job.name}`);
@@ -38,6 +38,10 @@ export function getProcessorForQueue(
 
   if (queue === "notifications") {
     return createNotificationsProcessor(deps.mailService);
+  }
+
+  if (queue === "seasons") {
+    return createSeasonResetProcessor(deps);
   }
 
   return STUB_PROCESSORS[queue];

--- a/docs/architecture/redis-keys.md
+++ b/docs/architecture/redis-keys.md
@@ -37,6 +37,7 @@ Ce document centralise les cles, channels et prefixes BullMQ utilises par Chifou
 | `<BULLMQ_PREFIX>:seasons:*` | Structures BullMQ | Selon retention BullMQ | Job Runner | Queue `seasons`, job repeatable `season-reset`; traitements planifies de saisons. |
 | `<BULLMQ_PREFIX>:tournaments:*` | Structures BullMQ | Selon retention BullMQ | Job Runner | Queue reservee aux traitements asynchrones de tournois. |
 | `<BULLMQ_PREFIX>:job-runner:cron-scheduler-lock` | String lock NX | 60 s | Job Runner | Lock de leader election courte pour qu'une seule instance enregistre les jobs cron repeatables. |
+| `<BULLMQ_PREFIX>:lock:season-reset:<seasonId>` | String lock NX | 600 s | Job Runner | Lock distribue par saison pendant le traitement `season-reset`; empeche deux workers d'archiver/reset en parallele. |
 
 ## Notes de synchronisation avec le code
 

--- a/packages/elo/src/index.ts
+++ b/packages/elo/src/index.ts
@@ -1,4 +1,8 @@
 export { computeElo } from "./computeElo.js";
 export { EloError, type EloErrorCode } from "./elo-error.js";
 export { getKFactor } from "./kFactor.js";
+export {
+  SEASON_SOFT_RESET_BASE_RATING,
+  softResetRating,
+} from "./softResetRating.js";
 export type { EloResult, Outcome } from "./types.js";

--- a/packages/elo/src/softResetRating.spec.ts
+++ b/packages/elo/src/softResetRating.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "@jest/globals";
+import { softResetRating } from "./softResetRating.js";
+
+describe("softResetRating", () => {
+  it("pulls high ratings toward the baseline", () => {
+    expect(softResetRating(1600)).toBe(1450);
+  });
+
+  it("pulls low ratings toward the baseline", () => {
+    expect(softResetRating(800)).toBe(850);
+  });
+
+  it("keeps the starting rating unchanged", () => {
+    expect(softResetRating(1000)).toBe(1000);
+  });
+
+  it("rounds to the nearest integer", () => {
+    expect(softResetRating(1101)).toBe(1076);
+  });
+});

--- a/packages/elo/src/softResetRating.ts
+++ b/packages/elo/src/softResetRating.ts
@@ -1,0 +1,13 @@
+/** Platform baseline rating used in the seasonal soft-reset formula (US-060 AC2). */
+export const SEASON_SOFT_RESET_BASE_RATING = 1000;
+
+const RETAIN_WEIGHT = 0.75;
+const BASE_WEIGHT = 0.25;
+
+/**
+ * Soft-resets a player's ELO toward the platform baseline between seasons.
+ * Formula: round(rating × 0.75 + 1000 × 0.25).
+ */
+export function softResetRating(rating: number): number {
+  return Math.round(rating * RETAIN_WEIGHT + SEASON_SOFT_RESET_BASE_RATING * BASE_WEIGHT);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@chifoumi/elo':
         specifier: workspace:*
         version: link:../../packages/elo
+      '@chifoumi/leagues':
+        specifier: workspace:*
+        version: link:../../packages/leagues
       '@nestjs/common':
         specifier: ^11.1.21
         version: 11.1.21(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)


### PR DESCRIPTION
## Summary

- Replace the \seasons\ queue stub with a full \season-reset\ processor: archive \SeasonStanding\ rows, soft-reset ELO via \softResetRating\, activate the next \upcoming\ season, enqueue \season-reward\ notification jobs, and invalidate the leaderboard cache.
- Add per-season Redis lock (\<prefix>:lock:season-reset:<seasonId>\, TTL 600s) for multi-instance safety, plus idempotent replay when standings already exist.
- Add \softResetRating\ to \@chifoumi/elo\ (\ound(rating * 0.75 + 1000 * 0.25)\, \gamesPlayed\ reset to 0).

Closes #116

## Acceptance criteria

- [x] AC1 — Archive standings with \inalRating\, \inalLeagueId\ (\@chifoumi/leagues\), and \ank\
- [x] AC2 — Soft reset ELO formula + \gamesPlayed\ reset to 0
- [x] AC3 — Idempotence via existing \SeasonStanding\ rows
- [x] AC4 — Redis lock \lock:season-reset:<seasonId>\
- [x] AC5 — Activate next \upcoming\ season when none active
- [x] AC6 — Publish \leaderboard:invalidate\
- [x] AC7 — Unit tests (archive, idempotence, soft reset math, lock)

## Test plan

- [x] \pnpm --filter @chifoumi/elo test --coverage\
- [x] \pnpm --filter @chifoumi/job-runner test --coverage\
- [x] \pnpm biome check\ + \pnpm -r typecheck\
- [ ] Manual: \PATCH /admin/seasons/:id/close\ → standings archived, ELO reset, next season active
- [ ] Manual: double job execution → same final state (idempotent)