### PR TITLE
feat(game-service): add directed tournament match via gRPC (#125)

### DIFF
--- a/apps/api/src/matches/audit.service.spec.ts
+++ b/apps/api/src/matches/audit.service.spec.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { jest } from "@jest/globals";
-import { ForbiddenException, NotFoundException } from "@nestjs/common";
+import { ForbiddenException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { MatchStatus } from "@prisma/client";
 import { PrismaService } from "../prisma/prisma.service.js";
@@ -94,6 +94,11 @@ describe("AuditService", () => {
     it("should return audit trail for ended match", async () => {
       jest.spyOn(prisma.match, "findUnique").mockResolvedValue(mockMatch);
 
+      const [round0, round1, round2] = mockMatch.rounds;
+      if (round0 === undefined || round1 === undefined || round2 === undefined) {
+        throw new Error("mockMatch must define three rounds");
+      }
+
       const result = await service.buildAudit("123");
 
       expect(result).toEqual({
@@ -105,9 +110,8 @@ describe("AuditService", () => {
         rounds: [
           {
             roundNumber: 1,
-            // Non-null assertions safe: mockMatch.rounds is always populated
-            commitA: mockMatch.rounds[0]!.commitA,
-            commitB: mockMatch.rounds[0]!.commitB,
+            commitA: round0.commitA,
+            commitB: round0.commitB,
             moveA: "rock",
             moveB: "paper",
             nonceA: "nonce-a",
@@ -116,8 +120,8 @@ describe("AuditService", () => {
           },
           {
             roundNumber: 2,
-            commitA: mockMatch.rounds[1]!.commitA,
-            commitB: mockMatch.rounds[1]!.commitB,
+            commitA: round1.commitA,
+            commitB: round1.commitB,
             moveA: "scissors",
             moveB: "rock",
             nonceA: "nonce-a2",
@@ -126,8 +130,8 @@ describe("AuditService", () => {
           },
           {
             roundNumber: 3,
-            commitA: mockMatch.rounds[2]!.commitA,
-            commitB: mockMatch.rounds[2]!.commitB,
+            commitA: round2.commitA,
+            commitB: round2.commitB,
             moveA: "paper",
             moveB: "scissors",
             nonceA: "nonce-a3",
@@ -177,9 +181,13 @@ describe("AuditService", () => {
       jest.spyOn(prisma.match, "findUnique").mockResolvedValue(mismatchMatch);
 
       const result = await service.buildAudit("123");
+      const firstRound = result.rounds[0];
+      if (firstRound === undefined) {
+        throw new Error("expected first round in audit result");
+      }
 
-      expect(result.rounds[0]!.hashCheck.a).toBe("mismatch");
-      expect(result.rounds[0]!.hashCheck.b).toBe("match");
+      expect(firstRound.hashCheck.a).toBe("mismatch");
+      expect(firstRound.hashCheck.b).toBe("match");
     });
 
     it("should include rounds with null fields as mismatch in hashCheck", async () => {
@@ -197,8 +205,12 @@ describe("AuditService", () => {
       const result = await service.buildAudit("123");
 
       expect(result.rounds).toHaveLength(1);
-      expect(result.rounds[0]!.hashCheck.a).toBe("mismatch");
-      expect(result.rounds[0]!.hashCheck.b).toBe("match");
+      const firstRound = result.rounds[0];
+      if (firstRound === undefined) {
+        throw new Error("expected first round in audit result");
+      }
+      expect(firstRound.hashCheck.a).toBe("mismatch");
+      expect(firstRound.hashCheck.b).toBe("match");
     });
   });
 });

--- a/apps/game-service/src/app.module.ts
+++ b/apps/game-service/src/app.module.ts
@@ -2,8 +2,10 @@ import { Module } from "@nestjs/common";
 import { LoggerModule } from "nestjs-pino";
 import { AuthModule } from "./auth/auth.module.js";
 import { AppConfigModule } from "./config/config.module.js";
+import { DirectedMatchModule } from "./directed-match/directed-match.module.js";
 import { GameGateway } from "./game.gateway.js";
 import { GrpcClientModule } from "./grpc/grpc-client.module.js";
+import { GrpcServerModule } from "./grpc/grpc-server.module.js";
 import { HealthModule } from "./health/health.module.js";
 import { MatchModule } from "./match/match.module.js";
 import { MatchSessionModule } from "./match-session/match-session.module.js";
@@ -27,6 +29,8 @@ import { RedisModule } from "./redis/redis.module.js";
     MatchSessionModule,
     MatchModule,
     MatchmakingModule,
+    DirectedMatchModule,
+    GrpcServerModule,
   ],
   providers: [GameGateway],
 })

--- a/apps/game-service/src/directed-match/directed-match.constants.ts
+++ b/apps/game-service/src/directed-match/directed-match.constants.ts
@@ -1,0 +1,33 @@
+export const CLAIM_DIRECTED_PLAYERS_SCRIPT = `
+local queueKey = KEYS[1]
+local pairLockKey = ARGV[1]
+local matchId = ARGV[2]
+local userA = ARGV[3]
+local userB = ARGV[4]
+local matchByUserPrefix = ARGV[5]
+local matchTtl = tonumber(ARGV[6])
+
+if redis.call("EXISTS", pairLockKey) == 0 then
+  return 0
+end
+
+if redis.call("EXISTS", matchByUserPrefix .. userA) == 1 then
+  redis.call("DEL", pairLockKey)
+  return 0
+end
+if redis.call("EXISTS", matchByUserPrefix .. userB) == 1 then
+  redis.call("DEL", pairLockKey)
+  return 0
+end
+
+if redis.call("ZSCORE", queueKey, userA) or redis.call("ZSCORE", queueKey, userB) then
+  redis.call("DEL", pairLockKey)
+  return 0
+end
+
+redis.call("SETEX", matchByUserPrefix .. userA, matchTtl, matchId)
+redis.call("SETEX", matchByUserPrefix .. userB, matchTtl, matchId)
+redis.call("DEL", pairLockKey)
+
+return 1
+`;

--- a/apps/game-service/src/directed-match/directed-match.constants.ts
+++ b/apps/game-service/src/directed-match/directed-match.constants.ts
@@ -5,10 +5,17 @@ local matchId = ARGV[2]
 local userA = ARGV[3]
 local userB = ARGV[4]
 local matchByUserPrefix = ARGV[5]
-local matchTtl = tonumber(ARGV[6])
+local metaPrefix = ARGV[6]
+local tournamentMatchKey = ARGV[7]
+local matchTtl = tonumber(ARGV[8])
 
 if redis.call("EXISTS", pairLockKey) == 0 then
   return 0
+end
+
+if redis.call("EXISTS", tournamentMatchKey) == 1 then
+  redis.call("DEL", pairLockKey)
+  return 2
 end
 
 if redis.call("EXISTS", matchByUserPrefix .. userA) == 1 then
@@ -20,13 +27,11 @@ if redis.call("EXISTS", matchByUserPrefix .. userB) == 1 then
   return 0
 end
 
-if redis.call("ZSCORE", queueKey, userA) or redis.call("ZSCORE", queueKey, userB) then
-  redis.call("DEL", pairLockKey)
-  return 0
-end
-
+redis.call("ZREM", queueKey, userA, userB)
+redis.call("DEL", metaPrefix .. userA, metaPrefix .. userB)
 redis.call("SETEX", matchByUserPrefix .. userA, matchTtl, matchId)
 redis.call("SETEX", matchByUserPrefix .. userB, matchTtl, matchId)
+redis.call("SETEX", tournamentMatchKey, matchTtl, matchId)
 redis.call("DEL", pairLockKey)
 
 return 1

--- a/apps/game-service/src/directed-match/directed-match.module.ts
+++ b/apps/game-service/src/directed-match/directed-match.module.ts
@@ -1,0 +1,13 @@
+import { forwardRef, Module } from "@nestjs/common";
+import { MatchModule } from "../match/match.module.js";
+import { MatchSessionModule } from "../match-session/match-session.module.js";
+import { MatchmakingModule } from "../matchmaking/matchmaking.module.js";
+import { RedisModule } from "../redis/redis.module.js";
+import { DirectedMatchService } from "./directed-match.service.js";
+
+@Module({
+  imports: [RedisModule, MatchSessionModule, MatchmakingModule, forwardRef(() => MatchModule)],
+  providers: [DirectedMatchService],
+  exports: [DirectedMatchService],
+})
+export class DirectedMatchModule {}

--- a/apps/game-service/src/directed-match/directed-match.service.spec.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { MatchPlayService } from "../match/match-play.service.js";
+import type { MatchSessionService } from "../match-session/match-session.service.js";
+import type { MatchState } from "../match-session/match-session.types.js";
+import type { MatchmakingService } from "../matchmaking/matchmaking.service.js";
+import type { RatingService } from "../matchmaking/rating.service.js";
+import type { RedisService } from "../redis/redis.service.js";
+import { DirectedMatchService } from "./directed-match.service.js";
+
+const slotAId = "11111111-1111-4111-8111-111111111111";
+const slotBId = "22222222-2222-4222-8222-222222222222";
+const tournamentMatchId = "33333333-3333-4333-8333-333333333333";
+
+function createState(matchId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"): MatchState {
+  return {
+    matchId,
+    players: [
+      { userId: slotAId, displayName: "Ace", rating: 1000 },
+      { userId: slotBId, displayName: "Bob", rating: 1040 },
+    ],
+    scoreA: 0,
+    scoreB: 0,
+    currentRound: 1,
+    status: "WAITING_PLAYS",
+    startedAt: "2026-06-09T10:00:00.000Z",
+    roundDeadline: "2026-06-09T10:00:05.000Z",
+    roundPlays: { a: null, b: null },
+    tournamentMatchId,
+  };
+}
+
+describe("DirectedMatchService", () => {
+  let redisService: {
+    get: jest.Mock<(key: string) => Promise<string | null>>;
+  };
+  let matchmakingService: {
+    isInQueue: jest.Mock<(userId: string) => Promise<boolean>>;
+  };
+  let ratingService: {
+    getRating: jest.Mock<(userId: string) => Promise<number>>;
+  };
+  let matchSessionService: {
+    create: jest.Mock;
+  };
+  let matchPlayService: {
+    onMatchStarted: jest.Mock;
+  };
+  let service: DirectedMatchService;
+
+  beforeEach(() => {
+    redisService = {
+      get: jest.fn(async () => null),
+    };
+    matchmakingService = {
+      isInQueue: jest.fn(async () => false),
+    };
+    ratingService = {
+      getRating: jest.fn(async (userId: string) => (userId === slotAId ? 1000 : 1040)),
+    };
+    matchSessionService = {
+      create: jest.fn(async () => createState()),
+    };
+    matchPlayService = {
+      onMatchStarted: jest.fn(async () => undefined),
+    };
+
+    service = new DirectedMatchService(
+      redisService as unknown as RedisService,
+      matchmakingService as unknown as MatchmakingService,
+      ratingService as unknown as RatingService,
+      matchSessionService as unknown as MatchSessionService,
+      matchPlayService as unknown as MatchPlayService,
+      { log: jest.fn() } as never,
+    );
+  });
+
+  it("creates a directed match without using the matchmaking queue", async () => {
+    const result = await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      matchId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+    expect(matchSessionService.create).toHaveBeenCalledWith({
+      players: [
+        { userId: slotAId, displayName: "Ace", rating: 1000 },
+        { userId: slotBId, displayName: "Bob", rating: 1040 },
+      ],
+      tournamentMatchId,
+    });
+    expect(matchPlayService.onMatchStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when a player is already in a match", async () => {
+    redisService.get.mockImplementation(async (key: string) =>
+      key.includes(slotAId) ? "existing-match" : null,
+    );
+
+    const result = await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({ ok: false, code: "PLAYER_ALREADY_IN_MATCH" });
+    expect(matchSessionService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects when both slots refer to the same player", async () => {
+    const result = await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotAId, displayName: "Ace" },
+    });
+
+    expect(result).toEqual({ ok: false, code: "SAME_PLAYER" });
+  });
+});

--- a/apps/game-service/src/directed-match/directed-match.service.spec.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.spec.ts
@@ -33,6 +33,7 @@ describe("DirectedMatchService", () => {
     setnx: jest.Mock<(key: string, ttlSeconds: number) => Promise<boolean>>;
     evalScript: jest.Mock<(script: string, keys: string[], args: string[]) => Promise<number>>;
     del: jest.Mock<(key: string) => Promise<void>>;
+    get: jest.Mock<(key: string) => Promise<string | null>>;
   };
   let ratingService: {
     getRating: jest.Mock<(userId: string) => Promise<number>>;
@@ -56,6 +57,7 @@ describe("DirectedMatchService", () => {
       setnx: jest.fn(async () => true),
       evalScript: jest.fn(async () => 1),
       del: jest.fn(async () => undefined),
+      get: jest.fn(async () => null),
     };
     ratingService = {
       getRating: jest.fn(async (userId: string) => (userId === slotAId ? 1000 : 1040)),
@@ -149,6 +151,29 @@ describe("DirectedMatchService", () => {
     });
 
     expect(result).toEqual({ ok: false, code: "TOURNAMENT_MATCH_ALREADY_STARTED" });
+    expect(matchSessionService.create).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing matchId when the same tournamentMatchId is retried while active", async () => {
+    const existingMatchId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    redisService.evalScript.mockResolvedValue(2);
+    redisService.get.mockImplementation(async (key: string) => {
+      if (key === `tournament-match:${tournamentMatchId}:match`) {
+        return existingMatchId;
+      }
+      if (key === `match:byUser:${slotAId}` || key === `match:byUser:${slotBId}`) {
+        return existingMatchId;
+      }
+      return null;
+    });
+
+    const result = await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({ ok: true, matchId: existingMatchId });
     expect(matchSessionService.create).not.toHaveBeenCalled();
   });
 

--- a/apps/game-service/src/directed-match/directed-match.service.spec.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.spec.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { MatchPlayService } from "../match/match-play.service.js";
 import type { MatchSessionService } from "../match-session/match-session.service.js";
 import type { MatchState } from "../match-session/match-session.types.js";
-import type { MatchmakingService } from "../matchmaking/matchmaking.service.js";
 import type { RatingService } from "../matchmaking/rating.service.js";
 import type { RedisService } from "../redis/redis.service.js";
 import { DirectedMatchService } from "./directed-match.service.js";
@@ -31,16 +30,21 @@ function createState(matchId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"): MatchSta
 
 describe("DirectedMatchService", () => {
   let redisService: {
-    get: jest.Mock<(key: string) => Promise<string | null>>;
-  };
-  let matchmakingService: {
-    isInQueue: jest.Mock<(userId: string) => Promise<boolean>>;
+    setnx: jest.Mock<(key: string, ttlSeconds: number) => Promise<boolean>>;
+    evalScript: jest.Mock<(script: string, keys: string[], args: string[]) => Promise<number>>;
+    del: jest.Mock<(key: string) => Promise<void>>;
   };
   let ratingService: {
     getRating: jest.Mock<(userId: string) => Promise<number>>;
   };
   let matchSessionService: {
-    create: jest.Mock;
+    create: jest.Mock<
+      (input: {
+        players: unknown;
+        matchId?: string;
+        tournamentMatchId?: string;
+      }) => Promise<MatchState>
+    >;
   };
   let matchPlayService: {
     onMatchStarted: jest.Mock;
@@ -49,16 +53,18 @@ describe("DirectedMatchService", () => {
 
   beforeEach(() => {
     redisService = {
-      get: jest.fn(async () => null),
-    };
-    matchmakingService = {
-      isInQueue: jest.fn(async () => false),
+      setnx: jest.fn(async () => true),
+      evalScript: jest.fn(async () => 1),
+      del: jest.fn(async () => undefined),
     };
     ratingService = {
       getRating: jest.fn(async (userId: string) => (userId === slotAId ? 1000 : 1040)),
     };
     matchSessionService = {
-      create: jest.fn(async () => createState()),
+      create: jest.fn(
+        async (input: { players: unknown; matchId?: string; tournamentMatchId?: string }) =>
+          createState(input.matchId ?? "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+      ),
     };
     matchPlayService = {
       onMatchStarted: jest.fn(async () => undefined),
@@ -66,7 +72,6 @@ describe("DirectedMatchService", () => {
 
     service = new DirectedMatchService(
       redisService as unknown as RedisService,
-      matchmakingService as unknown as MatchmakingService,
       ratingService as unknown as RatingService,
       matchSessionService as unknown as MatchSessionService,
       matchPlayService as unknown as MatchPlayService,
@@ -81,24 +86,26 @@ describe("DirectedMatchService", () => {
       slotB: { userId: slotBId, displayName: "Bob" },
     });
 
-    expect(result).toEqual({
-      ok: true,
-      matchId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected directed match to start");
+    }
+
+    expect(redisService.setnx).toHaveBeenCalledTimes(1);
+    expect(redisService.evalScript).toHaveBeenCalledTimes(1);
     expect(matchSessionService.create).toHaveBeenCalledWith({
       players: [
         { userId: slotAId, displayName: "Ace", rating: 1000 },
         { userId: slotBId, displayName: "Bob", rating: 1040 },
       ],
+      matchId: result.matchId,
       tournamentMatchId,
     });
     expect(matchPlayService.onMatchStarted).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects when a player is already in a match", async () => {
-    redisService.get.mockImplementation(async (key: string) =>
-      key.includes(slotAId) ? "existing-match" : null,
-    );
+  it("rejects when atomic player claim fails", async () => {
+    redisService.evalScript.mockResolvedValue(0);
 
     const result = await service.startMatch({
       tournamentMatchId,
@@ -110,6 +117,32 @@ describe("DirectedMatchService", () => {
     expect(matchSessionService.create).not.toHaveBeenCalled();
   });
 
+  it("rejects when pair lock cannot be acquired", async () => {
+    redisService.setnx.mockResolvedValue(false);
+
+    const result = await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({ ok: false, code: "PLAYER_ALREADY_IN_MATCH" });
+    expect(redisService.evalScript).not.toHaveBeenCalled();
+    expect(matchSessionService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects when tournamentMatchId is not a UUID", async () => {
+    const result = await service.startMatch({
+      tournamentMatchId: "bracket-1",
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({ ok: false, code: "INVALID_TOURNAMENT_MATCH" });
+    expect(redisService.setnx).not.toHaveBeenCalled();
+    expect(matchSessionService.create).not.toHaveBeenCalled();
+  });
+
   it("rejects when both slots refer to the same player", async () => {
     const result = await service.startMatch({
       tournamentMatchId,
@@ -118,5 +151,19 @@ describe("DirectedMatchService", () => {
     });
 
     expect(result).toEqual({ ok: false, code: "SAME_PLAYER" });
+  });
+
+  it("releases player claims when session creation fails", async () => {
+    matchSessionService.create.mockRejectedValue(new Error("redis unavailable"));
+
+    await expect(
+      service.startMatch({
+        tournamentMatchId,
+        slotA: { userId: slotAId, displayName: "Ace" },
+        slotB: { userId: slotBId, displayName: "Bob" },
+      }),
+    ).rejects.toThrow("redis unavailable");
+
+    expect(redisService.del).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/game-service/src/directed-match/directed-match.service.spec.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.spec.ts
@@ -93,6 +93,15 @@ describe("DirectedMatchService", () => {
 
     expect(redisService.setnx).toHaveBeenCalledTimes(1);
     expect(redisService.evalScript).toHaveBeenCalledTimes(1);
+    expect(redisService.evalScript).toHaveBeenCalledWith(
+      expect.any(String),
+      ["matchmaking:queue"],
+      expect.arrayContaining([
+        "match:byUser:",
+        "matchmaking:meta:",
+        `tournament-match:${tournamentMatchId}:match`,
+      ]),
+    );
     expect(matchSessionService.create).toHaveBeenCalledWith({
       players: [
         { userId: slotAId, displayName: "Ace", rating: 1000 },
@@ -102,6 +111,19 @@ describe("DirectedMatchService", () => {
       tournamentMatchId,
     });
     expect(matchPlayService.onMatchStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows directed matches to pull players out of the matchmaking queue", async () => {
+    await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    const script = redisService.evalScript.mock.calls[0]?.[0] ?? "";
+    expect(script).toContain('redis.call("ZREM", queueKey, userA, userB)');
+    expect(script).toContain('redis.call("DEL", metaPrefix .. userA, metaPrefix .. userB)');
+    expect(script).not.toContain('redis.call("ZSCORE", queueKey');
   });
 
   it("rejects when atomic player claim fails", async () => {
@@ -114,6 +136,19 @@ describe("DirectedMatchService", () => {
     });
 
     expect(result).toEqual({ ok: false, code: "PLAYER_ALREADY_IN_MATCH" });
+    expect(matchSessionService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the tournament match is already claimed", async () => {
+    redisService.evalScript.mockResolvedValue(2);
+
+    const result = await service.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({ ok: false, code: "TOURNAMENT_MATCH_ALREADY_STARTED" });
     expect(matchSessionService.create).not.toHaveBeenCalled();
   });
 
@@ -164,6 +199,7 @@ describe("DirectedMatchService", () => {
       }),
     ).rejects.toThrow("redis unavailable");
 
-    expect(redisService.del).toHaveBeenCalledTimes(2);
+    expect(redisService.del).toHaveBeenCalledTimes(3);
+    expect(redisService.del).toHaveBeenCalledWith(`tournament-match:${tournamentMatchId}:match`);
   });
 });

--- a/apps/game-service/src/directed-match/directed-match.service.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.ts
@@ -1,12 +1,22 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { Logger } from "nestjs-pino";
+import { validate as uuidValidate, v4 as uuidv4 } from "uuid";
 import { MatchPlayService } from "../match/match-play.service.js";
 import { MatchSessionService } from "../match-session/match-session.service.js";
-import type { MatchPlayer } from "../match-session/match-session.types.js";
-import { matchByUserKey } from "../matchmaking/matchmaking.constants.js";
-import { MatchmakingService } from "../matchmaking/matchmaking.service.js";
+import {
+  MATCH_SESSION_TTL_SECONDS,
+  type MatchPlayer,
+  userMatchKey,
+} from "../match-session/match-session.types.js";
+import {
+  MATCH_BY_USER_PREFIX,
+  MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
+  MATCHMAKING_QUEUE_KEY,
+  matchmakingPairLockKey,
+} from "../matchmaking/matchmaking.constants.js";
 import { RatingService } from "../matchmaking/rating.service.js";
 import { RedisService } from "../redis/redis.service.js";
+import { CLAIM_DIRECTED_PLAYERS_SCRIPT } from "./directed-match.constants.js";
 
 export type DirectedMatchPlayer = {
   userId: string;
@@ -22,7 +32,8 @@ export type StartDirectedMatchInput = {
 export type StartDirectedMatchErrorCode =
   | "SAME_PLAYER"
   | "PLAYER_ALREADY_IN_MATCH"
-  | "INVALID_PLAYER";
+  | "INVALID_PLAYER"
+  | "INVALID_TOURNAMENT_MATCH";
 
 export type StartDirectedMatchResult =
   | { ok: true; matchId: string }
@@ -32,7 +43,6 @@ export type StartDirectedMatchResult =
 export class DirectedMatchService {
   constructor(
     @Inject(RedisService) private readonly redisService: RedisService,
-    @Inject(MatchmakingService) private readonly matchmakingService: MatchmakingService,
     @Inject(RatingService) private readonly ratingService: RatingService,
     @Inject(MatchSessionService) private readonly matchSessionService: MatchSessionService,
     @Inject(MatchPlayService) private readonly matchPlayService: MatchPlayService,
@@ -44,17 +54,13 @@ export class DirectedMatchService {
       return { ok: false, code: "SAME_PLAYER" };
     }
 
-    if (
-      !this.isValidPlayer(input.slotA) ||
-      !this.isValidPlayer(input.slotB) ||
-      input.tournamentMatchId.trim().length === 0
-    ) {
+    if (!this.isValidPlayer(input.slotA) || !this.isValidPlayer(input.slotB)) {
       return { ok: false, code: "INVALID_PLAYER" };
     }
 
-    const busyCheck = await this.ensurePlayersAvailable(input.slotA.userId, input.slotB.userId);
-    if (!busyCheck.ok) {
-      return busyCheck;
+    const tournamentMatchId = input.tournamentMatchId.trim();
+    if (tournamentMatchId.length === 0 || !uuidValidate(tournamentMatchId)) {
+      return { ok: false, code: "INVALID_TOURNAMENT_MATCH" };
     }
 
     const [playerA, playerB] = await Promise.all([
@@ -62,53 +68,66 @@ export class DirectedMatchService {
       this.toMatchPlayer(input.slotB),
     ]);
 
-    const state = await this.matchSessionService.create({
-      players: [playerA, playerB],
-      tournamentMatchId: input.tournamentMatchId,
-    });
+    const matchId = uuidv4();
+    const claimed = await this.claimPlayers(playerA.userId, playerB.userId, matchId);
+    if (!claimed) {
+      return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
+    }
 
-    await this.matchPlayService.onMatchStarted(state);
+    try {
+      const state = await this.matchSessionService.create({
+        players: [playerA, playerB],
+        matchId,
+        tournamentMatchId,
+      });
 
-    this.logger.log(
-      {
-        matchId: state.matchId,
-        tournamentMatchId: input.tournamentMatchId,
-        slotA: input.slotA.userId,
-        slotB: input.slotB.userId,
-      },
-      "directed tournament match created",
-    );
+      await this.matchPlayService.onMatchStarted(state);
 
-    return { ok: true, matchId: state.matchId };
+      this.logger.log(
+        {
+          matchId: state.matchId,
+          tournamentMatchId,
+          slotA: input.slotA.userId,
+          slotB: input.slotB.userId,
+        },
+        "directed tournament match created",
+      );
+
+      return { ok: true, matchId: state.matchId };
+    } catch (error) {
+      await this.releasePlayerClaims(playerA.userId, playerB.userId);
+      throw error;
+    }
   }
 
   private isValidPlayer(player: DirectedMatchPlayer): boolean {
     return player.userId.trim().length > 0 && player.displayName.trim().length > 0;
   }
 
-  private async ensurePlayersAvailable(
-    userA: string,
-    userB: string,
-  ): Promise<{ ok: true } | { ok: false; code: "PLAYER_ALREADY_IN_MATCH" }> {
-    const [matchA, matchB] = await Promise.all([
-      this.redisService.get(matchByUserKey(userA)),
-      this.redisService.get(matchByUserKey(userB)),
-    ]);
-
-    if (matchA || matchB) {
-      return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
+  private async claimPlayers(userA: string, userB: string, matchId: string): Promise<boolean> {
+    const pairLockKey = matchmakingPairLockKey(userA, userB);
+    const lockAcquired = await this.redisService.setnx(
+      pairLockKey,
+      MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
+    );
+    if (!lockAcquired) {
+      return false;
     }
 
-    const [inQueueA, inQueueB] = await Promise.all([
-      this.matchmakingService.isInQueue(userA),
-      this.matchmakingService.isInQueue(userB),
+    const claimed = await this.redisService.evalScript<number>(
+      CLAIM_DIRECTED_PLAYERS_SCRIPT,
+      [MATCHMAKING_QUEUE_KEY],
+      [pairLockKey, matchId, userA, userB, MATCH_BY_USER_PREFIX, String(MATCH_SESSION_TTL_SECONDS)],
+    );
+
+    return claimed === 1;
+  }
+
+  private async releasePlayerClaims(userA: string, userB: string): Promise<void> {
+    await Promise.all([
+      this.redisService.del(userMatchKey(userA)),
+      this.redisService.del(userMatchKey(userB)),
     ]);
-
-    if (inQueueA || inQueueB) {
-      return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
-    }
-
-    return { ok: true };
   }
 
   private async toMatchPlayer(player: DirectedMatchPlayer): Promise<MatchPlayer> {

--- a/apps/game-service/src/directed-match/directed-match.service.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.ts
@@ -78,7 +78,7 @@ export class DirectedMatchService {
       matchId,
     );
     if (claim === "tournament_already_started") {
-      return { ok: false, code: "TOURNAMENT_MATCH_ALREADY_STARTED" };
+      return this.resolveExistingTournamentMatch(tournamentMatchId, playerA.userId, playerB.userId);
     }
     if (claim === "players_busy") {
       return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
@@ -151,6 +151,28 @@ export class DirectedMatchService {
       return "tournament_already_started";
     }
     return "players_busy";
+  }
+
+  private async resolveExistingTournamentMatch(
+    tournamentMatchId: string,
+    userA: string,
+    userB: string,
+  ): Promise<StartDirectedMatchResult> {
+    const existingMatchId = await this.redisService.get(tournamentMatchKey(tournamentMatchId));
+    if (!existingMatchId) {
+      return { ok: false, code: "TOURNAMENT_MATCH_ALREADY_STARTED" };
+    }
+
+    const [userAMatchId, userBMatchId] = await Promise.all([
+      this.redisService.get(userMatchKey(userA)),
+      this.redisService.get(userMatchKey(userB)),
+    ]);
+
+    if (userAMatchId === existingMatchId && userBMatchId === existingMatchId) {
+      return { ok: true, matchId: existingMatchId };
+    }
+
+    return { ok: false, code: "TOURNAMENT_MATCH_ALREADY_STARTED" };
   }
 
   private async releaseClaims(

--- a/apps/game-service/src/directed-match/directed-match.service.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.ts
@@ -1,0 +1,122 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Logger } from "nestjs-pino";
+import { MatchPlayService } from "../match/match-play.service.js";
+import { MatchSessionService } from "../match-session/match-session.service.js";
+import type { MatchPlayer } from "../match-session/match-session.types.js";
+import { matchByUserKey } from "../matchmaking/matchmaking.constants.js";
+import { MatchmakingService } from "../matchmaking/matchmaking.service.js";
+import { RatingService } from "../matchmaking/rating.service.js";
+import { RedisService } from "../redis/redis.service.js";
+
+export type DirectedMatchPlayer = {
+  userId: string;
+  displayName: string;
+};
+
+export type StartDirectedMatchInput = {
+  tournamentMatchId: string;
+  slotA: DirectedMatchPlayer;
+  slotB: DirectedMatchPlayer;
+};
+
+export type StartDirectedMatchErrorCode =
+  | "SAME_PLAYER"
+  | "PLAYER_ALREADY_IN_MATCH"
+  | "INVALID_PLAYER";
+
+export type StartDirectedMatchResult =
+  | { ok: true; matchId: string }
+  | { ok: false; code: StartDirectedMatchErrorCode };
+
+@Injectable()
+export class DirectedMatchService {
+  constructor(
+    @Inject(RedisService) private readonly redisService: RedisService,
+    @Inject(MatchmakingService) private readonly matchmakingService: MatchmakingService,
+    @Inject(RatingService) private readonly ratingService: RatingService,
+    @Inject(MatchSessionService) private readonly matchSessionService: MatchSessionService,
+    @Inject(MatchPlayService) private readonly matchPlayService: MatchPlayService,
+    @Inject(Logger) private readonly logger: Logger,
+  ) {}
+
+  async startMatch(input: StartDirectedMatchInput): Promise<StartDirectedMatchResult> {
+    if (input.slotA.userId === input.slotB.userId) {
+      return { ok: false, code: "SAME_PLAYER" };
+    }
+
+    if (
+      !this.isValidPlayer(input.slotA) ||
+      !this.isValidPlayer(input.slotB) ||
+      input.tournamentMatchId.trim().length === 0
+    ) {
+      return { ok: false, code: "INVALID_PLAYER" };
+    }
+
+    const busyCheck = await this.ensurePlayersAvailable(input.slotA.userId, input.slotB.userId);
+    if (!busyCheck.ok) {
+      return busyCheck;
+    }
+
+    const [playerA, playerB] = await Promise.all([
+      this.toMatchPlayer(input.slotA),
+      this.toMatchPlayer(input.slotB),
+    ]);
+
+    const state = await this.matchSessionService.create({
+      players: [playerA, playerB],
+      tournamentMatchId: input.tournamentMatchId,
+    });
+
+    await this.matchPlayService.onMatchStarted(state);
+
+    this.logger.log(
+      {
+        matchId: state.matchId,
+        tournamentMatchId: input.tournamentMatchId,
+        slotA: input.slotA.userId,
+        slotB: input.slotB.userId,
+      },
+      "directed tournament match created",
+    );
+
+    return { ok: true, matchId: state.matchId };
+  }
+
+  private isValidPlayer(player: DirectedMatchPlayer): boolean {
+    return player.userId.trim().length > 0 && player.displayName.trim().length > 0;
+  }
+
+  private async ensurePlayersAvailable(
+    userA: string,
+    userB: string,
+  ): Promise<{ ok: true } | { ok: false; code: "PLAYER_ALREADY_IN_MATCH" }> {
+    const [matchA, matchB] = await Promise.all([
+      this.redisService.get(matchByUserKey(userA)),
+      this.redisService.get(matchByUserKey(userB)),
+    ]);
+
+    if (matchA || matchB) {
+      return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
+    }
+
+    const [inQueueA, inQueueB] = await Promise.all([
+      this.matchmakingService.isInQueue(userA),
+      this.matchmakingService.isInQueue(userB),
+    ]);
+
+    if (inQueueA || inQueueB) {
+      return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
+    }
+
+    return { ok: true };
+  }
+
+  private async toMatchPlayer(player: DirectedMatchPlayer): Promise<MatchPlayer> {
+    const rating = await this.ratingService.getRating(player.userId);
+    return {
+      userId: player.userId,
+      displayName: player.displayName,
+      rating,
+    };
+  }
+}

--- a/apps/game-service/src/directed-match/directed-match.service.ts
+++ b/apps/game-service/src/directed-match/directed-match.service.ts
@@ -10,6 +10,7 @@ import {
 } from "../match-session/match-session.types.js";
 import {
   MATCH_BY_USER_PREFIX,
+  MATCHMAKING_META_PREFIX,
   MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
   MATCHMAKING_QUEUE_KEY,
   matchmakingPairLockKey,
@@ -33,7 +34,8 @@ export type StartDirectedMatchErrorCode =
   | "SAME_PLAYER"
   | "PLAYER_ALREADY_IN_MATCH"
   | "INVALID_PLAYER"
-  | "INVALID_TOURNAMENT_MATCH";
+  | "INVALID_TOURNAMENT_MATCH"
+  | "TOURNAMENT_MATCH_ALREADY_STARTED";
 
 export type StartDirectedMatchResult =
   | { ok: true; matchId: string }
@@ -69,8 +71,16 @@ export class DirectedMatchService {
     ]);
 
     const matchId = uuidv4();
-    const claimed = await this.claimPlayers(playerA.userId, playerB.userId, matchId);
-    if (!claimed) {
+    const claim = await this.claimPlayers(
+      playerA.userId,
+      playerB.userId,
+      tournamentMatchId,
+      matchId,
+    );
+    if (claim === "tournament_already_started") {
+      return { ok: false, code: "TOURNAMENT_MATCH_ALREADY_STARTED" };
+    }
+    if (claim === "players_busy") {
       return { ok: false, code: "PLAYER_ALREADY_IN_MATCH" };
     }
 
@@ -95,7 +105,7 @@ export class DirectedMatchService {
 
       return { ok: true, matchId: state.matchId };
     } catch (error) {
-      await this.releasePlayerClaims(playerA.userId, playerB.userId);
+      await this.releaseClaims(playerA.userId, playerB.userId, tournamentMatchId);
       throw error;
     }
   }
@@ -104,29 +114,54 @@ export class DirectedMatchService {
     return player.userId.trim().length > 0 && player.displayName.trim().length > 0;
   }
 
-  private async claimPlayers(userA: string, userB: string, matchId: string): Promise<boolean> {
+  private async claimPlayers(
+    userA: string,
+    userB: string,
+    tournamentMatchId: string,
+    matchId: string,
+  ): Promise<"claimed" | "players_busy" | "tournament_already_started"> {
     const pairLockKey = matchmakingPairLockKey(userA, userB);
     const lockAcquired = await this.redisService.setnx(
       pairLockKey,
       MATCHMAKING_PAIR_LOCK_TTL_SECONDS,
     );
     if (!lockAcquired) {
-      return false;
+      return "players_busy";
     }
 
     const claimed = await this.redisService.evalScript<number>(
       CLAIM_DIRECTED_PLAYERS_SCRIPT,
       [MATCHMAKING_QUEUE_KEY],
-      [pairLockKey, matchId, userA, userB, MATCH_BY_USER_PREFIX, String(MATCH_SESSION_TTL_SECONDS)],
+      [
+        pairLockKey,
+        matchId,
+        userA,
+        userB,
+        MATCH_BY_USER_PREFIX,
+        MATCHMAKING_META_PREFIX,
+        tournamentMatchKey(tournamentMatchId),
+        String(MATCH_SESSION_TTL_SECONDS),
+      ],
     );
 
-    return claimed === 1;
+    if (claimed === 1) {
+      return "claimed";
+    }
+    if (claimed === 2) {
+      return "tournament_already_started";
+    }
+    return "players_busy";
   }
 
-  private async releasePlayerClaims(userA: string, userB: string): Promise<void> {
+  private async releaseClaims(
+    userA: string,
+    userB: string,
+    tournamentMatchId: string,
+  ): Promise<void> {
     await Promise.all([
       this.redisService.del(userMatchKey(userA)),
       this.redisService.del(userMatchKey(userB)),
+      this.redisService.del(tournamentMatchKey(tournamentMatchId)),
     ]);
   }
 
@@ -138,4 +173,8 @@ export class DirectedMatchService {
       rating,
     };
   }
+}
+
+function tournamentMatchKey(tournamentMatchId: string): string {
+  return `tournament-match:${tournamentMatchId}:match`;
 }

--- a/apps/game-service/src/grpc/grpc-server.module.ts
+++ b/apps/game-service/src/grpc/grpc-server.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { DirectedMatchModule } from "../directed-match/directed-match.module.js";
+import { TournamentsGrpcController } from "./tournaments-grpc.controller.js";
+
+@Module({
+  imports: [DirectedMatchModule],
+  controllers: [TournamentsGrpcController],
+})
+export class GrpcServerModule {}

--- a/apps/game-service/src/grpc/tournaments-grpc.controller.spec.ts
+++ b/apps/game-service/src/grpc/tournaments-grpc.controller.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type {
+  DirectedMatchService,
+  StartDirectedMatchResult,
+} from "../directed-match/directed-match.service.js";
+import { TournamentsGrpcController } from "./tournaments-grpc.controller.js";
+
+describe("TournamentsGrpcController", () => {
+  let directedMatchService: {
+    startMatch: jest.Mock<(input: unknown) => Promise<StartDirectedMatchResult>>;
+  };
+  let controller: TournamentsGrpcController;
+
+  beforeEach(() => {
+    directedMatchService = {
+      startMatch: jest.fn<(input: unknown) => Promise<StartDirectedMatchResult>>(),
+    };
+    controller = new TournamentsGrpcController(
+      directedMatchService as unknown as DirectedMatchService,
+    );
+  });
+
+  it("maps a successful StartMatch request to the gRPC response", async () => {
+    directedMatchService.startMatch.mockResolvedValue({
+      ok: true,
+      matchId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+
+    const response = await controller.startMatch({
+      tournament_match_id: "33333333-3333-4333-8333-333333333333",
+      slot_a: { user_id: "11111111-1111-4111-8111-111111111111", display_name: "Ace" },
+      slot_b: { user_id: "22222222-2222-4222-8222-222222222222", display_name: "Bob" },
+    });
+
+    expect(response).toEqual({
+      success: true,
+      matchId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      match_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      errorCode: "",
+      error_code: "",
+    });
+  });
+
+  it("maps service errors to the gRPC response", async () => {
+    directedMatchService.startMatch.mockResolvedValue({
+      ok: false,
+      code: "PLAYER_ALREADY_IN_MATCH",
+    });
+
+    const response = await controller.startMatch({
+      tournament_match_id: "33333333-3333-4333-8333-333333333333",
+      slot_a: { user_id: "11111111-1111-4111-8111-111111111111", display_name: "Ace" },
+      slot_b: { user_id: "22222222-2222-4222-8222-222222222222", display_name: "Bob" },
+    });
+
+    expect(response).toEqual({
+      success: false,
+      matchId: "",
+      match_id: "",
+      errorCode: "PLAYER_ALREADY_IN_MATCH",
+      error_code: "PLAYER_ALREADY_IN_MATCH",
+    });
+  });
+});

--- a/apps/game-service/src/grpc/tournaments-grpc.controller.ts
+++ b/apps/game-service/src/grpc/tournaments-grpc.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Inject } from "@nestjs/common";
+import { GrpcMethod } from "@nestjs/microservices";
+import { DirectedMatchService } from "../directed-match/directed-match.service.js";
+
+type StartMatchRequest = {
+  tournamentMatchId?: string;
+  tournament_match_id?: string;
+  slotA?: { userId?: string; displayName?: string; user_id?: string; display_name?: string };
+  slot_a?: { userId?: string; displayName?: string; user_id?: string; display_name?: string };
+  slotB?: { userId?: string; displayName?: string; user_id?: string; display_name?: string };
+  slot_b?: { userId?: string; displayName?: string; user_id?: string; display_name?: string };
+};
+
+@Controller()
+export class TournamentsGrpcController {
+  constructor(
+    @Inject(DirectedMatchService) private readonly directedMatchService: DirectedMatchService,
+  ) {}
+
+  @GrpcMethod("Tournaments", "StartMatch")
+  async startMatch(data: StartMatchRequest) {
+    const slotA = data.slotA ?? data.slot_a;
+    const slotB = data.slotB ?? data.slot_b;
+    const tournamentMatchId = data.tournamentMatchId ?? data.tournament_match_id ?? "";
+
+    const result = await this.directedMatchService.startMatch({
+      tournamentMatchId,
+      slotA: {
+        userId: slotA?.userId ?? slotA?.user_id ?? "",
+        displayName: slotA?.displayName ?? slotA?.display_name ?? "",
+      },
+      slotB: {
+        userId: slotB?.userId ?? slotB?.user_id ?? "",
+        displayName: slotB?.displayName ?? slotB?.display_name ?? "",
+      },
+    });
+
+    if (!result.ok) {
+      return {
+        success: false,
+        matchId: "",
+        match_id: "",
+        errorCode: result.code,
+        error_code: result.code,
+      };
+    }
+
+    return {
+      success: true,
+      matchId: result.matchId,
+      match_id: result.matchId,
+      errorCode: "",
+      error_code: "",
+    };
+  }
+}

--- a/apps/game-service/src/main.ts
+++ b/apps/game-service/src/main.ts
@@ -1,8 +1,10 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { TOURNAMENTS_PROTO_PACKAGE, TOURNAMENTS_PROTO_PATH } from "@chifoumi/proto";
 import { config as dotenvConfig } from "dotenv";
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
+import { type MicroserviceOptions, Transport } from "@nestjs/microservices";
 import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module.js";
 import { resolveCorsOrigins } from "./cors.js";
@@ -11,6 +13,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 dotenvConfig({ path: resolve(repoRoot, ".env") });
 
 const DEFAULT_PORT = 3001;
+const DEFAULT_GRPC_PORT = 50052;
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -19,6 +22,17 @@ async function bootstrap() {
   app.enableCors({
     origin: resolveCorsOrigins(),
   });
+
+  const grpcPort = Number(process.env.GAME_SERVICE_GRPC_PORT ?? DEFAULT_GRPC_PORT);
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.GRPC,
+    options: {
+      package: TOURNAMENTS_PROTO_PACKAGE,
+      protoPath: TOURNAMENTS_PROTO_PATH,
+      url: `0.0.0.0:${grpcPort}`,
+    },
+  });
+  await app.startAllMicroservices();
 
   const port = Number(process.env.GAME_SERVICE_PORT ?? DEFAULT_PORT);
   await app.listen(port);

--- a/apps/game-service/src/match-session/match-session.service.ts
+++ b/apps/game-service/src/match-session/match-session.service.ts
@@ -47,6 +47,7 @@ export class MatchSessionService {
     playerB: MatchPlayer,
     matchId = uuidv4(),
     now = new Date(),
+    tournamentMatchId?: string,
   ): MatchState {
     return {
       matchId,
@@ -58,6 +59,7 @@ export class MatchSessionService {
       startedAt: now.toISOString(),
       roundDeadline: new Date(now.getTime() + ROUND_DEADLINE_MS).toISOString(),
       roundPlays: emptyRoundPlays(),
+      ...(tournamentMatchId ? { tournamentMatchId } : {}),
     };
   }
 
@@ -65,9 +67,16 @@ export class MatchSessionService {
     players: [MatchPlayer, MatchPlayer];
     matchId?: string;
     now?: Date;
+    tournamentMatchId?: string;
   }): Promise<MatchState> {
     const now = input.now ?? new Date();
-    const state = this.buildInitialState(input.players[0], input.players[1], input.matchId, now);
+    const state = this.buildInitialState(
+      input.players[0],
+      input.players[1],
+      input.matchId,
+      now,
+      input.tournamentMatchId,
+    );
 
     await this.saveState(state);
     await Promise.all(

--- a/apps/game-service/src/match-session/match-session.types.ts
+++ b/apps/game-service/src/match-session/match-session.types.ts
@@ -66,6 +66,7 @@ export type MatchState = {
   rounds?: ResolvedRound[];
   winnerId?: string;
   endReason?: MatchEndReason;
+  tournamentMatchId?: string;
 };
 
 export type MatchFoundPayload = {

--- a/apps/game-service/src/match/match-ended-publisher.service.ts
+++ b/apps/game-service/src/match/match-ended-publisher.service.ts
@@ -48,6 +48,7 @@ export class MatchEndedPublisher implements OnModuleInit, OnModuleDestroy {
       rounds: state.rounds ?? [],
       endReason: state.endReason,
       startedAt: state.startedAt,
+      ...(state.tournamentMatchId ? { tournamentMatchId: state.tournamentMatchId } : {}),
     };
 
     await this.queue.add("match-ended", payload, {

--- a/apps/game-service/src/matchmaking/matchmaking.module.ts
+++ b/apps/game-service/src/matchmaking/matchmaking.module.ts
@@ -17,6 +17,6 @@ import { RatingService } from "./rating.service.js";
     MatchmakingEventsService,
     MatchmakingGateway,
   ],
-  exports: [MatchmakingService, MatchmakingEventsService],
+  exports: [MatchmakingService, MatchmakingEventsService, RatingService],
 })
 export class MatchmakingModule {}

--- a/apps/game-service/test/directed-match.e2e-spec.ts
+++ b/apps/game-service/test/directed-match.e2e-spec.ts
@@ -5,6 +5,10 @@ import { Queue } from "bullmq";
 import { config } from "dotenv";
 import { io, type Socket } from "socket.io-client";
 import { DirectedMatchService } from "../src/directed-match/directed-match.service.js";
+import {
+  MATCHMAKING_QUEUE_KEY,
+  matchmakingMetaKey,
+} from "../src/matchmaking/matchmaking.constants.js";
 import { RedisService } from "../src/redis/redis.service.js";
 import { createGameServiceTestModule } from "../src/testing/create-game-service-test-module.js";
 import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
@@ -235,5 +239,51 @@ describe("Directed tournament match (e2e)", () => {
     });
 
     expect(second).toEqual({ ok: false, code: "PLAYER_ALREADY_IN_MATCH" });
+  });
+
+  it("pulls queued players into a directed match", async () => {
+    await redisService.setex(`user:rating:${slotAId}`, 60, "1000");
+    await redisService.setex(`user:rating:${slotBId}`, 60, "1040");
+    await redisService.zadd(MATCHMAKING_QUEUE_KEY, 1000, slotAId);
+    await redisService.hset(matchmakingMetaKey(slotAId), {
+      userId: slotAId,
+      rating: "1000",
+      displayName: "Ace",
+      queuedAt: String(Date.now()),
+    });
+
+    const result = await directedMatchService.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(result).toEqual({ ok: true, matchId: expect.any(String) });
+    const client = redisService.getClient();
+    expect(await client.zscore(MATCHMAKING_QUEUE_KEY, slotAId)).toBeNull();
+    expect(await client.exists(matchmakingMetaKey(slotAId))).toBe(0);
+  });
+
+  it("returns the same matchId for duplicate tournamentMatchId retries", async () => {
+    await redisService.setex(`user:rating:${slotAId}`, 60, "1000");
+    await redisService.setex(`user:rating:${slotBId}`, 60, "1040");
+
+    const first = await directedMatchService.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      throw new Error("expected directed match to start");
+    }
+
+    const retry = await directedMatchService.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(retry).toEqual({ ok: true, matchId: first.matchId });
   });
 });

--- a/apps/game-service/test/directed-match.e2e-spec.ts
+++ b/apps/game-service/test/directed-match.e2e-spec.ts
@@ -1,0 +1,239 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { INestApplication } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { config } from "dotenv";
+import { io, type Socket } from "socket.io-client";
+import { DirectedMatchService } from "../src/directed-match/directed-match.service.js";
+import { RedisService } from "../src/redis/redis.service.js";
+import { createGameServiceTestModule } from "../src/testing/create-game-service-test-module.js";
+import { issueTestAccessToken } from "../src/testing/issue-test-access-token.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.MATCHMAKING_WORKER_ENABLED = "false";
+process.env.MATCH_TIMEOUT_WORKER_ENABLED = "false";
+process.env.BULLMQ_PREFIX ??= "rps-test-directed";
+config({ path: resolve(repoRoot, ".env") });
+
+const slotAId = "11111111-1111-4111-8111-111111111111";
+const slotBId = "22222222-2222-4222-8222-222222222222";
+const tournamentMatchId = "33333333-3333-4333-8333-333333333333";
+
+type ConnectedPayload = { userId: string; displayName: string };
+type MatchFoundPayload = {
+  matchId: string;
+  opponent: { userId: string; displayName: string; rating: number };
+  bestOf: number;
+};
+type RoundStartPayload = { matchId: string; roundNumber: number; deadline: string };
+type RoundResolvedPayload = {
+  matchId: string;
+  roundNumber: number;
+  yourMove: string;
+  theirMove: string;
+  winner: string;
+  scoreA: number;
+  scoreB: number;
+};
+type MatchEndedPayload = {
+  matchId: string;
+  winner: string | null;
+  finalScore: { a: number; b: number };
+};
+
+function connectClient(port: number, token: string): Socket {
+  return io(`http://127.0.0.1:${port}/game`, {
+    transports: ["websocket"],
+    forceNew: true,
+    reconnection: false,
+    query: { token },
+  });
+}
+
+function waitForEvent<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${event} timeout`)), 10_000);
+    socket.once(event, (payload: T) => {
+      clearTimeout(timeout);
+      resolvePromise(payload);
+    });
+  });
+}
+
+async function waitForQueueJob(
+  queue: Queue,
+  name: string,
+  timeoutMs = 5_000,
+): Promise<Record<string, unknown> | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const jobs = await queue.getJobs(["wait", "active", "delayed", "prioritized", "paused"]);
+    const job = jobs.find((entry) => entry.name === name);
+    if (job) {
+      return job.data as Record<string, unknown>;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+  }
+  return null;
+}
+
+async function connectAuthenticated(
+  port: number,
+  input: { userId: string; displayName: string },
+): Promise<Socket> {
+  const token = await issueTestAccessToken({
+    userId: input.userId,
+    displayName: input.displayName,
+  });
+  const socket = connectClient(port, token);
+  const connectedPromise = waitForEvent<ConnectedPayload>(socket, "connected");
+
+  await new Promise<void>((resolvePromise, reject) => {
+    socket.once("connect", () => resolvePromise());
+    socket.once("connect_error", reject);
+  });
+
+  await connectedPromise;
+  return socket;
+}
+
+describe("Directed tournament match (e2e)", () => {
+  let app: INestApplication;
+  let port: number;
+  let redisService: RedisService;
+  let directedMatchService: DirectedMatchService;
+
+  beforeAll(async () => {
+    const moduleRef = await createGameServiceTestModule().compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0, "127.0.0.1");
+    port = app.getHttpServer().address().port as number;
+    redisService = app.get(RedisService);
+    directedMatchService = app.get(DirectedMatchService);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  beforeEach(async () => {
+    const client = redisService.getClient();
+    const keys = await client.keys("*");
+    if (keys.length > 0) {
+      await client.del(...keys);
+    }
+  });
+
+  it("creates a directed match, plays BO3, and publishes tournamentMatchId in match-ended", async () => {
+    await redisService.setex(`user:rating:${slotAId}`, 60, "1000");
+    await redisService.setex(`user:rating:${slotBId}`, 60, "1040");
+
+    const playerA = await connectAuthenticated(port, { userId: slotAId, displayName: "Ace" });
+    const playerB = await connectAuthenticated(port, { userId: slotBId, displayName: "Bob" });
+
+    const matchFoundA = waitForEvent<MatchFoundPayload>(playerA, "matchFound");
+    const matchFoundB = waitForEvent<MatchFoundPayload>(playerB, "matchFound");
+    const roundStartA = waitForEvent<RoundStartPayload>(playerA, "roundStart");
+    const roundStartB = waitForEvent<RoundStartPayload>(playerB, "roundStart");
+
+    const started = await directedMatchService.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+
+    expect(started).toEqual({ ok: true, matchId: expect.any(String) });
+    if (!started.ok) {
+      throw new Error("expected directed match to start");
+    }
+
+    const payloadA = await matchFoundA;
+    const payloadB = await matchFoundB;
+    expect(payloadA.matchId).toBe(started.matchId);
+    expect(payloadB.matchId).toBe(started.matchId);
+
+    const roundStart = await roundStartA;
+    await roundStartB;
+
+    const round1ResolvedA = waitForEvent<RoundResolvedPayload>(playerA, "roundResolved");
+    const round1ResolvedB = waitForEvent<RoundResolvedPayload>(playerB, "roundResolved");
+
+    playerA.emit("play", {
+      matchId: started.matchId,
+      roundNumber: roundStart.roundNumber,
+      move: "rock",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    playerB.emit("play", {
+      matchId: started.matchId,
+      roundNumber: roundStart.roundNumber,
+      move: "scissors",
+    });
+    await round1ResolvedA;
+    await round1ResolvedB;
+
+    const round2Start = await waitForEvent<RoundStartPayload>(playerA, "roundStart");
+    await waitForEvent<RoundStartPayload>(playerB, "roundStart");
+
+    const matchEndedA = waitForEvent<MatchEndedPayload>(playerA, "matchEnded");
+    const matchEndedB = waitForEvent<MatchEndedPayload>(playerB, "matchEnded");
+
+    playerA.emit("play", {
+      matchId: started.matchId,
+      roundNumber: round2Start.roundNumber,
+      move: "paper",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    playerB.emit("play", {
+      matchId: started.matchId,
+      roundNumber: round2Start.roundNumber,
+      move: "rock",
+    });
+    await matchEndedA;
+    await matchEndedB;
+
+    const queue = new Queue("match-events", {
+      connection: { url: process.env.REDIS_URL ?? "redis://localhost:6379" },
+      prefix: process.env.BULLMQ_PREFIX ?? "rps-test-directed",
+    });
+    try {
+      const jobData = await waitForQueueJob(queue, "match-ended");
+      expect(jobData).toEqual(
+        expect.objectContaining({
+          matchId: started.matchId,
+          tournamentMatchId,
+        }),
+      );
+    } finally {
+      await queue.close();
+    }
+
+    playerA.disconnect();
+    playerB.disconnect();
+  });
+
+  it("rejects a second directed match when a player is already busy", async () => {
+    await redisService.setex(`user:rating:${slotAId}`, 60, "1000");
+    await redisService.setex(`user:rating:${slotBId}`, 60, "1040");
+
+    const first = await directedMatchService.startMatch({
+      tournamentMatchId,
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: slotBId, displayName: "Bob" },
+    });
+    expect(first.ok).toBe(true);
+
+    const second = await directedMatchService.startMatch({
+      tournamentMatchId: "44444444-4444-4444-8444-444444444444",
+      slotA: { userId: slotAId, displayName: "Ace" },
+      slotB: { userId: "55555555-5555-4555-8555-555555555555", displayName: "Cara" },
+    });
+
+    expect(second).toEqual({ ok: false, code: "PLAYER_ALREADY_IN_MATCH" });
+  });
+});

--- a/apps/job-runner/src/match-events/match-ended.processor.ts
+++ b/apps/job-runner/src/match-events/match-ended.processor.ts
@@ -40,7 +40,6 @@ const matchEndedPayloadSchema = z
       b: z.number().int().nonnegative(),
     }),
     startedAt: z.string().datetime(),
-    tournamentMatchId: z.string().uuid().optional(),
   })
   .refine(
     (payload) =>

--- a/apps/job-runner/src/match-events/match-ended.processor.ts
+++ b/apps/job-runner/src/match-events/match-ended.processor.ts
@@ -38,6 +38,7 @@ const matchEndedPayloadSchema = z
       b: z.number().int().nonnegative(),
     }),
     startedAt: z.string().datetime(),
+    tournamentMatchId: z.string().uuid().optional(),
   })
   .refine(
     (payload) =>

--- a/apps/job-runner/src/match-events/match-ended.types.ts
+++ b/apps/job-runner/src/match-events/match-ended.types.ts
@@ -21,4 +21,5 @@ export type MatchEndedPayload = {
   winner: string | null;
   finalScore: { a: number; b: number };
   startedAt: string;
+  tournamentMatchId?: string;
 };

--- a/apps/job-runner/src/persistence/match-persistence.service.spec.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.spec.ts
@@ -52,6 +52,9 @@ type MockTx = {
   eloHistory: {
     createMany: jest.Mock;
   };
+  tournamentMatch: {
+    update: jest.Mock;
+  };
 };
 
 function createTx(overrides: Partial<MockTx> = {}): MockTx {
@@ -69,6 +72,9 @@ function createTx(overrides: Partial<MockTx> = {}): MockTx {
     },
     eloHistory: {
       createMany: jest.fn(async () => ({})),
+    },
+    tournamentMatch: {
+      update: jest.fn(async () => ({})),
     },
     ...overrides,
   };
@@ -147,5 +153,18 @@ describe("MatchPersistenceService", () => {
     const persisted = await service.persistMatchEnded(createPayload());
 
     expect(persisted).toBe("already_exists");
+  });
+
+  it("links tournament_matches.match_id when tournamentMatchId is present", async () => {
+    const tournamentMatchId = "44444444-4444-4444-8444-444444444444";
+    const payload = { ...createPayload(), tournamentMatchId };
+
+    const persisted = await service.persistMatchEnded(payload);
+
+    expect(persisted).toBe("created");
+    expect(tx.tournamentMatch.update).toHaveBeenCalledWith({
+      where: { id: tournamentMatchId },
+      data: { matchId },
+    });
   });
 });

--- a/apps/job-runner/src/persistence/match-persistence.service.spec.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.spec.ts
@@ -53,7 +53,8 @@ type MockTx = {
     createMany: jest.Mock;
   };
   tournamentMatch: {
-    update: jest.Mock;
+    findUnique: jest.Mock;
+    updateMany: jest.Mock;
   };
 };
 
@@ -74,7 +75,8 @@ function createTx(overrides: Partial<MockTx> = {}): MockTx {
       createMany: jest.fn(async () => ({})),
     },
     tournamentMatch: {
-      update: jest.fn(async () => ({})),
+      findUnique: jest.fn(async () => ({ matchId: null })),
+      updateMany: jest.fn(async () => ({ count: 1 })),
     },
     ...overrides,
   };
@@ -162,9 +164,25 @@ describe("MatchPersistenceService", () => {
     const persisted = await service.persistMatchEnded(payload);
 
     expect(persisted).toBe("created");
-    expect(tx.tournamentMatch.update).toHaveBeenCalledWith({
-      where: { id: tournamentMatchId },
+    expect(tx.tournamentMatch.updateMany).toHaveBeenCalledWith({
+      where: { id: tournamentMatchId, matchId: null },
       data: { matchId },
     });
+  });
+
+  it("skips all match and ELO writes when tournament match is already linked", async () => {
+    const tournamentMatchId = "44444444-4444-4444-8444-444444444444";
+    tx.tournamentMatch.findUnique.mockImplementation(async () => ({
+      matchId: "55555555-5555-4555-8555-555555555555",
+    }));
+
+    const persisted = await service.persistMatchEnded({ ...createPayload(), tournamentMatchId });
+
+    expect(persisted).toBe("already_exists");
+    expect(tx.match.create).not.toHaveBeenCalled();
+    expect(tx.round.upsert).not.toHaveBeenCalled();
+    expect(tx.eloRating.update).not.toHaveBeenCalled();
+    expect(tx.eloHistory.createMany).not.toHaveBeenCalled();
+    expect(tx.tournamentMatch.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/job-runner/src/persistence/match-persistence.service.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.ts
@@ -24,6 +24,16 @@ export class MatchPersistenceService {
           return "already_exists";
         }
 
+        if (payload.tournamentMatchId) {
+          const tournamentMatch = await tx.tournamentMatch.findUnique({
+            where: { id: payload.tournamentMatchId },
+            select: { matchId: true },
+          });
+          if (tournamentMatch?.matchId) {
+            return "already_exists";
+          }
+        }
+
         const [playerA, playerB] = payload.players;
         const [ratingA, ratingB] = await Promise.all([
           this.findOrCreateRating(tx, playerA.userId),
@@ -52,10 +62,13 @@ export class MatchPersistenceService {
         });
 
         if (payload.tournamentMatchId) {
-          await tx.tournamentMatch.update({
-            where: { id: payload.tournamentMatchId },
+          const linked = await tx.tournamentMatch.updateMany({
+            where: { id: payload.tournamentMatchId, matchId: null },
             data: { matchId: payload.matchId },
           });
+          if (linked.count === 0) {
+            throw new TournamentMatchLinkConflictError(payload.tournamentMatchId);
+          }
         }
 
         for (const round of payload.rounds) {
@@ -159,5 +172,12 @@ export class MatchPersistenceService {
 
   private isUniqueMatchConflict(error: unknown): boolean {
     return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+  }
+}
+
+class TournamentMatchLinkConflictError extends Error {
+  constructor(tournamentMatchId: string) {
+    super(`Tournament match is already linked or missing: ${tournamentMatchId}`);
+    this.name = "TournamentMatchLinkConflictError";
   }
 }

--- a/apps/job-runner/src/persistence/match-persistence.service.ts
+++ b/apps/job-runner/src/persistence/match-persistence.service.ts
@@ -51,6 +51,13 @@ export class MatchPersistenceService {
           },
         });
 
+        if (payload.tournamentMatchId) {
+          await tx.tournamentMatch.update({
+            where: { id: payload.tournamentMatchId },
+            data: { matchId: payload.matchId },
+          });
+        }
+
         for (const round of payload.rounds) {
           await tx.round.upsert({
             where: {

--- a/packages/proto/proto/tournaments.proto
+++ b/packages/proto/proto/tournaments.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package chifoumi.tournaments.v1;
+
+service Tournaments {
+  rpc StartMatch(StartMatchRequest) returns (StartMatchResponse);
+}
+
+message TournamentPlayer {
+  string user_id = 1;
+  string display_name = 2;
+}
+
+message StartMatchRequest {
+  string tournament_match_id = 1;
+  TournamentPlayer slot_a = 2;
+  TournamentPlayer slot_b = 3;
+}
+
+message StartMatchResponse {
+  bool success = 1;
+  string match_id = 2;
+  string error_code = 3;
+}

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -6,6 +6,9 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 export const AUTH_PROTO_PATH = join(packageRoot, "proto", "auth.proto");
 export const AUTH_PROTO_PACKAGE = "chifoumi.auth.v1";
 
+export const TOURNAMENTS_PROTO_PATH = join(packageRoot, "proto", "tournaments.proto");
+export const TOURNAMENTS_PROTO_PACKAGE = "chifoumi.tournaments.v1";
+
 export type VerifyTokenReason = "INVALID" | "EXPIRED" | "REVOKED" | "UNAVAILABLE";
 
 export type VerifyTokenResponse = {


### PR DESCRIPTION
## Summary

- Adds \Tournaments.StartMatch\ gRPC entry point on Game Service to launch BO3 matches between two designated players without using the ELO matchmaking queue.
- Reuses the existing \match-session\ state machine and \match:byUser\ guard to prevent concurrent pairing.
- Propagates \	ournamentMatchId\ through match state and the \match-ended\ BullMQ payload; job-runner links \	ournament_matches.match_id\ on persistence.

Closes #125

## Acceptance criteria

- [x] AC1: Directed match creation (slotA, slotB, tournamentMatchId) bypasses \matchmaking:queue\`n- [x] AC2: Both players receive \matchFound\ and play standard BO3 commit-reveal
- [x] AC3: \	ournament_matches.match_id\ written on match-ended persistence
- [x] AC4: \match-ended\ payload includes \	ournamentMatchId\`n- [x] AC5: \match:byUser\ guard blocks players already in a match
- [x] AC6: Unit + e2e tests for directed match creation and BO3 flow

## Test plan

- [x] \pnpm --filter @chifoumi/game-service test\ (directed-match + grpc controller specs)
- [x] \pnpm --filter @chifoumi/job-runner test\ (match-persistence tournament link)
- [x] \pnpm biome check\ + \pnpm -r typecheck\ via lefthook pre-commit
- [ ] \directed-match.e2e-spec.ts\ with Redis running (CI)

Made with [Cursor](https://cursor.com)