### PR TITLE
feat(front) : add bracket visualization - US-073

### DIFF
--- a/apps/front/src/App.css
+++ b/apps/front/src/App.css
@@ -930,3 +930,79 @@ a {
     grid-template-columns: 1fr;
   }
 }
+
+.bracket-section {
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid #e7ebf2;
+}
+
+.bracket-view {
+  overflow-x: auto;
+}
+
+.bracket-rounds {
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+  min-width: min-content;
+}
+
+.bracket-round {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 180px;
+}
+
+.bracket-round-title {
+  margin: 0;
+  font-size: 14px;
+  color: #5d6675;
+}
+
+.bracket-round-matches {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  flex: 1;
+  gap: 16px;
+}
+
+.bracket-match {
+  display: grid;
+  gap: 6px;
+  border: 1px solid #d9dee7;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #ffffff;
+}
+
+.bracket-slot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.bracket-slot-winner {
+  font-weight: 700;
+  color: #067647;
+}
+
+.bracket-slot-score {
+  font-variant-numeric: tabular-nums;
+  color: #5d6675;
+}
+
+.bracket-bye {
+  margin: 0;
+  font-size: 13px;
+}
+
+.bracket-cta {
+  margin-top: 4px;
+  text-align: center;
+  text-decoration: none;
+}

