### PR TITLE
US-062 - Badge ligue profil et header

### DIFF
--- a/apps/front/src/App.css
+++ b/apps/front/src/App.css
@@ -193,6 +193,21 @@ a {
   background: #1f5fbf;
 }
 
+.league-badge-tier-default {
+  border-color: #d9dee7;
+  background: #ffffff;
+  color: #15171a;
+}
+
+.league-badge-tier-default .league-badge-mark {
+  background: #5d6675;
+}
+
+.nav-league .league-badge {
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
 .form {
   display: grid;
   gap: 16px;
@@ -301,6 +316,51 @@ a {
 
 .profile-header {
   margin-bottom: 24px;
+}
+
+.profile-league {
+  display: grid;
+  gap: 12px;
+  margin: 12px 0 20px;
+}
+
+.league-progress {
+  display: grid;
+  gap: 6px;
+  max-width: 360px;
+}
+
+.league-progress-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #5d6675;
+  font-size: 14px;
+}
+
+.league-progress-label strong {
+  color: #15171a;
+}
+
+.league-progress-max {
+  margin: 0;
+  color: #5d6675;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.league-progress-bar {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e7ebf2;
+}
+
+.league-progress-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #1f5fbf, #75c9a5);
 }
 
 .profile-stats {

--- a/apps/front/src/App.css
+++ b/apps/front/src/App.css
@@ -131,6 +131,83 @@ a {
   color: #1f5fbf;
 }
 
+.league-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  border: 1px solid #d9dee7;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: #ffffff;
+  color: #15171a;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.league-badge-mark {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #8a6100;
+  box-shadow: inset 0 0 0 2px rgb(255 255 255 / 55%);
+}
+
+.league-badge-tier-1 {
+  border-color: #c99362;
+  background: #fff7ed;
+  color: #7a4a12;
+}
+
+.league-badge-tier-1 .league-badge-mark {
+  background: #b86b2b;
+}
+
+.league-badge-tier-2 {
+  border-color: #b7c1d0;
+  background: #f7f8fa;
+  color: #475467;
+}
+
+.league-badge-tier-2 .league-badge-mark {
+  background: #98a2b3;
+}
+
+.league-badge-tier-3 {
+  border-color: #f5c451;
+  background: #fff8e7;
+  color: #8a6100;
+}
+
+.league-badge-tier-3 .league-badge-mark {
+  background: #f5b301;
+}
+
+.league-badge-tier-4 {
+  border-color: #8db6ee;
+  background: #eef3fb;
+  color: #1f5fbf;
+}
+
+.league-badge-tier-4 .league-badge-mark {
+  background: #1f5fbf;
+}
+
+.league-badge-tier-default {
+  border-color: #d9dee7;
+  background: #ffffff;
+  color: #15171a;
+}
+
+.league-badge-tier-default .league-badge-mark {
+  background: #5d6675;
+}
+
+.nav-league .league-badge {
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
 .form {
   display: grid;
   gap: 16px;
@@ -204,6 +281,51 @@ a {
 
 .profile-header {
   margin-bottom: 24px;
+}
+
+.profile-league {
+  display: grid;
+  gap: 12px;
+  margin: 12px 0 20px;
+}
+
+.league-progress {
+  display: grid;
+  gap: 6px;
+  max-width: 360px;
+}
+
+.league-progress-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #5d6675;
+  font-size: 14px;
+}
+
+.league-progress-label strong {
+  color: #15171a;
+}
+
+.league-progress-max {
+  margin: 0;
+  color: #5d6675;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.league-progress-bar {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e7ebf2;
+}
+
+.league-progress-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #1f5fbf, #75c9a5);
 }
 
 .profile-stats {

--- a/apps/front/src/api/types.ts
+++ b/apps/front/src/api/types.ts
@@ -24,6 +24,26 @@ export type LeagueSummary = {
   tier: number;
 };
 
+export type CurrentSeason = {
+  id: string;
+  name: string;
+  startedAt: string;
+  endsAt: string | null;
+  status: "upcoming" | "active" | "closed";
+};
+
+export type CurrentSeasonMe = {
+  rating: number;
+  league: LeagueSummary;
+  rank: number;
+  progressToNextLeague: number;
+};
+
+export type CurrentSeasonResponse = {
+  season: CurrentSeason;
+  me: CurrentSeasonMe;
+};
+
 export type MeProfile = {
   id: string;
   email: string;

--- a/apps/front/src/components/Header.tsx
+++ b/apps/front/src/components/Header.tsx
@@ -1,8 +1,12 @@
 import { Link, NavLink } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext.js";
+import { useCurrentSeason } from "../hooks/useCurrentSeason.js";
+import { LeagueBadge } from "./LeagueBadge.js";
 
 export function Header() {
   const { user, isAuthenticated, isBootstrapping, logout } = useAuth();
+  const currentSeasonQuery = useCurrentSeason(isAuthenticated && !isBootstrapping);
+  const league = currentSeasonQuery.data?.me.league;
 
   return (
     <header className="header">
@@ -28,6 +32,11 @@ export function Header() {
               <NavLink to="/admin/users" className="nav-link">
                 Admin
               </NavLink>
+            ) : null}
+            {league ? (
+              <span className="nav-league">
+                <LeagueBadge name={league.name} tier={league.tier} />
+              </span>
             ) : null}
             <span className="nav-user">{user?.displayName}</span>
             <button type="button" className="button button-secondary" onClick={() => void logout()}>

--- a/apps/front/src/components/LeagueBadge.test.tsx
+++ b/apps/front/src/components/LeagueBadge.test.tsx
@@ -13,11 +13,19 @@ describe("LeagueBadge", () => {
   it.each(tiers)("renders the $name tier indicator", ({ name, tier }) => {
     render(<LeagueBadge name={name} tier={tier} />);
 
-    const badge = screen.getByText(name).closest(".league-badge");
+    const badge = screen.getByRole("img", { name: `Ligue ${name}, palier ${name}` });
 
     expect(screen.getByText(name)).toBeInTheDocument();
-    expect(screen.getByText(`, palier ${name}`)).toBeInTheDocument();
     expect(badge).toHaveClass(`league-badge-tier-${tier}`);
     expect(badge).toHaveAttribute("data-tier", String(tier));
+  });
+
+  it("uses the default visual style for unknown tiers", () => {
+    render(<LeagueBadge name="Legend" tier={5} />);
+
+    const badge = screen.getByRole("img", { name: "Ligue Legend, palier 5" });
+
+    expect(badge).toHaveClass("league-badge-tier-default");
+    expect(badge).toHaveAttribute("data-tier", "5");
   });
 });

--- a/apps/front/src/components/LeagueBadge.test.tsx
+++ b/apps/front/src/components/LeagueBadge.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LeagueBadge } from "./LeagueBadge.js";
+
+const tiers = [
+  { name: "Bronze", tier: 1 },
+  { name: "Silver", tier: 2 },
+  { name: "Gold", tier: 3 },
+  { name: "Platinum", tier: 4 },
+];
+
+describe("LeagueBadge", () => {
+  it.each(tiers)("renders the $name tier indicator", ({ name, tier }) => {
+    render(<LeagueBadge name={name} tier={tier} />);
+
+    const badge = screen.getByRole("img", { name: `Ligue ${name}, palier ${name}` });
+
+    expect(screen.getByText(name)).toBeInTheDocument();
+    expect(badge).toHaveClass(`league-badge-tier-${tier}`);
+    expect(badge).toHaveAttribute("data-tier", String(tier));
+  });
+
+  it("uses the default visual style for unknown tiers", () => {
+    render(<LeagueBadge name="Legend" tier={5} />);
+
+    const badge = screen.getByRole("img", { name: "Ligue Legend, palier 5" });
+
+    expect(badge).toHaveClass("league-badge-tier-default");
+    expect(badge).toHaveAttribute("data-tier", "5");
+  });
+});

--- a/apps/front/src/components/LeagueBadge.tsx
+++ b/apps/front/src/components/LeagueBadge.tsx
@@ -1,0 +1,28 @@
+type LeagueBadgeProps = {
+  name: string;
+  tier: number;
+};
+
+const TIER_LABELS: Record<number, string> = {
+  1: "palier Bronze",
+  2: "palier Silver",
+  3: "palier Gold",
+  4: "palier Platinum",
+};
+
+export function LeagueBadge({ name, tier }: LeagueBadgeProps) {
+  const tierLabel = TIER_LABELS[tier] ?? `palier ${tier}`;
+  const visualTier = tier >= 1 && tier <= 4 ? String(tier) : "default";
+
+  return (
+    <span
+      className={`league-badge league-badge-tier-${visualTier}`}
+      data-tier={tier}
+      role="img"
+      aria-label={`Ligue ${name}, ${tierLabel}`}
+    >
+      <span className="league-badge-mark" aria-hidden="true" />
+      <span aria-hidden="true">{name}</span>
+    </span>
+  );
+}

--- a/apps/front/src/components/LeagueBadge.tsx
+++ b/apps/front/src/components/LeagueBadge.tsx
@@ -12,12 +12,17 @@ const TIER_LABELS: Record<number, string> = {
 
 export function LeagueBadge({ name, tier }: LeagueBadgeProps) {
   const tierLabel = TIER_LABELS[tier] ?? `palier ${tier}`;
+  const visualTier = tier >= 1 && tier <= 4 ? String(tier) : "default";
 
   return (
-    <span className={`league-badge league-badge-tier-${tier}`} data-tier={tier}>
+    <span
+      className={`league-badge league-badge-tier-${visualTier}`}
+      data-tier={tier}
+      role="img"
+      aria-label={`Ligue ${name}, ${tierLabel}`}
+    >
       <span className="league-badge-mark" aria-hidden="true" />
-      <span>{name}</span>
-      <span className="sr-only">, {tierLabel}</span>
+      <span aria-hidden="true">{name}</span>
     </span>
   );
 }

--- a/apps/front/src/components/ProfileHeader.test.tsx
+++ b/apps/front/src/components/ProfileHeader.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ProfileData } from "../hooks/useProfile.js";
+import { ProfileHeader } from "./ProfileHeader.js";
+
+const profile: ProfileData = {
+  kind: "other",
+  stats: {
+    id: "player-1",
+    displayName: "alice",
+    rating: 1400,
+    gamesPlayed: 12,
+    league: { name: "Platinum", tier: 4 },
+    winRate: 0.5,
+    createdAt: "2026-06-01T00:00:00.000Z",
+  },
+};
+
+describe("ProfileHeader", () => {
+  it("does not show next league progress for the top league", () => {
+    render(<ProfileHeader profile={profile} progressToNextLeague={1} />);
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.getByText("Ligue maximale atteinte")).toBeInTheDocument();
+  });
+});

--- a/apps/front/src/components/ProfileHeader.tsx
+++ b/apps/front/src/components/ProfileHeader.tsx
@@ -1,7 +1,9 @@
 import type { ProfileData } from "../hooks/useProfile.js";
+import { LeagueBadge } from "./LeagueBadge.js";
 
 type ProfileHeaderProps = {
   profile: ProfileData;
+  progressToNextLeague?: number;
 };
 
 function formatDate(value: string): string {
@@ -14,15 +16,42 @@ function formatWinRate(value: number): string {
   return `${Math.round(value * 100)} %`;
 }
 
-export function ProfileHeader({ profile }: ProfileHeaderProps) {
+export function ProfileHeader({ profile, progressToNextLeague }: ProfileHeaderProps) {
   const email = profile.kind === "own" ? profile.me.email : null;
   const { stats } = profile;
+  const progressPercent =
+    progressToNextLeague === undefined ? null : Math.round(progressToNextLeague * 100);
+  const hasNextLeague = stats.league.tier < 4;
 
   return (
     <section className="profile-header" aria-labelledby="profile-title">
       <h2 id="profile-title" className="title">
         {stats.displayName}
       </h2>
+
+      <div className="profile-league">
+        <LeagueBadge name={stats.league.name} tier={stats.league.tier} />
+        {progressPercent !== null && hasNextLeague ? (
+          <div className="league-progress">
+            <div className="league-progress-label">
+              <span>Progression</span>
+              <strong>{progressPercent} %</strong>
+            </div>
+            <div
+              className="league-progress-bar"
+              role="progressbar"
+              aria-label="Progression vers la prochaine ligue"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={progressPercent}
+            >
+              <span style={{ width: `${progressPercent}%` }} />
+            </div>
+          </div>
+        ) : progressPercent !== null ? (
+          <p className="league-progress-max">Ligue maximale atteinte</p>
+        ) : null}
+      </div>
 
       <dl className="profile-stats">
         {email ? (
@@ -33,8 +62,6 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
         ) : null}
         <dt>Rating</dt>
         <dd>{stats.rating}</dd>
-        <dt>Ligue</dt>
-        <dd>{stats.league.name}</dd>
         <dt>Matchs joués</dt>
         <dd>{stats.gamesPlayed}</dd>
         <dt>Taux de victoire</dt>

--- a/apps/front/src/hooks/useCurrentSeason.ts
+++ b/apps/front/src/hooks/useCurrentSeason.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { CurrentSeasonResponse } from "../api/types.js";
+
+const CURRENT_SEASON_REFRESH_MS = 30_000;
+
+export function useCurrentSeason(enabled = true) {
+  return useQuery({
+    queryKey: ["current-season"],
+    enabled,
+    queryFn: () => apiRequest<CurrentSeasonResponse>("/seasons/current"),
+    refetchInterval: CURRENT_SEASON_REFRESH_MS,
+    refetchIntervalInBackground: true,
+  });
+}

--- a/apps/front/src/pages/ProfilePage.tsx
+++ b/apps/front/src/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../auth/AuthContext.js";
 import { AsyncPanel, ProfileSkeleton } from "../components/AsyncState.js";
 import { MatchHistoryList } from "../components/MatchHistoryList.js";
 import { ProfileHeader } from "../components/ProfileHeader.js";
+import { useCurrentSeason } from "../hooks/useCurrentSeason.js";
 import { useMyHistory } from "../hooks/useMyHistory.js";
 import { useProfile } from "../hooks/useProfile.js";
 
@@ -17,6 +18,7 @@ export function ProfilePage() {
   const profileUserId = isOwnProfile ? user?.id : id;
 
   const profileQuery = useProfile(profileUserId, isOwnProfile);
+  const currentSeasonQuery = useCurrentSeason(Boolean(profileUserId) && isOwnProfile);
   const historyQuery = useMyHistory(user?.id, isOwnProfile && activeTab === "history");
 
   const historyItems = useMemo(
@@ -46,7 +48,10 @@ export function ProfilePage() {
         >
           {profileQuery.data ? (
             <>
-              <ProfileHeader profile={profileQuery.data} />
+              <ProfileHeader
+                profile={profileQuery.data}
+                progressToNextLeague={currentSeasonQuery.data?.me.progressToNextLeague}
+              />
 
               {isOwnProfile ? (
                 <div className="tabs" role="tablist" aria-label="Profil">


### PR DESCRIPTION
## Résumé
- Ajoute le composant pur `LeagueBadge` avec indicateur visuel par tier et tests RTL/Vitest.
- Ajoute le hook `useCurrentSeason` consommant `GET /seasons/current` via TanStack Query.
- Affiche le badge ligue dans le header connecté et dans le profil, avec progression vers la prochaine ligue sur le profil connecté.

## Vérifications
- `npx pnpm@9.15.9 --filter @chifoumi/front test -- LeagueBadge`
- `npx pnpm@9.15.9 --filter @chifoumi/front typecheck`
- `npx pnpm@9.15.9 exec biome check apps/front/src/api/types.ts apps/front/src/hooks/useCurrentSeason.ts apps/front/src/components/LeagueBadge.tsx apps/front/src/components/LeagueBadge.test.tsx apps/front/src/components/ProfileHeader.tsx apps/front/src/pages/ProfilePage.tsx apps/front/src/components/Header.tsx apps/front/src/App.css`
- pre-commit `biome` + typecheck racine

Closes #118