### PR TITLE
feat(api): add admin tournament create open start endpoints (#122)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { PrismaModule } from "./prisma/prisma.module.js";
 import { QueuesModule } from "./queues/queues.module.js";
 import { RedisModule } from "./redis/redis.module.js";
 import { SeasonsModule } from "./seasons/seasons.module.js";
+import { TournamentsModule } from "./tournaments/tournaments.module.js";
 import { UsersModule } from "./users/users.module.js";
 
 @Module({
@@ -48,6 +49,7 @@ import { UsersModule } from "./users/users.module.js";
     MatchesModule,
     MetricsModule,
     SeasonsModule,
+    TournamentsModule,
     JwksModule,
     GrpcModule,
   ],

--- a/apps/api/src/queues/queues.module.ts
+++ b/apps/api/src/queues/queues.module.ts
@@ -2,6 +2,7 @@ import { Global, Module } from "@nestjs/common";
 import { loadQueueConfig, QUEUE_CONFIG } from "../config/queue.config.js";
 import { NotificationsQueueService } from "./notifications-queue.service.js";
 import { SeasonsQueueService } from "./seasons-queue.service.js";
+import { TournamentsQueueService } from "./tournaments-queue.service.js";
 
 @Global()
 @Module({
@@ -12,7 +13,8 @@ import { SeasonsQueueService } from "./seasons-queue.service.js";
     },
     NotificationsQueueService,
     SeasonsQueueService,
+    TournamentsQueueService,
   ],
-  exports: [NotificationsQueueService, SeasonsQueueService],
+  exports: [NotificationsQueueService, SeasonsQueueService, TournamentsQueueService],
 })
 export class QueuesModule {}