--- a/apps/front/src/components/BracketMatchCard.tsx
+++ b/apps/front/src/components/BracketMatchCard.tsx
@@ -1,0 +1,63 @@
+import { Link } from "react-router-dom";
+import type { BracketMatch, BracketSlot } from "../api/types.js";
+import { canCurrentPlayerPlay, isByeMatch } from "../tournaments/bracket.js";
+
+function SlotRow({
+  player,
+  score,
+  isWinner,
+}: {
+  player: BracketSlot | null;
+  score: number | null;
+  isWinner: boolean;
+}) {
+  return (
+    <div className={`bracket-slot${isWinner ? " bracket-slot-winner" : ""}`}>
+      <span className="bracket-slot-name">{player ? player.displayName : "À déterminer"}</span>
+      {score !== null ? <span className="bracket-slot-score">{score}</span> : null}
+      {isWinner ? <span className="sr-only"> (vainqueur)</span> : null}
+    </div>
+  );
+}
+
+export function BracketMatchCard({
+  match,
+  round,
+  currentUserId,
+}: {
+  match: BracketMatch;
+  round: number;
+  currentUserId?: string;
+}) {
+  if (isByeMatch(match, round)) {
+    const qualified = match.slotA ?? match.slotB;
+    return (
+      <div className="bracket-match bracket-match-bye">
+        <SlotRow player={qualified} score={null} isWinner={true} />
+        <p className="bracket-bye muted">Qualifié d’office</p>
+      </div>
+    );
+  }
+
+  const hasScore = match.scoreA !== null && match.scoreB !== null;
+
+  return (
+    <div className="bracket-match">
+      <SlotRow
+        player={match.slotA}
+        score={hasScore ? match.scoreA : null}
+        isWinner={match.winnerSlot === "a"}
+      />
+      <SlotRow
+        player={match.slotB}
+        score={hasScore ? match.scoreB : null}
+        isWinner={match.winnerSlot === "b"}
+      />
+      {canCurrentPlayerPlay(match, currentUserId) ? (
+        <Link className="button bracket-cta" to={`/match/${match.matchId}`}>
+          Jouer
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/front/src/components/BracketView.test.tsx
+++ b/apps/front/src/components/BracketView.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { BracketRound } from "../api/types.js";
+import { BracketView } from "./BracketView.js";
+
+function makeBracket(): BracketRound[] {
+  return [
+    {
+      round: 1,
+      matches: [
+        {
+          id: "m1",
+          matchId: "match-1",
+          slotA: { userId: "u1", displayName: "alice" },
+          slotB: { userId: "u2", displayName: "bob" },
+          scoreA: 2,
+          scoreB: 1,
+          winnerSlot: "a",
+        },
+        {
+          id: "m2",
+          matchId: "match-2",
+          slotA: { userId: "u3", displayName: "carol" },
+          slotB: { userId: "u4", displayName: "dan" },
+          scoreA: null,
+          scoreB: null,
+          winnerSlot: null,
+        },
+        {
+          id: "bye1",
+          matchId: null,
+          slotA: { userId: "u5", displayName: "eve" },
+          slotB: null,
+          scoreA: null,
+          scoreB: null,
+          winnerSlot: null,
+        },
+      ],
+    },
+    {
+      round: 2,
+      matches: [
+        {
+          id: "m3",
+          matchId: null,
+          slotA: { userId: "u1", displayName: "alice" },
+          slotB: null,
+          scoreA: null,
+          scoreB: null,
+          winnerSlot: null,
+        },
+      ],
+    },
+  ];
+}
+
+function renderBracket(currentUserId?: string) {
+  return render(
+    <MemoryRouter>
+      <BracketView bracket={makeBracket()} currentUserId={currentUserId} />
+    </MemoryRouter>,
+  );
+}
+
+describe("BracketView", () => {
+  it("renders every round side by side with its label", () => {
+    renderBracket();
+    expect(screen.getByRole("heading", { name: "Demi-finales" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Finale" })).toBeInTheDocument();
+  });
+
+  it("shows player names, the score when played and 'À déterminer' for empty slots", () => {
+    renderBracket();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+    expect(screen.getByText("carol")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("À déterminer")).toBeInTheDocument();
+  });
+
+  it("highlights the winning slot", () => {
+    const { container } = renderBracket();
+    const winnerNames = Array.from(container.querySelectorAll(".bracket-slot-winner")).map(
+      (slot) => slot.querySelector(".bracket-slot-name")?.textContent,
+    );
+    expect(winnerNames).toContain("alice");
+
+    const bobSlot = Array.from(container.querySelectorAll(".bracket-slot")).find((slot) =>
+      slot.textContent?.includes("bob"),
+    );
+    expect(bobSlot).not.toHaveClass("bracket-slot-winner");
+  });
+
+  it("renders round-1 byes explicitly", () => {
+    renderBracket();
+    expect(screen.getByText("eve")).toBeInTheDocument();
+    expect(screen.getByText("Qualifié d’office")).toBeInTheDocument();
+  });
+
+  it("shows a 'Jouer' CTA only for the current player's ready match", () => {
+    renderBracket("u3");
+    const cta = screen.getByRole("link", { name: "Jouer" });
+    expect(cta).toHaveAttribute("href", "/match/match-2");
+  });
+
+  it("hides the CTA for spectators and finished matches", () => {
+    renderBracket();
+    expect(screen.queryByRole("link", { name: "Jouer" })).not.toBeInTheDocument();
+
+    renderBracket("u1");
+    expect(screen.queryByRole("link", { name: "Jouer" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/front/src/components/BracketView.tsx
+++ b/apps/front/src/components/BracketView.tsx
@@ -1,0 +1,38 @@
+import type { BracketRound } from "../api/types.js";
+import { roundLabel } from "../tournaments/bracket.js";
+import { BracketMatchCard } from "./BracketMatchCard.js";
+
+type BracketViewProps = {
+  bracket: BracketRound[];
+  currentUserId?: string;
+};
+
+export function BracketView({ bracket, currentUserId }: BracketViewProps) {
+  const totalRounds = bracket.length;
+
+  return (
+    <div className="bracket-view">
+      <div className="bracket-rounds">
+        {bracket.map((round) => (
+          <section
+            className="bracket-round"
+            key={round.round}
+            aria-label={roundLabel(round.round, totalRounds)}
+          >
+            <h3 className="bracket-round-title">{roundLabel(round.round, totalRounds)}</h3>
+            <div className="bracket-round-matches">
+              {round.matches.map((match) => (
+                <BracketMatchCard
+                  key={match.id}
+                  match={match}
+                  round={round.round}
+                  currentUserId={currentUserId}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/front/src/pages/TournamentDetailPage.tsx
+++ b/apps/front/src/pages/TournamentDetailPage.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext.js";
 import { AsyncPanel, ProfileSkeleton } from "../components/AsyncState.js";
+import { BracketView } from "../components/BracketView.js";
 import { TournamentErrorNotice } from "../components/TournamentErrorNotice.js";
 import { useTournament, useTournamentRegistration } from "../hooks/useTournaments.js";
 import {
@@ -127,6 +128,15 @@ export function TournamentDetailPage() {
                   <p className="muted">Aucun joueur inscrit pour le moment.</p>
                 )}
               </section>
+
+              {data.bracket.length > 0 ? (
+                <section className="bracket-section" aria-labelledby="bracket-title">
+                  <h2 id="bracket-title" className="section-title">
+                    Bracket
+                  </h2>
+                  <BracketView bracket={data.bracket} currentUserId={user?.id} />
+                </section>
+              ) : null}
             </>
           ) : null}
         </AsyncPanel>

--- a/apps/front/src/tournaments/bracket.test.ts
+++ b/apps/front/src/tournaments/bracket.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { BracketMatch } from "../api/types.js";
+import { canCurrentPlayerPlay, isByeMatch, roundLabel } from "./bracket.js";
+
+describe("roundLabel", () => {
+  it("names the final rounds explicitly", () => {
+    expect(roundLabel(3, 3)).toBe("Finale");
+    expect(roundLabel(2, 3)).toBe("Demi-finales");
+    expect(roundLabel(1, 3)).toBe("Quarts de finale");
+  });
+
+  it("falls back to a generic label for earlier rounds", () => {
+    expect(roundLabel(1, 4)).toBe("Tour 1");
+  });
+});
+
+describe("isByeMatch", () => {
+  const filled = { userId: "u1", displayName: "alice" };
+
+  it("is true for a round-1 match with a single filled slot", () => {
+    expect(isByeMatch({ slotA: filled, slotB: null } as BracketMatch, 1)).toBe(true);
+    expect(isByeMatch({ slotA: null, slotB: filled } as BracketMatch, 1)).toBe(true);
+  });
+
+  it("is false for full matches and for empty slots in later rounds", () => {
+    const fullMatch = { slotA: filled, slotB: { userId: "u2", displayName: "bob" } };
+    expect(isByeMatch(fullMatch as BracketMatch, 1)).toBe(false);
+    // a single filled slot after round 1 only means the opponent is not decided yet
+    expect(isByeMatch({ slotA: filled, slotB: null } as BracketMatch, 2)).toBe(false);
+  });
+});
+
+describe("canCurrentPlayerPlay", () => {
+  const base: BracketMatch = {
+    id: "m",
+    matchId: "match-1",
+    slotA: { userId: "u1", displayName: "alice" },
+    slotB: { userId: "u2", displayName: "bob" },
+    scoreA: null,
+    scoreB: null,
+    winnerSlot: null,
+  };
+
+  it("is true for a participant when the game is ready", () => {
+    expect(canCurrentPlayerPlay(base, "u1")).toBe(true);
+    expect(canCurrentPlayerPlay(base, "u2")).toBe(true);
+  });
+
+  it("is false for spectators and non-participants", () => {
+    expect(canCurrentPlayerPlay(base, undefined)).toBe(false);
+    expect(canCurrentPlayerPlay(base, "u9")).toBe(false);
+  });
+
+  it("is false when the match is finished or has no game id (incl. byes)", () => {
+    expect(canCurrentPlayerPlay({ ...base, winnerSlot: "a" }, "u1")).toBe(false);
+    expect(canCurrentPlayerPlay({ ...base, matchId: null }, "u1")).toBe(false);
+  });
+});

--- a/apps/front/src/tournaments/bracket.ts
+++ b/apps/front/src/tournaments/bracket.ts
@@ -1,0 +1,38 @@
+import type { BracketMatch } from "../api/types.js";
+
+export function roundLabel(round: number, totalRounds: number): string {
+  if (round === totalRounds) {
+    return "Finale";
+  }
+  if (round === totalRounds - 1) {
+    return "Demi-finales";
+  }
+  if (round === totalRounds - 2) {
+    return "Quarts de finale";
+  }
+  return `Tour ${round}`;
+}
+
+/**
+ * The API does not flag byes. A bye only happens in round 1, where the best seeds
+ * face an empty slot and auto-qualify. In later rounds a single filled slot just means
+ * the opponent is not decided yet, so it must not be treated as a bye.
+ */
+export function isByeMatch(match: BracketMatch, round: number): boolean {
+  return round === 1 && (match.slotA === null) !== (match.slotB === null);
+}
+
+/**
+ * The current player can play a match when the game is ready (a real match id exists),
+ * it has no winner yet, and the player is one of the two slots. A bye has no match id,
+ * so it is excluded by the match id check.
+ */
+export function canCurrentPlayerPlay(
+  match: BracketMatch,
+  currentUserId: string | undefined,
+): boolean {
+  if (!currentUserId || match.matchId === null || match.winnerSlot !== null) {
+    return false;
+  }
+  return match.slotA?.userId === currentUserId || match.slotB?.userId === currentUserId;
+}


### PR DESCRIPTION
## Summary
Add a tournament bracket visualization on the detail page (US-073 / Closes US-073 — Visualisation du bracket de tournoi #73)
- Render the bracket as `BracketRound[]` from the tournaments read API: rounds laid out side by side, each match showing both slots, scores when played, and the winning slot highlighted (with an `sr-only` "(vainqueur)" for a11y)
- Resolve players by `userId` (`BracketSlot`) and derive registered/playable state from `registrations` + the authenticated user — no client-only API fields
- Handle round-1 byes client-side (`isByeMatch` = round 1 with a single filled slot, since the API never flags byes) by showing the auto-qualified player as "Qualifié d'office"
- Show a "Jouer" CTA linking to `/match/:matchId` only for the current player's ready match (real `matchId`, no winner yet), reusing the existing MatchPage flow

## Test plan
- [ ] `pnpm --filter @chifoumi/front test` (roundLabel, bye derivation, canCurrentPlayerPlay, BracketView rendering/CTA — 61 tests green)
- [ ] `pnpm biome check apps/front`
- [ ] `pnpm --filter @chifoumi/front typecheck`
- [ ] Manual: open a tournament with a generated bracket → rounds, scores and winners render correctly
- [ ] Manual: as a participant with a ready match → "Jouer" appears and links to `/match/:matchId`; hidden for spectators, byes and finished matches

## DoD checklist
- [ ] Tests added and passing
- [ ] Biome + typecheck green
- [ ] Front types aligned with the tournaments read API on develop (`BracketRound[]`, `userId`)
- [ ] Byes derived client-side (no stale `isBye`/`match.round`/`BracketPlayer` fields)
- [ ] Conventional commit, history rebased onto current develop

Closes #129 