### PR TITLE
fix(api): replace @ApiPropertyOptional with @ApiProperty nullable on tournament DTOs (#123)

### DIFF
--- a/apps/api/src/tournaments/dto/tournament-read-response.dto.ts
+++ b/apps/api/src/tournaments/dto/tournament-read-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { ApiProperty } from "@nestjs/swagger";
 import { TournamentFormat, TournamentStatus, WinnerSlot } from "@prisma/client";
 
 export class TournamentListItemDto {
@@ -45,7 +45,7 @@ export class TournamentRegistrationDto {
   @ApiProperty({ type: String, example: "Ada" })
   displayName!: string;
 
-  @ApiPropertyOptional({ type: Number, example: 1, nullable: true })
+  @ApiProperty({ type: Number, example: 1, nullable: true })
   seed!: number | null;
 }
 
@@ -61,7 +61,7 @@ export class BracketMatchDto {
   @ApiProperty({ type: String, format: "uuid", example: "d91fdde2-e4c2-4e89-a80e-328245385d2d" })
   id!: string;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     type: String,
     format: "uuid",
     nullable: true,
@@ -69,19 +69,19 @@ export class BracketMatchDto {
   })
   matchId!: string | null;
 
-  @ApiPropertyOptional({ type: BracketSlotDto, nullable: true })
+  @ApiProperty({ type: BracketSlotDto, nullable: true })
   slotA!: BracketSlotDto | null;
 
-  @ApiPropertyOptional({ type: BracketSlotDto, nullable: true })
+  @ApiProperty({ type: BracketSlotDto, nullable: true })
   slotB!: BracketSlotDto | null;
 
-  @ApiPropertyOptional({ type: Number, nullable: true, example: 2 })
+  @ApiProperty({ type: Number, nullable: true, example: 2 })
   scoreA!: number | null;
 
-  @ApiPropertyOptional({ type: Number, nullable: true, example: 1 })
+  @ApiProperty({ type: Number, nullable: true, example: 1 })
   scoreB!: number | null;
 
-  @ApiPropertyOptional({ enum: WinnerSlot, nullable: true, example: WinnerSlot.a })
+  @ApiProperty({ enum: WinnerSlot, nullable: true, example: WinnerSlot.a })
   winnerSlot!: WinnerSlot | null;
 }
 
@@ -97,7 +97,7 @@ export class TournamentDetailDto extends TournamentListItemDto {
   @ApiProperty({ type: String, format: "date-time", example: "2026-07-01T00:00:00.000Z" })
   registrationOpensAt!: Date;
 
-  @ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
+  @ApiProperty({ type: String, format: "date-time", nullable: true, example: null })
   endedAt!: Date | null;
 
   @ApiProperty({ type: [TournamentRegistrationDto] })


### PR DESCRIPTION
## Summary

Closes the Swagger contract regression introduced by PR #151 (feat: expose tournament read endpoints).

8 nullable fields in `tournament-read-response.dto.ts` were decorated with `@ApiPropertyOptional` instead of `@ApiProperty({ nullable: true })`, causing them to appear as optional (absent) in the OpenAPI schema rather than required-but-nullable.

Affected fields: `seed`, `matchId`, `slotA`, `slotB`, `scoreA`, `scoreB`, `winnerSlot`, `endedAt`.

Also removes the now-unused `ApiPropertyOptional` import.

## Why it matters

`@ApiPropertyOptional` omits the field from the OpenAPI `required` array, telling API clients the field may not exist at all. For fields typed `T | null` that are always serialized, the correct decorator is `@ApiProperty({ nullable: true })` — the field is always present, just sometimes `null`. Auto-generated clients (SDKs, type generators) would produce incorrect types without this fix.

## Test plan

- [x] `pnpm biome check` passes (verified via pre-commit hook)
- [x] `pnpm -r typecheck` passes (verified via pre-commit hook)
- [ ] Verify Swagger UI at `/api-docs` shows the fields as required with nullable type