--- a/apps/api/src/queues/tournaments-queue.service.spec.ts
+++ b/apps/api/src/queues/tournaments-queue.service.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { QueueConfig } from "../config/queue.config.js";
+
+const queueAdd = jest.fn<() => Promise<unknown>>();
+const queueClose = jest.fn<() => Promise<void>>();
+
+jest.unstable_mockModule("bullmq", () => ({
+  Queue: jest.fn(() => ({
+    add: queueAdd,
+    close: queueClose,
+  })),
+}));
+
+const { TournamentsQueueService: TournamentsQueueServiceClass } = await import(
+  "./tournaments-queue.service.js"
+);
+
+function createConfig(): QueueConfig {
+  return {
+    redisUrl: "redis://localhost:6379",
+    bullmqPrefix: "rps",
+  };
+}
+
+describe("TournamentsQueueService", () => {
+  beforeEach(() => {
+    queueAdd.mockReset();
+    queueClose.mockReset();
+    queueAdd.mockResolvedValue({ id: "job-1" });
+    queueClose.mockResolvedValue();
+    delete process.env.SKIP_REDIS_CONNECT;
+  });
+
+  it("enqueues a generate-bracket job with retry options and the tournament id", async () => {
+    const service = new TournamentsQueueServiceClass(createConfig());
+    await service.onModuleInit();
+
+    await service.enqueueGenerateBracket("tournament-1");
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      "generate-bracket",
+      { tournamentId: "tournament-1" },
+      {
+        attempts: 3,
+        backoff: {
+          type: "exponential",
+          delay: 1000,
+        },
+      },
+    );
+  });
+
+  it("throws when the queue is not connected", async () => {
+    process.env.SKIP_REDIS_CONNECT = "true";
+    const service = new TournamentsQueueServiceClass(createConfig());
+    await service.onModuleInit();
+
+    await expect(service.enqueueGenerateBracket("tournament-1")).rejects.toThrow(
+      "Tournaments queue is not connected",
+    );
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/queues/tournaments-queue.service.ts
+++ b/apps/api/src/queues/tournaments-queue.service.ts
@@ -1,0 +1,59 @@
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { QUEUE_CONFIG, type QueueConfig } from "../config/queue.config.js";
+
+export type GenerateBracketJobData = {
+  tournamentId: string;
+};
+
+const TOURNAMENTS_QUEUE_NAME = "tournaments";
+const GENERATE_BRACKET_JOB_NAME = "generate-bracket";
+
+const GENERATE_BRACKET_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: {
+    type: "exponential" as const,
+    delay: 1000,
+  },
+};
+
+/**
+ * Enqueues tournament lifecycle jobs on the shared "tournaments" BullMQ queue.
+ * Starting a tournament publishes a `generate-bracket` job consumed by the
+ * job-runner `bracket-generator` worker (US-070).
+ */
+@Injectable()
+export class TournamentsQueueService implements OnModuleInit, OnModuleDestroy {
+  private queue: Queue | null = null;
+
+  constructor(@Inject(QUEUE_CONFIG) private readonly queueConfig: QueueConfig) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.queue = new Queue(TOURNAMENTS_QUEUE_NAME, {
+      connection: { url: this.queueConfig.redisUrl },
+      prefix: this.queueConfig.bullmqPrefix,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.queue?.close();
+    this.queue = null;
+  }
+
+  async enqueueGenerateBracket(tournamentId: string): Promise<void> {
+    const payload: GenerateBracketJobData = { tournamentId };
+    await this.requireQueue().add(GENERATE_BRACKET_JOB_NAME, payload, GENERATE_BRACKET_JOB_OPTIONS);
+  }
+
+  private requireQueue(): Queue {
+    if (!this.queue) {
+      throw new Error("Tournaments queue is not connected");
+    }
+
+    return this.queue;
+  }
+}

--- a/apps/api/src/tournaments/admin-tournaments.controller.spec.ts
+++ b/apps/api/src/tournaments/admin-tournaments.controller.spec.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { type ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { TournamentFormat, TournamentStatus } from "@prisma/client";
+import { RolesGuard } from "../auth/guards/roles.guard.js";
+import { AdminTournamentsController } from "./admin-tournaments.controller.js";
+import { CreateTournamentDto } from "./dto/create-tournament.dto.js";
+import type { TournamentsService } from "./tournaments.service.js";
+
+function makeTournament(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "tournament-1",
+    name: "Spring Cup",
+    format: TournamentFormat.single_elim,
+    bracketSize: 16,
+    registrationOpensAt: new Date("2026-07-01T00:00:00.000Z"),
+    startsAt: new Date("2026-07-15T18:00:00.000Z"),
+    endedAt: null,
+    status: TournamentStatus.upcoming,
+    winnerId: null,
+    createdAt: new Date("2026-06-23T12:00:00.000Z"),
+    updatedAt: new Date("2026-06-23T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("AdminTournamentsController", () => {
+  let controller: AdminTournamentsController;
+  let tournamentsService: {
+    createTournament: ReturnType<typeof jest.fn>;
+    openRegistration: ReturnType<typeof jest.fn>;
+    startTournament: ReturnType<typeof jest.fn>;
+  };
+
+  beforeEach(() => {
+    tournamentsService = {
+      createTournament: jest.fn(),
+      openRegistration: jest.fn(),
+      startTournament: jest.fn(),
+    };
+    controller = new AdminTournamentsController(
+      tournamentsService as unknown as TournamentsService,
+    );
+  });
+
+  describe("createTournament", () => {
+    it("delegates to the service and maps the tournament to a response DTO", async () => {
+      tournamentsService.createTournament.mockResolvedValue(makeTournament());
+
+      const dto = new CreateTournamentDto();
+      dto.name = "Spring Cup";
+      dto.format = TournamentFormat.single_elim;
+      dto.bracketSize = 16;
+      dto.registrationOpensAt = new Date("2026-07-01T00:00:00.000Z");
+      dto.startsAt = new Date("2026-07-15T18:00:00.000Z");
+
+      const result = await controller.createTournament(dto);
+
+      expect(tournamentsService.createTournament).toHaveBeenCalledWith({
+        name: "Spring Cup",
+        format: TournamentFormat.single_elim,
+        bracketSize: 16,
+        registrationOpensAt: new Date("2026-07-01T00:00:00.000Z"),
+        startsAt: new Date("2026-07-15T18:00:00.000Z"),
+      });
+      expect(result).toEqual({
+        id: "tournament-1",
+        name: "Spring Cup",
+        format: TournamentFormat.single_elim,
+        bracketSize: 16,
+        registrationOpensAt: new Date("2026-07-01T00:00:00.000Z"),
+        startsAt: new Date("2026-07-15T18:00:00.000Z"),
+        status: TournamentStatus.upcoming,
+        createdAt: new Date("2026-06-23T12:00:00.000Z"),
+        updatedAt: new Date("2026-06-23T12:00:00.000Z"),
+      });
+    });
+  });
+
+  describe("openRegistration", () => {
+    it("delegates to the service with the tournament id", async () => {
+      tournamentsService.openRegistration.mockResolvedValue(
+        makeTournament({ status: TournamentStatus.registration_open }),
+      );
+
+      const result = await controller.openRegistration("tournament-1");
+
+      expect(tournamentsService.openRegistration).toHaveBeenCalledWith("tournament-1");
+      expect(result.status).toBe(TournamentStatus.registration_open);
+    });
+  });
+
+  describe("startTournament", () => {
+    it("delegates to the service with the tournament id", async () => {
+      tournamentsService.startTournament.mockResolvedValue(
+        makeTournament({ status: TournamentStatus.in_progress }),
+      );
+
+      const result = await controller.startTournament("tournament-1");
+
+      expect(tournamentsService.startTournament).toHaveBeenCalledWith("tournament-1");
+      expect(result.status).toBe(TournamentStatus.in_progress);
+    });
+  });
+});
+
+describe("AdminTournamentsController role protection", () => {
+  const guard = new RolesGuard(new Reflector());
+
+  function contextForRole(role: string | undefined): ExecutionContext {
+    return {
+      getHandler: () => AdminTournamentsController.prototype.createTournament,
+      getClass: () => AdminTournamentsController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: role ? { role } : undefined }),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it("allows an admin to reach the controller", () => {
+    expect(guard.canActivate(contextForRole("admin"))).toBe(true);
+  });
+
+  it("rejects a non-admin with a 403 ForbiddenException", () => {
+    expect(() => guard.canActivate(contextForRole("player"))).toThrow(ForbiddenException);
+  });
+});

--- a/apps/api/src/tournaments/admin-tournaments.controller.ts
+++ b/apps/api/src/tournaments/admin-tournaments.controller.ts
@@ -1,0 +1,155 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import type { Tournament } from "@prisma/client";
+import { Roles } from "../auth/decorators/roles.decorator.js";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard.js";
+import { RolesGuard } from "../auth/guards/roles.guard.js";
+import { SWAGGER_BEARER_AUTH } from "../swagger.js";
+import { CreateTournamentDto } from "./dto/create-tournament.dto.js";
+import { TournamentResponseDto } from "./dto/tournament-response.dto.js";
+import { TournamentsService } from "./tournaments.service.js";
+
+@ApiTags("admin-tournaments")
+@ApiBearerAuth(SWAGGER_BEARER_AUTH)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles("admin")
+@Controller("admin/tournaments")
+export class AdminTournamentsController {
+  constructor(
+    @Inject(TournamentsService) private readonly tournamentsService: TournamentsService,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Create a tournament (admin only)",
+    description: "Creates a new tournament in the `upcoming` state.",
+  })
+  @ApiCreatedResponse({ description: "Tournament created", type: TournamentResponseDto })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked access token",
+    schema: { example: { statusCode: 401, message: "Unauthorized" } },
+  })
+  @ApiForbiddenResponse({
+    description: "Authenticated user is not an administrator",
+    schema: { example: { error: "FORBIDDEN" } },
+  })
+  async createTournament(@Body() dto: CreateTournamentDto): Promise<TournamentResponseDto> {
+    const tournament = await this.tournamentsService.createTournament({
+      name: dto.name,
+      format: dto.format,
+      bracketSize: dto.bracketSize,
+      registrationOpensAt: dto.registrationOpensAt,
+      startsAt: dto.startsAt,
+    });
+    return this.toResponse(tournament);
+  }
+
+  @Patch(":id/open")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Open tournament registration (admin only)",
+    description: "Transitions the tournament from `upcoming` to `registration_open`.",
+  })
+  @ApiParam({ name: "id", format: "uuid", description: "Tournament id" })
+  @ApiOkResponse({ description: "Registration opened", type: TournamentResponseDto })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked access token",
+    schema: { example: { statusCode: 401, message: "Unauthorized" } },
+  })
+  @ApiForbiddenResponse({
+    description: "Authenticated user is not an administrator",
+    schema: { example: { error: "FORBIDDEN" } },
+  })
+  @ApiNotFoundResponse({
+    description: "TOURNAMENT_NOT_FOUND",
+    schema: { example: { error: "TOURNAMENT_NOT_FOUND" } },
+  })
+  @ApiConflictResponse({
+    description: "Tournament is not in the upcoming state",
+    schema: { example: { error: "TOURNAMENT_NOT_UPCOMING" } },
+  })
+  async openRegistration(
+    @Param("id", new ParseUUIDPipe()) tournamentId: string,
+  ): Promise<TournamentResponseDto> {
+    const tournament = await this.tournamentsService.openRegistration(tournamentId);
+    return this.toResponse(tournament);
+  }
+
+  @Patch(":id/start")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Start a tournament (admin only)",
+    description:
+      "Requires at least two registered players. Transitions `registration_open → in_progress` and enqueues a `generate-bracket` job on the tournaments queue.",
+  })
+  @ApiParam({ name: "id", format: "uuid", description: "Tournament id" })
+  @ApiOkResponse({
+    description: "Tournament started and bracket generation enqueued",
+    type: TournamentResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: "Missing, invalid or revoked access token",
+    schema: { example: { statusCode: 401, message: "Unauthorized" } },
+  })
+  @ApiForbiddenResponse({
+    description: "Authenticated user is not an administrator",
+    schema: { example: { error: "FORBIDDEN" } },
+  })
+  @ApiNotFoundResponse({
+    description: "TOURNAMENT_NOT_FOUND",
+    schema: { example: { error: "TOURNAMENT_NOT_FOUND" } },
+  })
+  @ApiConflictResponse({
+    description:
+      "Tournament already started/completed, not open for registration, or fewer than two players registered",
+    schema: {
+      oneOf: [
+        { example: { error: "TOURNAMENT_ALREADY_STARTED" } },
+        { example: { error: "NOT_ENOUGH_PLAYERS" } },
+      ],
+    },
+  })
+  async startTournament(
+    @Param("id", new ParseUUIDPipe()) tournamentId: string,
+  ): Promise<TournamentResponseDto> {
+    const tournament = await this.tournamentsService.startTournament(tournamentId);
+    return this.toResponse(tournament);
+  }
+
+  private toResponse(tournament: Tournament): TournamentResponseDto {
+    return {
+      id: tournament.id,
+      name: tournament.name,
+      format: tournament.format,
+      bracketSize: tournament.bracketSize,
+      registrationOpensAt: tournament.registrationOpensAt,
+      startsAt: tournament.startsAt,
+      status: tournament.status,
+      createdAt: tournament.createdAt,
+      updatedAt: tournament.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/tournaments/dto/create-tournament.dto.ts
+++ b/apps/api/src/tournaments/dto/create-tournament.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { TournamentFormat } from "@prisma/client";
+import { Type } from "class-transformer";
+import { IsDate, IsEnum, IsIn, IsInt, IsString, Length } from "class-validator";
+
+const ALLOWED_BRACKET_SIZES = [8, 16, 32, 64, 128, 256, 512, 1024] as const;
+
+export class CreateTournamentDto {
+  @ApiProperty({ type: String, minLength: 3, maxLength: 80, example: "Spring Cup 2026" })
+  @IsString()
+  @Length(3, 80)
+  name!: string;
+
+  @ApiProperty({ enum: TournamentFormat, example: TournamentFormat.single_elim })
+  @IsEnum(TournamentFormat)
+  format!: TournamentFormat;
+
+  @ApiProperty({
+    type: Number,
+    enum: ALLOWED_BRACKET_SIZES,
+    description: "Bracket size — must be a power of 2",
+    example: 16,
+  })
+  @IsInt()
+  @IsIn(ALLOWED_BRACKET_SIZES)
+  bracketSize!: number;
+
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    description: "When player registration opens",
+    example: "2026-07-01T00:00:00.000Z",
+  })
+  @Type(() => Date)
+  @IsDate()
+  registrationOpensAt!: Date;
+
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    description: "When the tournament is scheduled to start",
+    example: "2026-07-15T18:00:00.000Z",
+  })
+  @Type(() => Date)
+  @IsDate()
+  startsAt!: Date;
+}

