### PR TITLE
feat(seasons): add public league-filtered season standings

### DIFF
--- a/apps/api/src/seasons/dto/closed-seasons-response.dto.ts
+++ b/apps/api/src/seasons/dto/closed-seasons-response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ClosedSeasonSummaryDto {
+  @ApiProperty({ type: String, format: "uuid", example: "9b6f7c2a-4e8c-4b1a-9f24-5a7a7a8e6c4a" })
+  id!: string;
+
+  @ApiProperty({ type: String, example: "Saison 1" })
+  name!: string;
+
+  @ApiProperty({ type: String, format: "date-time", example: "2026-06-01T00:00:00.000Z" })
+  startedAt!: Date;
+
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    nullable: true,
+    example: "2026-07-01T00:00:00.000Z",
+  })
+  endsAt!: Date | null;
+
+  @ApiProperty({ enum: ["closed"], example: "closed" })
+  status!: "closed";
+}
+
+export class ClosedSeasonsResponseDto {
+  @ApiProperty({ type: () => ClosedSeasonSummaryDto, isArray: true })
+  items!: ClosedSeasonSummaryDto[];
+}

--- a/apps/api/src/seasons/dto/season-standings-query.dto.ts
+++ b/apps/api/src/seasons/dto/season-standings-query.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsInt, IsOptional, IsString, Max, Min } from "class-validator";
+
+export class SeasonStandingsQueryDto {
+  @ApiPropertyOptional({ type: Number, minimum: 1, default: 1, example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page = 1;
+
+  @ApiPropertyOptional({ type: Number, minimum: 1, maximum: 100, default: 50, example: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100, { message: "limit must be ≤ 100" })
+  limit = 50;
+
+  @ApiPropertyOptional({ type: String, example: "gold" })
+  @IsOptional()
+  @IsString()
+  league?: string;
+}

--- a/apps/api/src/seasons/dto/season-standings-response.dto.ts
+++ b/apps/api/src/seasons/dto/season-standings-response.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { LeagueSummaryDto } from "../../leagues/dto/league-summary.dto.js";
+
+export class SeasonStandingsSeasonDto {
+  @ApiProperty({ type: String, format: "uuid", example: "9b6f7c2a-4e8c-4b1a-9f24-5a7a7a8e6c4a" })
+  id!: string;
+
+  @ApiProperty({ type: String, example: "Saison 1" })
+  name!: string;
+
+  @ApiProperty({ enum: ["upcoming", "active", "closed"], example: "closed" })
+  status!: "upcoming" | "active" | "closed";
+}
+
+export class SeasonStandingEntryDto {
+  @ApiProperty({ type: Number, example: 1 })
+  rank!: number;
+
+  @ApiProperty({ type: String, format: "uuid", example: "7b6b95f2-39d9-4f2d-8a58-fb8580d2f7a1" })
+  userId!: string;
+
+  @ApiProperty({ type: String, example: "player1" })
+  displayName!: string;
+
+  @ApiProperty({ type: Number, example: 1600 })
+  finalRating!: number;
+
+  @ApiProperty({ type: () => LeagueSummaryDto })
+  finalLeague!: LeagueSummaryDto;
+}
+
+export class SeasonStandingsResponseDto {
+  @ApiProperty({ type: () => SeasonStandingsSeasonDto })
+  season!: SeasonStandingsSeasonDto;
+
+  @ApiProperty({ type: () => SeasonStandingEntryDto, isArray: true })
+  items!: SeasonStandingEntryDto[];
+
+  @ApiProperty({ type: Number, example: 42 })
+  total!: number;
+
+  @ApiProperty({ type: Number, example: 1 })
+  page!: number;
+
+  @ApiProperty({ type: Number, example: 50 })
+  limit!: number;
+}

--- a/apps/api/src/seasons/seasons.controller.spec.ts
+++ b/apps/api/src/seasons/seasons.controller.spec.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { CurrentSeasonResponseDto } from "./dto/current-season-response.dto.js";
+import type { SeasonStandingsResponseDto } from "./dto/season-standings-response.dto.js";
 import { SeasonsController } from "./seasons.controller.js";
 import type { SeasonsService } from "./seasons.service.js";
 
 describe("SeasonsController", () => {
   let controller: SeasonsController;
-  let seasonsService: { getCurrent: ReturnType<typeof jest.fn> };
+  let seasonsService: {
+    getCurrent: ReturnType<typeof jest.fn>;
+    getStandings: ReturnType<typeof jest.fn>;
+    listClosed: ReturnType<typeof jest.fn>;
+  };
 
   beforeEach(() => {
-    seasonsService = { getCurrent: jest.fn() };
+    seasonsService = { getCurrent: jest.fn(), getStandings: jest.fn(), listClosed: jest.fn() };
     controller = new SeasonsController(seasonsService as unknown as SeasonsService);
   });
 
@@ -22,5 +27,31 @@ describe("SeasonsController", () => {
 
     expect(result).toBe(response);
     expect(seasonsService.getCurrent).toHaveBeenCalledWith("ryu-id");
+  });
+
+  it("delegates standings lookup to the service", async () => {
+    const response: SeasonStandingsResponseDto = {
+      season: { id: "season-1", name: "Saison 1", status: "closed" },
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+    };
+    seasonsService.getStandings.mockResolvedValue(response);
+
+    const result = await controller.getStandings("season-1", { page: 1, limit: 50 });
+
+    expect(result).toBe(response);
+    expect(seasonsService.getStandings).toHaveBeenCalledWith("season-1", { page: 1, limit: 50 });
+  });
+
+  it("delegates closed season listing to the service", async () => {
+    const response = { items: [] };
+    seasonsService.listClosed.mockResolvedValue(response);
+
+    const result = await controller.listClosed();
+
+    expect(result).toBe(response);
+    expect(seasonsService.listClosed).toHaveBeenCalledWith();
   });
 });

--- a/apps/api/src/seasons/seasons.controller.ts
+++ b/apps/api/src/seasons/seasons.controller.ts
@@ -1,16 +1,32 @@
-import { Controller, Get, Inject, Req, UseGuards } from "@nestjs/common";
 import {
+  Controller,
+  Get,
+  Inject,
+  Param,
+  ParseUUIDPipe,
+  Query,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiConflictResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
+import { Public } from "../auth/decorators/public.decorator.js";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
 import { SWAGGER_BEARER_AUTH } from "../swagger.js";
 import type { SafeUser } from "../users/users.service.js";
+import { ClosedSeasonsResponseDto } from "./dto/closed-seasons-response.dto.js";
 import { CurrentSeasonResponseDto } from "./dto/current-season-response.dto.js";
+import { SeasonStandingsQueryDto } from "./dto/season-standings-query.dto.js";
+import { SeasonStandingsResponseDto } from "./dto/season-standings-response.dto.js";
 import { SeasonsService } from "./seasons.service.js";
 
 type AuthenticatedRequest = { user: SafeUser };
@@ -42,5 +58,58 @@ export class SeasonsController {
   })
   getCurrent(@Req() req: AuthenticatedRequest): Promise<CurrentSeasonResponseDto> {
     return this.seasonsService.getCurrent(req.user.id);
+  }
+
+  @Public()
+  @Get("closed")
+  @ApiOperation({
+    summary: "List closed seasons",
+    description: "Returns recent closed seasons so public clients can link to archived standings.",
+  })
+  @ApiOkResponse({
+    description: "Recent closed seasons",
+    type: ClosedSeasonsResponseDto,
+  })
+  listClosed(): Promise<ClosedSeasonsResponseDto> {
+    return this.seasonsService.listClosed();
+  }
+
+  @Public()
+  @Get(":id/standings")
+  @ApiOperation({
+    summary: "Get archived standings for a season",
+    description:
+      "Returns the public archived final standings for a closed season, ordered by final rank, paginated and optionally filtered by final league.",
+  })
+  @ApiQuery({ name: "page", required: false, type: Number, example: 1, minimum: 1 })
+  @ApiQuery({ name: "limit", required: false, type: Number, example: 50, minimum: 1, maximum: 100 })
+  @ApiQuery({ name: "league", required: false, type: String, example: "gold" })
+  @ApiOkResponse({
+    description: "Archived season standings",
+    type: SeasonStandingsResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: "Invalid season id, query parameters or league filter",
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ["page must not be less than 1"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: "Season is not closed yet",
+    schema: { example: { error: "SEASON_NOT_CLOSED" } },
+  })
+  @ApiNotFoundResponse({
+    description: "Season not found",
+    schema: { example: { error: "SEASON_NOT_FOUND" } },
+  })
+  getStandings(
+    @Param("id", ParseUUIDPipe) seasonId: string,
+    @Query() query: SeasonStandingsQueryDto,
+  ): Promise<SeasonStandingsResponseDto> {
+    return this.seasonsService.getStandings(seasonId, query);
   }
 }

--- a/apps/api/src/seasons/seasons.service.spec.ts
+++ b/apps/api/src/seasons/seasons.service.spec.ts
@@ -28,12 +28,14 @@ describe("SeasonsService", () => {
   let prisma: {
     season: {
       create: ReturnType<typeof jest.fn>;
+      findMany: ReturnType<typeof jest.fn>;
       findFirst: ReturnType<typeof jest.fn>;
       findUnique: ReturnType<typeof jest.fn>;
       updateMany: ReturnType<typeof jest.fn>;
     };
     eloRating: { findUnique: ReturnType<typeof jest.fn>; count: ReturnType<typeof jest.fn> };
     league: { findMany: ReturnType<typeof jest.fn> };
+    seasonStanding: { findMany: ReturnType<typeof jest.fn>; count: ReturnType<typeof jest.fn> };
   };
   let enqueueSeasonReset: ReturnType<typeof jest.fn>;
 
@@ -41,12 +43,14 @@ describe("SeasonsService", () => {
     prisma = {
       season: {
         create: jest.fn(),
+        findMany: jest.fn(),
         findFirst: jest.fn(),
         findUnique: jest.fn(),
         updateMany: jest.fn(),
       },
       eloRating: { findUnique: jest.fn(), count: jest.fn() },
       league: { findMany: jest.fn() },
+      seasonStanding: { findMany: jest.fn(), count: jest.fn() },
     };
     prisma.league.findMany.mockResolvedValue(DB_LEAGUES);
     enqueueSeasonReset = jest.fn();
@@ -113,6 +117,146 @@ describe("SeasonsService", () => {
         response: { code: "NO_ACTIVE_SEASON" },
       });
       expect(prisma.eloRating.count).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getStandings", () => {
+    it("returns paginated archived standings ordered by rank", async () => {
+      prisma.season.findUnique.mockResolvedValue({
+        id: "season-closed",
+        name: "Saison 0",
+        status: SeasonStatus.closed,
+      });
+      prisma.seasonStanding.findMany.mockResolvedValue([
+        {
+          rank: 1,
+          finalRating: 1400,
+          user: { id: "player-1", displayName: "alice" },
+          finalLeague: { name: "Platinum", tier: 4 },
+        },
+      ]);
+      prisma.seasonStanding.count.mockResolvedValue(12);
+
+      const result = await service.getStandings("season-closed", { page: 2, limit: 5 });
+
+      expect(prisma.seasonStanding.findMany).toHaveBeenCalledWith({
+        where: { seasonId: "season-closed" },
+        orderBy: { rank: "asc" },
+        skip: 5,
+        take: 5,
+        include: {
+          user: { select: { id: true, displayName: true } },
+          finalLeague: { select: { name: true, tier: true } },
+        },
+      });
+      expect(prisma.seasonStanding.count).toHaveBeenCalledWith({
+        where: { seasonId: "season-closed" },
+      });
+      expect(result).toEqual({
+        season: { id: "season-closed", name: "Saison 0", status: SeasonStatus.closed },
+        items: [
+          {
+            rank: 1,
+            userId: "player-1",
+            displayName: "alice",
+            finalRating: 1400,
+            finalLeague: { name: "Platinum", tier: 4 },
+          },
+        ],
+        total: 12,
+        page: 2,
+        limit: 5,
+      });
+    });
+
+    it("filters archived standings by final league", async () => {
+      prisma.season.findUnique.mockResolvedValue({
+        id: "season-closed",
+        name: "Saison 0",
+        status: SeasonStatus.closed,
+      });
+      prisma.seasonStanding.findMany.mockResolvedValue([]);
+      prisma.seasonStanding.count.mockResolvedValue(0);
+
+      await service.getStandings("season-closed", { page: 1, limit: 50, league: "gold" });
+
+      expect(prisma.seasonStanding.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { seasonId: "season-closed", finalLeague: { name: "Gold" } },
+        }),
+      );
+      expect(prisma.seasonStanding.count).toHaveBeenCalledWith({
+        where: { seasonId: "season-closed", finalLeague: { name: "Gold" } },
+      });
+    });
+
+    it("throws 400 UNKNOWN_LEAGUE when the league filter is invalid", async () => {
+      prisma.season.findUnique.mockResolvedValue({
+        id: "season-closed",
+        name: "Saison 0",
+        status: SeasonStatus.closed,
+      });
+
+      await expect(
+        service.getStandings("season-closed", { page: 1, limit: 50, league: "diamond" }),
+      ).rejects.toMatchObject({
+        response: { code: "UNKNOWN_LEAGUE" },
+      });
+      expect(prisma.seasonStanding.findMany).not.toHaveBeenCalled();
+    });
+
+    it("throws 409 SEASON_NOT_CLOSED when standings are requested for an active season", async () => {
+      prisma.season.findUnique.mockResolvedValue({
+        id: "season-active",
+        name: "Saison courante",
+        status: SeasonStatus.active,
+      });
+
+      await expect(
+        service.getStandings("season-active", { page: 1, limit: 50 }),
+      ).rejects.toMatchObject({
+        response: { error: "SEASON_NOT_CLOSED" },
+      });
+      await expect(
+        service.getStandings("season-active", { page: 1, limit: 50 }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(prisma.seasonStanding.findMany).not.toHaveBeenCalled();
+    });
+
+    it("throws 404 SEASON_NOT_FOUND when the season does not exist", async () => {
+      prisma.season.findUnique.mockResolvedValue(null);
+
+      await expect(service.getStandings("missing", { page: 1, limit: 50 })).rejects.toMatchObject({
+        response: { error: "SEASON_NOT_FOUND" },
+      });
+      expect(prisma.seasonStanding.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listClosed", () => {
+    it("returns recent closed seasons ordered by end date", async () => {
+      const closedSeason = {
+        id: "season-closed",
+        name: "Saison 0",
+        startedAt: new Date("2026-05-01T00:00:00.000Z"),
+        endsAt: new Date("2026-06-01T00:00:00.000Z"),
+        status: SeasonStatus.closed,
+      };
+      prisma.season.findMany.mockResolvedValue([closedSeason]);
+
+      await expect(service.listClosed()).resolves.toEqual({ items: [closedSeason] });
+      expect(prisma.season.findMany).toHaveBeenCalledWith({
+        where: { status: SeasonStatus.closed },
+        orderBy: { endsAt: "desc" },
+        take: 5,
+        select: {
+          id: true,
+          name: true,
+          startedAt: true,
+          endsAt: true,
+          status: true,
+        },
+      });
     });
   });
 

--- a/apps/api/src/seasons/seasons.service.ts
+++ b/apps/api/src/seasons/seasons.service.ts
@@ -1,9 +1,22 @@
 import { type Season, SeasonStatus } from "@chifoumi/db";
-import { getLeagueForRating, getLeagueProgress } from "@chifoumi/leagues";
-import { ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import {
+  getLeagueForRating,
+  getLeagueProgress,
+  getReferenceLeagueByName,
+  type ReferenceLeague,
+} from "@chifoumi/leagues";
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { SeasonsQueueService } from "../queues/seasons-queue.service.js";
+import type { ClosedSeasonsResponseDto } from "./dto/closed-seasons-response.dto.js";
 import type { CurrentSeasonResponseDto } from "./dto/current-season-response.dto.js";
+import type { SeasonStandingsResponseDto } from "./dto/season-standings-response.dto.js";
 
 // Players always have an elo rating row created at registration, but fall back
 // to the platform starting rating defensively (mirrors UsersService).
@@ -49,6 +62,90 @@ export class SeasonsService {
         rank,
         progressToNextLeague,
       },
+    };
+  }
+
+  async getStandings(
+    seasonId: string,
+    query: { page: number; limit: number; league?: string },
+  ): Promise<SeasonStandingsResponseDto> {
+    const season = await this.prisma.season.findUnique({
+      where: { id: seasonId },
+      select: { id: true, name: true, status: true },
+    });
+
+    if (!season) {
+      throw new NotFoundException({ error: "SEASON_NOT_FOUND" });
+    }
+
+    if (season.status !== SeasonStatus.closed) {
+      throw new ConflictException({ error: "SEASON_NOT_CLOSED" });
+    }
+
+    const league = this.resolveLeague(query.league);
+    const where = {
+      seasonId,
+      ...(league ? { finalLeague: { name: league.name } } : {}),
+    };
+    const skip = (query.page - 1) * query.limit;
+    const [items, total] = await Promise.all([
+      this.prisma.seasonStanding.findMany({
+        where,
+        orderBy: { rank: "asc" },
+        skip,
+        take: query.limit,
+        include: {
+          user: {
+            select: {
+              id: true,
+              displayName: true,
+            },
+          },
+          finalLeague: {
+            select: {
+              name: true,
+              tier: true,
+            },
+          },
+        },
+      }),
+      this.prisma.seasonStanding.count({ where }),
+    ]);
+
+    return {
+      season,
+      items: items.map((standing) => ({
+        rank: standing.rank,
+        userId: standing.user.id,
+        displayName: standing.user.displayName,
+        finalRating: standing.finalRating,
+        finalLeague: standing.finalLeague,
+      })),
+      total,
+      page: query.page,
+      limit: query.limit,
+    };
+  }
+
+  async listClosed(): Promise<ClosedSeasonsResponseDto> {
+    const items = await this.prisma.season.findMany({
+      where: { status: SeasonStatus.closed },
+      orderBy: { endsAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        name: true,
+        startedAt: true,
+        endsAt: true,
+        status: true,
+      },
+    });
+
+    return {
+      items: items.map((season) => ({
+        ...season,
+        status: SeasonStatus.closed,
+      })),
     };
   }
 
@@ -117,6 +214,19 @@ export class SeasonsService {
     });
 
     return ahead + 1;
+  }
+
+  private resolveLeague(leagueName: string | undefined): ReferenceLeague | null {
+    if (!leagueName) {
+      return null;
+    }
+
+    const league = getReferenceLeagueByName(leagueName);
+    if (!league) {
+      throw new BadRequestException({ code: "UNKNOWN_LEAGUE" });
+    }
+
+    return league;
   }
 
   private async requireClosableSeason(seasonId: string): Promise<Season> {

--- a/apps/front/src/App.css
+++ b/apps/front/src/App.css
@@ -131,6 +131,68 @@ a {
   color: #1f5fbf;
 }
 
+.league-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  border: 1px solid #d9dee7;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: #ffffff;
+  color: #15171a;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.league-badge-mark {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #8a6100;
+  box-shadow: inset 0 0 0 2px rgb(255 255 255 / 55%);
+}
+
+.league-badge-tier-1 {
+  border-color: #c99362;
+  background: #fff7ed;
+  color: #7a4a12;
+}
+
+.league-badge-tier-1 .league-badge-mark {
+  background: #b86b2b;
+}
+
+.league-badge-tier-2 {
+  border-color: #b7c1d0;
+  background: #f7f8fa;
+  color: #475467;
+}
+
+.league-badge-tier-2 .league-badge-mark {
+  background: #98a2b3;
+}
+
+.league-badge-tier-3 {
+  border-color: #f5c451;
+  background: #fff8e7;
+  color: #8a6100;
+}
+
+.league-badge-tier-3 .league-badge-mark {
+  background: #f5b301;
+}
+
+.league-badge-tier-4 {
+  border-color: #8db6ee;
+  background: #eef3fb;
+  color: #1f5fbf;
+}
+
+.league-badge-tier-4 .league-badge-mark {
+  background: #1f5fbf;
+}
+
 .form {
   display: grid;
   gap: 16px;
@@ -147,6 +209,41 @@ a {
   border: 1px solid #d9dee7;
   border-radius: 6px;
   font: inherit;
+}
+
+.field select {
+  padding: 10px 12px;
+  border: 1px solid #d9dee7;
+  border-radius: 6px;
+  font: inherit;
+  background: #ffffff;
+}
+
+.leaderboard-filter {
+  max-width: 260px;
+  margin-bottom: 20px;
+}
+
+.season-archive {
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid #e7ebf2;
+}
+
+.archive-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.archive-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .form-error {

--- a/apps/front/src/App.tsx
+++ b/apps/front/src/App.tsx
@@ -14,6 +14,7 @@ import { MatchPage } from "./pages/MatchPage.js";
 import { ProfilePage } from "./pages/ProfilePage.js";
 import { RegisterPage } from "./pages/RegisterPage.js";
 import { ResetPasswordPage } from "./pages/ResetPasswordPage.js";
+import { SeasonStandingsPage } from "./pages/SeasonStandingsPage.js";
 import "./App.css";
 
 function CatchAllRedirect() {
@@ -48,6 +49,7 @@ export function App() {
           </Route>
 
           <Route path="/leaderboard" element={<LeaderboardPage />} />
+          <Route path="/seasons/:id/standings" element={<SeasonStandingsPage />} />
 
           <Route element={<ProtectedRoute />}>
             <Route path="/lobby" element={<LobbyPage />} />

--- a/apps/front/src/api/types.ts
+++ b/apps/front/src/api/types.ts
@@ -58,6 +58,40 @@ export type LeaderboardResponse = {
   items: LeaderboardEntry[];
 };
 
+export type SeasonStandingsSeason = {
+  id: string;
+  name: string;
+  status: "upcoming" | "active" | "closed";
+};
+
+export type SeasonStandingEntry = {
+  rank: number;
+  userId: string;
+  displayName: string;
+  finalRating: number;
+  finalLeague: LeagueSummary;
+};
+
+export type SeasonStandingsResponse = {
+  season: SeasonStandingsSeason;
+  items: SeasonStandingEntry[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type ClosedSeasonSummary = {
+  id: string;
+  name: string;
+  startedAt: string;
+  endsAt: string | null;
+  status: "closed";
+};
+
+export type ClosedSeasonsResponse = {
+  items: ClosedSeasonSummary[];
+};
+
 export type MeHistoryOpponent = {
   displayName: string;
   ratingAtMatch: number;

--- a/apps/front/src/components/LeaderboardTable.tsx
+++ b/apps/front/src/components/LeaderboardTable.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import type { LeaderboardEntry } from "../api/types.js";
+import { LeagueBadge } from "./LeagueBadge.js";
 
 type LeaderboardTableProps = {
   items: LeaderboardEntry[];
@@ -28,7 +29,9 @@ export function LeaderboardTable({ items }: LeaderboardTableProps) {
                 </Link>
               </td>
               <td>{entry.rating}</td>
-              <td>{entry.league.name}</td>
+              <td>
+                <LeagueBadge name={entry.league.name} tier={entry.league.tier} />
+              </td>
               <td>{entry.gamesPlayed}</td>
             </tr>
           ))}

--- a/apps/front/src/components/LeagueBadge.test.tsx
+++ b/apps/front/src/components/LeagueBadge.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LeagueBadge } from "./LeagueBadge.js";
+
+const tiers = [
+  { name: "Bronze", tier: 1 },
+  { name: "Silver", tier: 2 },
+  { name: "Gold", tier: 3 },
+  { name: "Platinum", tier: 4 },
+];
+
+describe("LeagueBadge", () => {
+  it.each(tiers)("renders the $name tier indicator", ({ name, tier }) => {
+    render(<LeagueBadge name={name} tier={tier} />);
+
+    const badge = screen.getByText(name).closest(".league-badge");
+
+    expect(screen.getByText(name)).toBeInTheDocument();
+    expect(screen.getByText(`, palier ${name}`)).toBeInTheDocument();
+    expect(badge).toHaveClass(`league-badge-tier-${tier}`);
+    expect(badge).toHaveAttribute("data-tier", String(tier));
+  });
+});

--- a/apps/front/src/components/LeagueBadge.tsx
+++ b/apps/front/src/components/LeagueBadge.tsx
@@ -1,0 +1,23 @@
+type LeagueBadgeProps = {
+  name: string;
+  tier: number;
+};
+
+const TIER_LABELS: Record<number, string> = {
+  1: "palier Bronze",
+  2: "palier Silver",
+  3: "palier Gold",
+  4: "palier Platinum",
+};
+
+export function LeagueBadge({ name, tier }: LeagueBadgeProps) {
+  const tierLabel = TIER_LABELS[tier] ?? `palier ${tier}`;
+
+  return (
+    <span className={`league-badge league-badge-tier-${tier}`} data-tier={tier}>
+      <span className="league-badge-mark" aria-hidden="true" />
+      <span>{name}</span>
+      <span className="sr-only">, {tierLabel}</span>
+    </span>
+  );
+}

--- a/apps/front/src/hooks/useClosedSeasons.ts
+++ b/apps/front/src/hooks/useClosedSeasons.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { ClosedSeasonsResponse } from "../api/types.js";
+
+export function useClosedSeasons() {
+  return useQuery({
+    queryKey: ["closed-seasons"],
+    queryFn: () => apiRequest<ClosedSeasonsResponse>("/seasons/closed"),
+  });
+}

--- a/apps/front/src/hooks/useLeaderboard.test.ts
+++ b/apps/front/src/hooks/useLeaderboard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildLeaderboardPath } from "./useLeaderboard.js";
+
+describe("buildLeaderboardPath", () => {
+  it("builds the default leaderboard path", () => {
+    expect(buildLeaderboardPath()).toBe("/leaderboard?limit=50");
+  });
+
+  it("adds the selected league filter", () => {
+    expect(buildLeaderboardPath("gold")).toBe("/leaderboard?limit=50&league=gold");
+  });
+});

--- a/apps/front/src/hooks/useLeaderboard.ts
+++ b/apps/front/src/hooks/useLeaderboard.ts
@@ -1,14 +1,26 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "../api/apiClient.js";
 import type { LeaderboardResponse } from "../api/types.js";
+import type { LeagueFilter } from "../leagues/leagueFilters.js";
 
 const LEADERBOARD_LIMIT = 50;
 const LEADERBOARD_REFRESH_MS = 30_000;
 
-export function useLeaderboard() {
+export type LeaderboardLeagueFilter = LeagueFilter;
+
+export function buildLeaderboardPath(league?: LeaderboardLeagueFilter): string {
+  const params = new URLSearchParams({ limit: String(LEADERBOARD_LIMIT) });
+  if (league) {
+    params.set("league", league);
+  }
+
+  return `/leaderboard?${params.toString()}`;
+}
+
+export function useLeaderboard(league?: LeaderboardLeagueFilter) {
   return useQuery({
-    queryKey: ["leaderboard", LEADERBOARD_LIMIT],
-    queryFn: () => apiRequest<LeaderboardResponse>(`/leaderboard?limit=${LEADERBOARD_LIMIT}`),
+    queryKey: ["leaderboard", LEADERBOARD_LIMIT, league ?? "all"],
+    queryFn: () => apiRequest<LeaderboardResponse>(buildLeaderboardPath(league)),
     refetchInterval: LEADERBOARD_REFRESH_MS,
     refetchIntervalInBackground: true,
   });

--- a/apps/front/src/hooks/useSeasonStandings.test.ts
+++ b/apps/front/src/hooks/useSeasonStandings.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildSeasonStandingsPath } from "./useSeasonStandings.js";
+
+describe("buildSeasonStandingsPath", () => {
+  it("builds the paginated season standings path", () => {
+    expect(buildSeasonStandingsPath("season-1")).toBe(
+      "/seasons/season-1/standings?page=1&limit=50",
+    );
+  });
+
+  it("builds the season standings path with page and league filters", () => {
+    expect(buildSeasonStandingsPath("season-1", 3, "gold")).toBe(
+      "/seasons/season-1/standings?page=3&limit=50&league=gold",
+    );
+  });
+});

--- a/apps/front/src/hooks/useSeasonStandings.ts
+++ b/apps/front/src/hooks/useSeasonStandings.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "../api/apiClient.js";
+import type { SeasonStandingsResponse } from "../api/types.js";
+import type { LeagueFilter } from "../leagues/leagueFilters.js";
+
+export const SEASON_STANDINGS_LIMIT = 50;
+
+export function buildSeasonStandingsPath(
+  seasonId: string,
+  page = 1,
+  league?: LeagueFilter,
+): string {
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(SEASON_STANDINGS_LIMIT),
+  });
+  if (league) {
+    params.set("league", league);
+  }
+
+  return `/seasons/${seasonId}/standings?${params.toString()}`;
+}
+
+export function useSeasonStandings(
+  seasonId: string | undefined,
+  page: number,
+  league?: LeagueFilter,
+) {
+  return useQuery({
+    queryKey: ["season-standings", seasonId, SEASON_STANDINGS_LIMIT, page, league ?? "all"],
+    enabled: Boolean(seasonId),
+    queryFn: async () => {
+      if (!seasonId) {
+        throw new Error("Missing season id");
+      }
+
+      return apiRequest<SeasonStandingsResponse>(buildSeasonStandingsPath(seasonId, page, league));
+    },
+  });
+}

--- a/apps/front/src/leagues/leagueFilters.ts
+++ b/apps/front/src/leagues/leagueFilters.ts
@@ -1,0 +1,9 @@
+export type LeagueFilter = "bronze" | "silver" | "gold" | "platinum";
+
+export const LEAGUE_FILTERS: { label: string; value: LeagueFilter | "" }[] = [
+  { label: "Toutes", value: "" },
+  { label: "Bronze", value: "bronze" },
+  { label: "Silver", value: "silver" },
+  { label: "Gold", value: "gold" },
+  { label: "Platinum", value: "platinum" },
+];

--- a/apps/front/src/pages/LeaderboardPage.tsx
+++ b/apps/front/src/pages/LeaderboardPage.tsx
@@ -1,9 +1,23 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
 import { AsyncPanel, TableSkeleton } from "../components/AsyncState.js";
 import { LeaderboardTable } from "../components/LeaderboardTable.js";
-import { useLeaderboard } from "../hooks/useLeaderboard.js";
+import { useClosedSeasons } from "../hooks/useClosedSeasons.js";
+import { type LeaderboardLeagueFilter, useLeaderboard } from "../hooks/useLeaderboard.js";
+import { LEAGUE_FILTERS } from "../leagues/leagueFilters.js";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
 
 export function LeaderboardPage() {
-  const { data, isLoading, isError, error, refetch, isFetching } = useLeaderboard();
+  const [league, setLeague] = useState<LeaderboardLeagueFilter | undefined>();
+  const { data, isLoading, isError, error, refetch, isFetching } = useLeaderboard(league);
+  const closedSeasonsQuery = useClosedSeasons();
 
   return (
     <div className="page">
@@ -18,17 +32,57 @@ export function LeaderboardPage() {
           {isFetching && !isLoading ? <span className="badge">Mise à jour…</span> : null}
         </div>
 
+        <label className="field leaderboard-filter">
+          <span>Ligue</span>
+          <select
+            value={league ?? ""}
+            onChange={(event) =>
+              setLeague((event.target.value || undefined) as LeaderboardLeagueFilter | undefined)
+            }
+          >
+            {LEAGUE_FILTERS.map((filter) => (
+              <option key={filter.value || "all"} value={filter.value}>
+                {filter.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
         <AsyncPanel
           isLoading={isLoading}
           isError={isError}
           errorMessage={error instanceof Error ? error.message : undefined}
           onRetry={() => void refetch()}
           isEmpty={!isLoading && !isError && (data?.items.length ?? 0) === 0}
-          emptyMessage="Aucun joueur classé pour le moment."
+          emptyMessage={
+            league
+              ? "Aucun joueur classé dans cette ligue pour le moment."
+              : "Aucun joueur classé pour le moment."
+          }
           skeleton={<TableSkeleton rows={10} />}
         >
           {data ? <LeaderboardTable items={data.items} /> : null}
         </AsyncPanel>
+
+        {closedSeasonsQuery.data?.items.length ? (
+          <section className="season-archive" aria-labelledby="season-archive-title">
+            <h2 id="season-archive-title" className="section-title">
+              Palmarès archivés
+            </h2>
+            <ul className="archive-list">
+              {closedSeasonsQuery.data.items.map((season) => (
+                <li key={season.id}>
+                  <Link to={`/seasons/${season.id}/standings`} className="table-link">
+                    {season.name}
+                  </Link>
+                  <span className="muted">
+                    {season.endsAt ? `Terminée le ${formatDate(season.endsAt)}` : "Terminée"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
       </section>
     </div>
   );

--- a/apps/front/src/pages/SeasonStandingsPage.tsx
+++ b/apps/front/src/pages/SeasonStandingsPage.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { ApiError } from "../api/apiClient.js";
+import type { SeasonStandingEntry } from "../api/types.js";
+import { AsyncPanel, TableSkeleton } from "../components/AsyncState.js";
+import { LeagueBadge } from "../components/LeagueBadge.js";
+import { SEASON_STANDINGS_LIMIT, useSeasonStandings } from "../hooks/useSeasonStandings.js";
+import { LEAGUE_FILTERS, type LeagueFilter } from "../leagues/leagueFilters.js";
+
+function SeasonStandingsTable({ items }: { items: SeasonStandingEntry[] }) {
+  return (
+    <div className="table-wrap">
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Rang</th>
+            <th scope="col">Joueur</th>
+            <th scope="col">Rating final</th>
+            <th scope="col">Ligue finale</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((entry) => (
+            <tr key={entry.userId}>
+              <td>{entry.rank}</td>
+              <td>
+                <Link to={`/profile/${entry.userId}`} className="table-link">
+                  {entry.displayName}
+                </Link>
+              </td>
+              <td>{entry.finalRating}</td>
+              <td>
+                <LeagueBadge name={entry.finalLeague.name} tier={entry.finalLeague.tier} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function SeasonStandingsPage() {
+  const { id } = useParams();
+  const [page, setPage] = useState(1);
+  const [league, setLeague] = useState<LeagueFilter | undefined>();
+  const { data, isLoading, isError, error, refetch, isFetching } = useSeasonStandings(
+    id,
+    page,
+    league,
+  );
+
+  const total = data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / SEASON_STANDINGS_LIMIT));
+  const canPrev = page > 1;
+  const canNext = page < pageCount;
+
+  function handleLeagueChange(value: string) {
+    setLeague((value || undefined) as LeagueFilter | undefined);
+    setPage(1);
+  }
+
+  return (
+    <div className="page">
+      <section className="panel panel-wide" aria-labelledby="season-standings-title">
+        <div className="page-heading">
+          <h1 id="season-standings-title" className="title">
+            Palmarès de saison
+          </h1>
+          <p className="subtitle">
+            {data ? `Classement final de ${data.season.name}.` : "Classement final archivé."}
+          </p>
+          {isFetching && !isLoading ? <span className="badge">Mise à jour…</span> : null}
+        </div>
+
+        <label className="field leaderboard-filter">
+          <span>Ligue finale</span>
+          <select value={league ?? ""} onChange={(event) => handleLeagueChange(event.target.value)}>
+            {LEAGUE_FILTERS.map((filter) => (
+              <option key={filter.value || "all"} value={filter.value}>
+                {filter.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <AsyncPanel
+          isLoading={isLoading}
+          isError={isError}
+          errorMessage={
+            error instanceof ApiError && error.status === 404
+              ? "Saison introuvable."
+              : error instanceof ApiError && error.status === 409
+                ? "Cette saison n'est pas encore clôturée."
+                : error instanceof Error
+                  ? error.message
+                  : undefined
+          }
+          onRetry={() => void refetch()}
+          isEmpty={!isLoading && !isError && (data?.items.length ?? 0) === 0}
+          emptyMessage={
+            league
+              ? "Aucun palmarès archivé dans cette ligue pour cette saison."
+              : "Aucun palmarès archivé pour cette saison."
+          }
+          skeleton={<TableSkeleton rows={10} />}
+        >
+          {data ? (
+            <>
+              <SeasonStandingsTable items={data.items} />
+
+              <div className="pagination">
+                <button
+                  type="button"
+                  className="button button-secondary"
+                  disabled={!canPrev}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                >
+                  Précédent
+                </button>
+                <span className="muted">
+                  Page {page} / {pageCount}
+                </span>
+                <button
+                  type="button"
+                  className="button button-secondary"
+                  disabled={!canNext}
+                  onClick={() => setPage((current) => current + 1)}
+                >
+                  Suivant
+                </button>
+              </div>
+            </>
+          ) : null}
+        </AsyncPanel>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Ticket
Closes #119

## Summary
- Add a public archived standings API for closed seasons with UUID validation, pagination and final-league filtering.
- Add a public closed-seasons endpoint so the leaderboard can link to past season standings.
- Add pagination and league filtering to the season standings page, and move the route out of the authenticated-only area.
- Share league filter values between the live leaderboard and archived standings UI.

## Validation
- `npx pnpm@9.15.9 --filter @chifoumi/api test`
- `npx pnpm@9.15.9 --filter @chifoumi/front test`
- `npx pnpm@9.15.9 --filter @chifoumi/api typecheck`
- `npx pnpm@9.15.9 --filter @chifoumi/front typecheck`
- `npx pnpm@9.15.9 biome check <modified files>`