--- a/apps/api/src/tournaments/dto/tournament-response.dto.ts
+++ b/apps/api/src/tournaments/dto/tournament-response.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { TournamentFormat, TournamentStatus } from "@prisma/client";
+
+export class TournamentResponseDto {
+  @ApiProperty({ type: String, format: "uuid", example: "9b6f7c2a-4e8c-4b1a-9f24-5a7a7a8e6c4a" })
+  id!: string;
+
+  @ApiProperty({ type: String, example: "Spring Cup 2026" })
+  name!: string;
+
+  @ApiProperty({ enum: TournamentFormat, example: TournamentFormat.single_elim })
+  format!: TournamentFormat;
+
+  @ApiProperty({ type: Number, example: 16 })
+  bracketSize!: number;
+
+  @ApiProperty({ type: String, format: "date-time", example: "2026-07-01T00:00:00.000Z" })
+  registrationOpensAt!: Date;
+
+  @ApiProperty({ type: String, format: "date-time", example: "2026-07-15T18:00:00.000Z" })
+  startsAt!: Date;
+
+  @ApiProperty({ enum: TournamentStatus, example: TournamentStatus.upcoming })
+  status!: TournamentStatus;
+
+  @ApiProperty({ type: String, format: "date-time", example: "2026-06-23T12:00:00.000Z" })
+  createdAt!: Date;
+
+  @ApiProperty({ type: String, format: "date-time", example: "2026-06-23T12:00:00.000Z" })
+  updatedAt!: Date;
+}

--- a/apps/api/src/tournaments/tournaments.module.spec.ts
+++ b/apps/api/src/tournaments/tournaments.module.spec.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { Test } from "@nestjs/testing";
+import { AppConfigModule } from "../config/config.module.js";
+import { PrismaModule } from "../prisma/prisma.module.js";
+import { PrismaService } from "../prisma/prisma.service.js";
+import { QueuesModule } from "../queues/queues.module.js";
+import { TournamentsModule } from "./tournaments.module.js";
+import { TournamentsService } from "./tournaments.service.js";
+
+describe("TournamentsModule wiring", () => {
+  const previousPrivateKey = process.env.JWT_PRIVATE_KEY;
+  const previousPublicKey = process.env.JWT_PUBLIC_KEY;
+  const previousRedisUrl = process.env.REDIS_URL;
+  const previousSkip = process.env.SKIP_REDIS_CONNECT;
+
+  beforeAll(() => {
+    process.env.JWT_PRIVATE_KEY = "-----BEGIN TEST PRIVATE KEY-----";
+    process.env.JWT_PUBLIC_KEY = "-----BEGIN TEST PUBLIC KEY-----";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env.SKIP_REDIS_CONNECT = "true";
+  });
+
+  afterAll(() => {
+    process.env.JWT_PRIVATE_KEY = previousPrivateKey;
+    process.env.JWT_PUBLIC_KEY = previousPublicKey;
+    process.env.REDIS_URL = previousRedisUrl;
+    process.env.SKIP_REDIS_CONNECT = previousSkip;
+  });
+
+  it("resolves TournamentsService with its queue dependency from the global QueuesModule", async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppConfigModule, PrismaModule, QueuesModule, TournamentsModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({})
+      .compile();
+
+    expect(moduleRef.get(TournamentsService)).toBeInstanceOf(TournamentsService);
+
+    await moduleRef.close();
+  });
+});

--- a/apps/api/src/tournaments/tournaments.module.ts
+++ b/apps/api/src/tournaments/tournaments.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module.js";
+import { AdminTournamentsController } from "./admin-tournaments.controller.js";
+import { TournamentsService } from "./tournaments.service.js";
+
+@Module({
+  imports: [AuthModule],
+  controllers: [AdminTournamentsController],
+  providers: [TournamentsService],
+  exports: [TournamentsService],
+})
+export class TournamentsModule {}

--- a/apps/api/src/tournaments/tournaments.service.spec.ts
+++ b/apps/api/src/tournaments/tournaments.service.spec.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ConflictException, NotFoundException } from "@nestjs/common";
+import { TournamentFormat, TournamentStatus } from "@prisma/client";
+import type { PrismaService } from "../prisma/prisma.service.js";
+import type { TournamentsQueueService } from "../queues/tournaments-queue.service.js";
+import { TournamentsService } from "./tournaments.service.js";
+
+function makeTournament(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "tournament-1",
+    name: "Spring Cup",
+    format: TournamentFormat.single_elim,
+    bracketSize: 16,
+    registrationOpensAt: new Date("2026-07-01T00:00:00.000Z"),
+    startsAt: new Date("2026-07-15T18:00:00.000Z"),
+    endedAt: null,
+    status: TournamentStatus.upcoming,
+    winnerId: null,
+    createdAt: new Date("2026-06-23T12:00:00.000Z"),
+    updatedAt: new Date("2026-06-23T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("TournamentsService", () => {
+  let service: TournamentsService;
+  let prisma: {
+    tournament: {
+      create: ReturnType<typeof jest.fn>;
+      findUnique: ReturnType<typeof jest.fn>;
+      updateMany: ReturnType<typeof jest.fn>;
+    };
+    tournamentRegistration: {
+      count: ReturnType<typeof jest.fn>;
+    };
+  };
+  let enqueueGenerateBracket: ReturnType<typeof jest.fn>;
+
+  beforeEach(() => {
+    prisma = {
+      tournament: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      tournamentRegistration: {
+        count: jest.fn(),
+      },
+    };
+    enqueueGenerateBracket = jest.fn();
+    enqueueGenerateBracket.mockResolvedValue(undefined);
+    service = new TournamentsService(
+      prisma as unknown as PrismaService,
+      { enqueueGenerateBracket } as unknown as TournamentsQueueService,
+    );
+  });
+
+  describe("createTournament", () => {
+    it("creates a tournament in the upcoming state", async () => {
+      prisma.tournament.create.mockResolvedValue(makeTournament());
+
+      await service.createTournament({
+        name: "Spring Cup",
+        format: TournamentFormat.single_elim,
+        bracketSize: 16,
+        registrationOpensAt: new Date("2026-07-01T00:00:00.000Z"),
+        startsAt: new Date("2026-07-15T18:00:00.000Z"),
+      });
+
+      expect(prisma.tournament.create).toHaveBeenCalledWith({
+        data: {
+          name: "Spring Cup",
+          format: TournamentFormat.single_elim,
+          bracketSize: 16,
+          registrationOpensAt: new Date("2026-07-01T00:00:00.000Z"),
+          startsAt: new Date("2026-07-15T18:00:00.000Z"),
+          status: TournamentStatus.upcoming,
+        },
+      });
+      expect(enqueueGenerateBracket).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("openRegistration", () => {
+    it("transitions an upcoming tournament to registration_open", async () => {
+      prisma.tournament.findUnique.mockResolvedValueOnce(makeTournament());
+      prisma.tournament.updateMany.mockResolvedValue({ count: 1 });
+      prisma.tournament.findUnique.mockResolvedValueOnce(
+        makeTournament({ status: TournamentStatus.registration_open }),
+      );
+
+      const result = await service.openRegistration("tournament-1");
+
+      expect(prisma.tournament.updateMany).toHaveBeenCalledWith({
+        where: { id: "tournament-1", status: TournamentStatus.upcoming },
+        data: { status: TournamentStatus.registration_open },
+      });
+      expect(result.status).toBe(TournamentStatus.registration_open);
+    });
+
+    it("throws 409 TOURNAMENT_ALREADY_OPEN when registration is already open", async () => {
+      prisma.tournament.findUnique.mockResolvedValue(
+        makeTournament({ status: TournamentStatus.registration_open }),
+      );
+
+      await expect(service.openRegistration("tournament-1")).rejects.toMatchObject({
+        response: { error: "TOURNAMENT_ALREADY_OPEN" },
+      });
+      await expect(service.openRegistration("tournament-1")).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(prisma.tournament.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("throws 404 TOURNAMENT_NOT_FOUND when the tournament does not exist", async () => {
+      prisma.tournament.findUnique.mockResolvedValue(null);
+
+      await expect(service.openRegistration("missing")).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe("startTournament", () => {
+    it("starts a tournament with enough players and enqueues generate-bracket", async () => {
+      prisma.tournament.findUnique.mockResolvedValueOnce(
+        makeTournament({ status: TournamentStatus.registration_open }),
+      );
+      prisma.tournamentRegistration.count.mockResolvedValue(2);
+      prisma.tournament.updateMany.mockResolvedValue({ count: 1 });
+      prisma.tournament.findUnique.mockResolvedValueOnce(
+        makeTournament({ status: TournamentStatus.in_progress }),
+      );
+
+      const result = await service.startTournament("tournament-1");
+
+      expect(prisma.tournament.updateMany).toHaveBeenCalledWith({
+        where: { id: "tournament-1", status: TournamentStatus.registration_open },
+        data: { status: TournamentStatus.in_progress },
+      });
+      expect(enqueueGenerateBracket).toHaveBeenCalledWith("tournament-1");
+      expect(result.status).toBe(TournamentStatus.in_progress);
+    });
+
+    it("throws 409 NOT_ENOUGH_PLAYERS when fewer than two players are registered", async () => {
+      prisma.tournament.findUnique.mockResolvedValue(
+        makeTournament({ status: TournamentStatus.registration_open }),
+      );
+      prisma.tournamentRegistration.count.mockResolvedValue(1);
+
+      await expect(service.startTournament("tournament-1")).rejects.toMatchObject({
+        response: { error: "NOT_ENOUGH_PLAYERS" },
+      });
+      await expect(service.startTournament("tournament-1")).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(enqueueGenerateBracket).not.toHaveBeenCalled();
+    });
+
+    it("throws 409 TOURNAMENT_ALREADY_STARTED when the tournament is in progress", async () => {
+      prisma.tournament.findUnique.mockResolvedValue(
+        makeTournament({ status: TournamentStatus.in_progress }),
+      );
+
+      await expect(service.startTournament("tournament-1")).rejects.toMatchObject({
+        response: { error: "TOURNAMENT_ALREADY_STARTED" },
+      });
+      expect(enqueueGenerateBracket).not.toHaveBeenCalled();
+    });
+
+    it("throws 409 TOURNAMENT_ALREADY_STARTED when the tournament is completed", async () => {
+      prisma.tournament.findUnique.mockResolvedValue(
+        makeTournament({ status: TournamentStatus.completed }),
+      );
+
+      await expect(service.startTournament("tournament-1")).rejects.toMatchObject({
+        response: { error: "TOURNAMENT_ALREADY_STARTED" },
+      });
+    });
+
+    it("rolls back the tournament status when enqueueing generate-bracket fails", async () => {
+      const queueError = new Error("Redis unavailable");
+      prisma.tournament.findUnique.mockResolvedValueOnce(
+        makeTournament({ status: TournamentStatus.registration_open }),
+      );
+      prisma.tournamentRegistration.count.mockResolvedValue(2);
+      prisma.tournament.updateMany.mockResolvedValueOnce({ count: 1 });
+      prisma.tournament.updateMany.mockResolvedValueOnce({ count: 1 });
+      enqueueGenerateBracket.mockRejectedValue(queueError);
+
+      await expect(service.startTournament("tournament-1")).rejects.toThrow(queueError);
+
+      expect(prisma.tournament.updateMany).toHaveBeenNthCalledWith(2, {
+        where: { id: "tournament-1", status: TournamentStatus.in_progress },
+        data: { status: TournamentStatus.registration_open },
+      });
+    });
+
+    it("throws 404 TOURNAMENT_NOT_FOUND when the tournament does not exist", async () => {
+      prisma.tournament.findUnique.mockResolvedValue(null);
+
+      await expect(service.startTournament("missing")).rejects.toBeInstanceOf(NotFoundException);
+      expect(enqueueGenerateBracket).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/tournaments/tournaments.service.ts
+++ b/apps/api/src/tournaments/tournaments.service.ts
@@ -1,0 +1,123 @@
+import { ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import type { Tournament } from "@prisma/client";
+import { TournamentFormat, TournamentStatus } from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service.js";
+import { TournamentsQueueService } from "../queues/tournaments-queue.service.js";
+
+@Injectable()
+export class TournamentsService {
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(TournamentsQueueService) private readonly tournamentsQueue: TournamentsQueueService,
+  ) {}
+
+  createTournament(input: {
+    name: string;
+    format: TournamentFormat;
+    bracketSize: number;
+    registrationOpensAt: Date;
+    startsAt: Date;
+  }): Promise<Tournament> {
+    return this.prisma.tournament.create({
+      data: {
+        name: input.name,
+        format: input.format,
+        bracketSize: input.bracketSize,
+        registrationOpensAt: input.registrationOpensAt,
+        startsAt: input.startsAt,
+        status: TournamentStatus.upcoming,
+      },
+    });
+  }
+
+  async openRegistration(tournamentId: string): Promise<Tournament> {
+    const tournament = await this.requireOpenableTournament(tournamentId);
+
+    const openResult = await this.prisma.tournament.updateMany({
+      where: { id: tournament.id, status: TournamentStatus.upcoming },
+      data: { status: TournamentStatus.registration_open },
+    });
+
+    if (openResult.count === 0) {
+      await this.requireOpenableTournament(tournamentId);
+      throw new ConflictException({ error: "TOURNAMENT_NOT_UPCOMING" });
+    }
+
+    return this.requireTournament(tournament.id);
+  }
+
+  async startTournament(tournamentId: string): Promise<Tournament> {
+    const tournament = await this.requireStartableTournament(tournamentId);
+
+    const registrationCount = await this.prisma.tournamentRegistration.count({
+      where: { tournamentId: tournament.id },
+    });
+
+    if (registrationCount < 2) {
+      throw new ConflictException({ error: "NOT_ENOUGH_PLAYERS" });
+    }
+
+    const startResult = await this.prisma.tournament.updateMany({
+      where: { id: tournament.id, status: TournamentStatus.registration_open },
+      data: { status: TournamentStatus.in_progress },
+    });
+
+    if (startResult.count === 0) {
+      await this.requireStartableTournament(tournamentId);
+      throw new ConflictException({ error: "TOURNAMENT_NOT_REGISTRATION_OPEN" });
+    }
+
+    try {
+      await this.tournamentsQueue.enqueueGenerateBracket(tournament.id);
+    } catch (error) {
+      await this.prisma.tournament.updateMany({
+        where: { id: tournament.id, status: TournamentStatus.in_progress },
+        data: { status: TournamentStatus.registration_open },
+      });
+      throw error;
+    }
+
+    return this.requireTournament(tournament.id);
+  }
+
+  private async requireTournament(tournamentId: string): Promise<Tournament> {
+    const tournament = await this.prisma.tournament.findUnique({ where: { id: tournamentId } });
+
+    if (!tournament) {
+      throw new NotFoundException({ error: "TOURNAMENT_NOT_FOUND" });
+    }
+
+    return tournament;
+  }
+
+  private async requireOpenableTournament(tournamentId: string): Promise<Tournament> {
+    const tournament = await this.requireTournament(tournamentId);
+
+    if (tournament.status === TournamentStatus.registration_open) {
+      throw new ConflictException({ error: "TOURNAMENT_ALREADY_OPEN" });
+    }
+
+    if (tournament.status !== TournamentStatus.upcoming) {
+      throw new ConflictException({ error: "TOURNAMENT_NOT_UPCOMING" });
+    }
+
+    return tournament;
+  }
+
+  private async requireStartableTournament(tournamentId: string): Promise<Tournament> {
+    const tournament = await this.requireTournament(tournamentId);
+
+    if (
+      tournament.status === TournamentStatus.in_progress ||
+      tournament.status === TournamentStatus.completed
+    ) {
+      throw new ConflictException({ error: "TOURNAMENT_ALREADY_STARTED" });
+    }
+
+    if (tournament.status !== TournamentStatus.registration_open) {
+      throw new ConflictException({ error: "TOURNAMENT_NOT_REGISTRATION_OPEN" });
+    }
+
+    return tournament;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements US-066 admin tournament lifecycle: create (upcoming), open registration, and start with BullMQ generate-bracket enqueue
- Adds TournamentsQueueService mirroring the seasons queue pattern
- Covers admin guard (403), invalid transitions (409), insufficient players (NOT_ENOUGH_PLAYERS), and enqueue rollback on failure

Closes #122

## Test plan

- [x] \pnpm biome check\ on changed files
- [x] Pre-commit typecheck passed
- [x] \pnpm --filter @chifoumi/api test -- --testPathPattern=tournaments\ (18 tests)
- [ ] Manual: create tournament as admin -> open -> register 2+ players -> start -> verify job on \	ournaments\ queue

Made with [Cursor](https://cursor.com)