### PR TITLE
feat(job-runner): implement generate-bracket processor (#126)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -11,6 +11,7 @@ COPY apps/front/package.json apps/front/package.json
 COPY apps/game-service/package.json apps/game-service/package.json
 COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
+COPY packages/bracket/package.json packages/bracket/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
 COPY packages/leagues/package.json packages/leagues/package.json

--- a/apps/game-service/Dockerfile
+++ b/apps/game-service/Dockerfile
@@ -11,6 +11,7 @@ COPY apps/front/package.json apps/front/package.json
 COPY apps/game-service/package.json apps/game-service/package.json
 COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
+COPY packages/bracket/package.json packages/bracket/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
 COPY packages/leagues/package.json packages/leagues/package.json

--- a/apps/job-runner/Dockerfile
+++ b/apps/job-runner/Dockerfile
@@ -11,6 +11,7 @@ COPY apps/front/package.json apps/front/package.json
 COPY apps/game-service/package.json apps/game-service/package.json
 COPY apps/job-runner/package.json apps/job-runner/package.json
 COPY packages/biome/package.json packages/biome/package.json
+COPY packages/bracket/package.json packages/bracket/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/elo/package.json packages/elo/package.json
 COPY packages/leagues/package.json packages/leagues/package.json

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/main.ts",
     "build": "tsc -p tsconfig.json && node scripts/copy-notification-templates.mjs",
     "start": "node dist/main.js",
+    "pretypecheck": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/bracket build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "pretest": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/bracket build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json && node scripts/copy-notification-templates.mjs",
     "start": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "pretest": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
+    "pretest": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/bracket build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "preintegration": "pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/db build",
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./jest-e2e.config.cjs --runInBand"
@@ -25,6 +25,7 @@
     "typescript": "~5.7.3"
   },
   "dependencies": {
+    "@chifoumi/bracket": "workspace:*",
     "@chifoumi/db": "workspace:*",
     "@chifoumi/elo": "workspace:*",
     "@chifoumi/leagues": "workspace:*",

--- a/apps/job-runner/package.json
+++ b/apps/job-runner/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/main.ts",
+    "prebuild": "pnpm run prepare:workspace",
     "build": "tsc -p tsconfig.json && node scripts/copy-notification-templates.mjs",
     "start": "node dist/main.js",
-    "pretypecheck": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/bracket build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
+    "prepare:workspace": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/bracket build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
+    "pretypecheck": "pnpm run prepare:workspace",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "pretest": "pnpm --filter @chifoumi/db build && pnpm --filter @chifoumi/bracket build && pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/leagues build",
+    "pretest": "pnpm run prepare:workspace",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "preintegration": "pnpm --filter @chifoumi/elo build && pnpm --filter @chifoumi/db build",
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./jest-e2e.config.cjs --runInBand"

--- a/apps/job-runner/src/app.module.ts
+++ b/apps/job-runner/src/app.module.ts
@@ -13,6 +13,8 @@ import { RedisInvalidationService } from "./redis/redis-invalidation.service.js"
 import { RunnerService } from "./runner.service.js";
 import { SeasonResetService } from "./seasons/season-reset.service.js";
 import { SeasonResetLockService } from "./seasons/season-reset-lock.service.js";
+import { GenerateBracketService } from "./tournaments/generate-bracket.service.js";
+import { GenerateBracketLockService } from "./tournaments/generate-bracket-lock.service.js";
 import { WorkerFactory } from "./workers/worker-factory.js";
 
 @Module({
@@ -35,6 +37,8 @@ import { WorkerFactory } from "./workers/worker-factory.js";
     NotificationsQueueService,
     SeasonResetLockService,
     SeasonResetService,
+    GenerateBracketLockService,
+    GenerateBracketService,
     WorkerFactory,
     CronSchedulerService,
     RunnerService,

--- a/apps/job-runner/src/notifications/template.service.ts
+++ b/apps/job-runner/src/notifications/template.service.ts
@@ -13,6 +13,7 @@ const TEMPLATE_SUBJECTS: Record<string, string> = {
   welcome: "Bienvenue sur Chifoumi",
   "reset-password": "Réinitialisation de votre mot de passe Chifoumi",
   "season-reward": "Fin de saison Chifoumi — tes résultats",
+  "tournament-started": "Ton tournoi Chifoumi a commencé",
 };
 
 @Injectable()

--- a/apps/job-runner/src/notifications/templates/tournament-started.html
+++ b/apps/job-runner/src/notifications/templates/tournament-started.html
@@ -1,0 +1,3 @@
+<p>Bonjour __DISPLAY_NAME__,</p>
+<p>Le tournoi « __TOURNAMENT_NAME__ » vient de démarrer. Consulte le bracket pour connaître ton prochain match.</p>
+<p>Bonne chance !</p>

--- a/apps/job-runner/src/notifications/templates/tournament-started.txt
+++ b/apps/job-runner/src/notifications/templates/tournament-started.txt
@@ -1,0 +1,5 @@
+Bonjour __DISPLAY_NAME__,
+
+Le tournoi « __TOURNAMENT_NAME__ » vient de démarrer. Consulte le bracket pour connaître ton prochain match.
+
+Bonne chance !

--- a/apps/job-runner/src/queues/notifications-queue.service.spec.ts
+++ b/apps/job-runner/src/queues/notifications-queue.service.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "@jest/globals";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import { NotificationsQueueService } from "./notifications-queue.service.js";
 
 describe("NotificationsQueueService", () => {
@@ -25,5 +25,40 @@ describe("NotificationsQueueService", () => {
         delta: "+50",
       }),
     ).rejects.toThrow("Notifications queue is not connected");
+  });
+
+  it("uses a deterministic job id for tournament started mails", async () => {
+    const queue = {
+      add: jest.fn(async () => ({})),
+    };
+    const service = new NotificationsQueueService({
+      REDIS_URL: "redis://localhost:6379",
+      BULLMQ_PREFIX: "rps",
+    } as never);
+    (service as never as { queue: typeof queue }).queue = queue;
+
+    await service.enqueueTournamentStartedMail({
+      tournamentId: "44444444-4444-4444-8444-444444444444",
+      userId: "11111111-1111-4111-8111-111111111111",
+      to: "alice@test.com",
+      displayName: "alice",
+      tournamentName: "Spring Cup",
+    });
+
+    expect(queue.add).toHaveBeenCalledWith(
+      "send-mail",
+      {
+        to: "alice@test.com",
+        template: "tournament-started",
+        data: {
+          displayName: "alice",
+          tournamentName: "Spring Cup",
+        },
+      },
+      expect.objectContaining({
+        jobId:
+          "tournament-started:44444444-4444-4444-8444-444444444444:11111111-1111-4111-8111-111111111111",
+      }),
+    );
   });
 });

--- a/apps/job-runner/src/queues/notifications-queue.service.ts
+++ b/apps/job-runner/src/queues/notifications-queue.service.ts
@@ -61,6 +61,23 @@ export class NotificationsQueueService implements OnModuleInit, OnModuleDestroy 
     await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, SEND_MAIL_JOB_OPTIONS);
   }
 
+  async enqueueTournamentStartedMail(input: {
+    to: string;
+    displayName: string;
+    tournamentName: string;
+  }): Promise<void> {
+    const payload: SendMailJobPayload = {
+      to: input.to,
+      template: "tournament-started",
+      data: {
+        displayName: input.displayName,
+        tournamentName: input.tournamentName,
+      },
+    };
+
+    await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, SEND_MAIL_JOB_OPTIONS);
+  }
+
   private requireQueue(): Queue {
     if (!this.queue) {
       throw new Error("Notifications queue is not connected");

--- a/apps/job-runner/src/queues/notifications-queue.service.ts
+++ b/apps/job-runner/src/queues/notifications-queue.service.ts
@@ -62,6 +62,8 @@ export class NotificationsQueueService implements OnModuleInit, OnModuleDestroy 
   }
 
   async enqueueTournamentStartedMail(input: {
+    tournamentId: string;
+    userId: string;
     to: string;
     displayName: string;
     tournamentName: string;
@@ -75,7 +77,10 @@ export class NotificationsQueueService implements OnModuleInit, OnModuleDestroy 
       },
     };
 
-    await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, SEND_MAIL_JOB_OPTIONS);
+    await this.requireQueue().add(SEND_MAIL_JOB_NAME, payload, {
+      ...SEND_MAIL_JOB_OPTIONS,
+      jobId: `tournament-started:${input.tournamentId}:${input.userId}`,
+    });
   }
 
   private requireQueue(): Queue {

--- a/apps/job-runner/src/tournaments/build-bracket-structure.spec.ts
+++ b/apps/job-runner/src/tournaments/build-bracket-structure.spec.ts
@@ -81,4 +81,34 @@ describe("buildBracketStructure", () => {
     expect(built.roundOnePlayable).toHaveLength(1);
     expect(built.matches).toHaveLength(7);
   });
+
+  it("does not leave a playable match pointing to an empty final branch", () => {
+    const seeded = makeSeeded([1800, 1700]);
+    const firstRound = generateFirstRound(seeded, 8);
+    const built = buildBracketStructure(seeded, 8, firstRound);
+
+    const playableMatches = built.matches.filter(
+      (match) => match.slotAId !== null && match.slotBId !== null && match.winnerSlot === null,
+    );
+
+    expect(playableMatches).toHaveLength(1);
+    expect(playableMatches[0]).toMatchObject({
+      slotAId: "player-1",
+      slotBId: "player-2",
+      nextMatchId: null,
+    });
+  });
+
+  it("propagates a multi-round bye into the final", () => {
+    const seeded = makeSeeded([1800, 1700, 1600]);
+    const firstRound = generateFirstRound(seeded, 8);
+    const built = buildBracketStructure(seeded, 8, firstRound);
+
+    const finalMatch = built.matches.find((match) => match.round === 3);
+
+    expect(finalMatch).toMatchObject({
+      slotAId: null,
+      slotBId: "player-3",
+    });
+  });
 });

--- a/apps/job-runner/src/tournaments/build-bracket-structure.spec.ts
+++ b/apps/job-runner/src/tournaments/build-bracket-structure.spec.ts
@@ -1,0 +1,84 @@
+import { generateFirstRound, type PlayerId, seedPlayers } from "@chifoumi/bracket";
+import { WinnerSlot } from "@chifoumi/db";
+import { describe, expect, it } from "@jest/globals";
+import { buildBracketStructure } from "./build-bracket-structure.js";
+
+function makeSeeded(ratings: number[]) {
+  const players = ratings.map((rating, index) => ({
+    id: `player-${index + 1}` as PlayerId,
+    rating,
+  }));
+  return seedPlayers(players);
+}
+
+describe("buildBracketStructure", () => {
+  it("creates a fully linked single-elimination tree", () => {
+    const seeded = makeSeeded([1600, 1500, 1400, 1300]);
+    const firstRound = generateFirstRound(seeded, 4);
+    const built = buildBracketStructure(seeded, 4, firstRound);
+
+    expect(built.matches).toHaveLength(3);
+    expect(built.matches.filter((match) => match.round === 1)).toHaveLength(2);
+    expect(built.matches.filter((match) => match.round === 2)).toHaveLength(1);
+
+    const roundOneMatches = built.matches.filter((match) => match.round === 1);
+    const finalMatch = built.matches.find((match) => match.round === 2);
+    expect(roundOneMatches.every((match) => match.nextMatchId === finalMatch?.id)).toBe(true);
+    expect(finalMatch?.nextMatchId).toBeNull();
+  });
+
+  it("seeds round 1 with standard pairings for 4 players", () => {
+    const seeded = makeSeeded([1600, 1500, 1400, 1300]);
+    const firstRound = generateFirstRound(seeded, 4);
+    const built = buildBracketStructure(seeded, 4, firstRound);
+    const roundOne = built.matches
+      .filter((match) => match.round === 1)
+      .sort((left, right) => left.positionIndex - right.positionIndex);
+
+    expect(roundOne[0]).toMatchObject({
+      slotAId: "player-1",
+      slotBId: "player-4",
+      winnerSlot: null,
+    });
+    expect(roundOne[1]).toMatchObject({
+      slotAId: "player-2",
+      slotBId: "player-3",
+      winnerSlot: null,
+    });
+    expect(built.roundOnePlayable).toHaveLength(2);
+  });
+
+  it("advances bye winners into the next round slots", () => {
+    const seeded = makeSeeded([1700, 1600, 1500]);
+    const firstRound = generateFirstRound(seeded, 4);
+    const built = buildBracketStructure(seeded, 4, firstRound);
+    const roundOne = built.matches
+      .filter((match) => match.round === 1)
+      .sort((left, right) => left.positionIndex - right.positionIndex);
+    const roundTwo = built.matches.find((match) => match.round === 2);
+
+    expect(roundOne[0]).toMatchObject({
+      slotAId: "player-1",
+      slotBId: null,
+      winnerSlot: WinnerSlot.a,
+    });
+    expect(roundTwo).toMatchObject({
+      slotAId: "player-1",
+      slotBId: null,
+    });
+    expect(built.roundOnePlayable).toHaveLength(1);
+  });
+
+  it("handles multiple byes in an oversized bracket", () => {
+    const seeded = makeSeeded([1800, 1700, 1600, 1500, 1400]);
+    const firstRound = generateFirstRound(seeded, 8);
+    const built = buildBracketStructure(seeded, 8, firstRound);
+
+    const byeMatches = built.matches.filter(
+      (match) => match.round === 1 && match.winnerSlot === WinnerSlot.a,
+    );
+    expect(byeMatches).toHaveLength(3);
+    expect(built.roundOnePlayable).toHaveLength(1);
+    expect(built.matches).toHaveLength(7);
+  });
+});

--- a/apps/job-runner/src/tournaments/build-bracket-structure.ts
+++ b/apps/job-runner/src/tournaments/build-bracket-structure.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import type { BracketMatch, SeededPlayer } from "@chifoumi/bracket";
+import { WinnerSlot } from "@chifoumi/db";
+
+const DEFAULT_RATING = 1000;
+
+export type BracketMatchDraft = {
+  id: string;
+  round: number;
+  positionIndex: number;
+  slotAId: string | null;
+  slotBId: string | null;
+  winnerSlot: WinnerSlot | null;
+  nextMatchId: string | null;
+};
+
+export type RoundOnePlayableMatch = {
+  tournamentMatchId: string;
+  slotAId: string;
+  slotBId: string;
+};
+
+export type BuiltBracketStructure = {
+  matches: BracketMatchDraft[];
+  roundOnePlayable: RoundOnePlayableMatch[];
+};
+
+export function buildBracketStructure(
+  seededPlayers: SeededPlayer[],
+  bracketSize: number,
+  firstRoundPairings: BracketMatch[],
+): BuiltBracketStructure {
+  const totalRounds = Math.log2(bracketSize);
+  const rounds: BracketMatchDraft[][] = [];
+
+  for (let round = 1; round <= totalRounds; round++) {
+    const matchCount = bracketSize / 2 ** round;
+    const roundMatches: BracketMatchDraft[] = [];
+
+    for (let positionIndex = 0; positionIndex < matchCount; positionIndex++) {
+      roundMatches.push({
+        id: randomUUID(),
+        round,
+        positionIndex,
+        slotAId: null,
+        slotBId: null,
+        winnerSlot: null,
+        nextMatchId: null,
+      });
+    }
+
+    rounds.push(roundMatches);
+  }
+
+  for (let roundIndex = 0; roundIndex < totalRounds - 1; roundIndex++) {
+    const currentRound = rounds[roundIndex];
+    const nextRound = rounds[roundIndex + 1];
+
+    if (!currentRound || !nextRound) {
+      continue;
+    }
+
+    for (let positionIndex = 0; positionIndex < currentRound.length; positionIndex++) {
+      const match = currentRound[positionIndex];
+      const parent = nextRound[Math.floor(positionIndex / 2)];
+      if (match && parent) {
+        match.nextMatchId = parent.id;
+      }
+    }
+  }
+
+  const slots: Array<SeededPlayer | null> = Array.from(
+    { length: bracketSize },
+    (_, index) => seededPlayers[index] ?? null,
+  );
+  const halfSize = bracketSize / 2;
+  const roundOne = rounds[0];
+  const roundTwo = rounds[1];
+  const roundOnePlayable: RoundOnePlayableMatch[] = [];
+  let pairingIndex = 0;
+
+  for (let positionIndex = 0; positionIndex < halfSize; positionIndex++) {
+    const slotA = slots[positionIndex];
+    if (!slotA) {
+      continue;
+    }
+
+    const pairing = firstRoundPairings[pairingIndex];
+    pairingIndex += 1;
+    if (!pairing) {
+      continue;
+    }
+
+    const match = roundOne?.[positionIndex];
+    if (!match) {
+      continue;
+    }
+
+    match.slotAId = pairing.player1.id;
+    match.slotBId = pairing.player2?.id ?? null;
+
+    if (pairing.player2 === null) {
+      match.winnerSlot = WinnerSlot.a;
+      advanceByeWinner(match, roundTwo);
+      continue;
+    }
+
+    roundOnePlayable.push({
+      tournamentMatchId: match.id,
+      slotAId: pairing.player1.id,
+      slotBId: pairing.player2.id,
+    });
+  }
+
+  return {
+    matches: rounds.flat(),
+    roundOnePlayable,
+  };
+}
+
+function advanceByeWinner(
+  match: BracketMatchDraft,
+  nextRound: BracketMatchDraft[] | undefined,
+): void {
+  if (!nextRound || !match.slotAId) {
+    return;
+  }
+
+  const parent = nextRound[Math.floor(match.positionIndex / 2)];
+  if (!parent) {
+    return;
+  }
+
+  if (match.positionIndex % 2 === 0) {
+    parent.slotAId = match.slotAId;
+    return;
+  }
+
+  parent.slotBId = match.slotAId;
+}
+
+export function defaultRatingForUser(rating: number | undefined): number {
+  return rating !== undefined && Number.isFinite(rating) ? rating : DEFAULT_RATING;
+}

--- a/apps/job-runner/src/tournaments/build-bracket-structure.ts
+++ b/apps/job-runner/src/tournaments/build-bracket-structure.ts
@@ -101,7 +101,7 @@ export function buildBracketStructure(
 
     if (pairing.player2 === null) {
       match.winnerSlot = WinnerSlot.a;
-      advanceByeWinner(match, roundTwo);
+      advanceWinner(match, roundTwo, pairing.player1.id);
       continue;
     }
 
@@ -112,17 +112,21 @@ export function buildBracketStructure(
     });
   }
 
+  advanceUnopposedPlayers(rounds);
+  prunePlayableMatchesWithEmptySibling(rounds);
+
   return {
     matches: rounds.flat(),
     roundOnePlayable,
   };
 }
 
-function advanceByeWinner(
+function advanceWinner(
   match: BracketMatchDraft,
   nextRound: BracketMatchDraft[] | undefined,
+  winnerId: string,
 ): void {
-  if (!nextRound || !match.slotAId) {
+  if (!nextRound) {
     return;
   }
 
@@ -132,11 +136,116 @@ function advanceByeWinner(
   }
 
   if (match.positionIndex % 2 === 0) {
-    parent.slotAId = match.slotAId;
+    parent.slotAId = winnerId;
     return;
   }
 
-  parent.slotBId = match.slotAId;
+  parent.slotBId = winnerId;
+}
+
+function advanceUnopposedPlayers(rounds: BracketMatchDraft[][]): void {
+  let advanced = true;
+
+  while (advanced) {
+    advanced = false;
+
+    for (let roundIndex = 1; roundIndex < rounds.length; roundIndex++) {
+      const currentRound = rounds[roundIndex];
+      const nextRound = rounds[roundIndex + 1];
+      if (!currentRound) {
+        continue;
+      }
+
+      for (const match of currentRound) {
+        if (match.winnerSlot !== null) {
+          continue;
+        }
+
+        const hasSlotA = match.slotAId !== null;
+        const hasSlotB = match.slotBId !== null;
+        if (hasSlotA === hasSlotB) {
+          continue;
+        }
+
+        const missingSlot = hasSlotA ? WinnerSlot.b : WinnerSlot.a;
+        if (hasPendingFeeder(rounds, roundIndex, match.positionIndex, missingSlot)) {
+          continue;
+        }
+
+        match.winnerSlot = hasSlotA ? WinnerSlot.a : WinnerSlot.b;
+        const winnerId = hasSlotA ? match.slotAId : match.slotBId;
+        if (winnerId) {
+          advanceWinner(match, nextRound, winnerId);
+        }
+        advanced = true;
+      }
+    }
+  }
+}
+
+function hasPendingFeeder(
+  rounds: BracketMatchDraft[][],
+  roundIndex: number,
+  positionIndex: number,
+  slot: WinnerSlot,
+): boolean {
+  const previousRound = rounds[roundIndex - 1];
+  if (!previousRound) {
+    return false;
+  }
+
+  const feederPosition = positionIndex * 2 + (slot === WinnerSlot.a ? 0 : 1);
+  const feeder = previousRound[feederPosition];
+  return feeder ? !isBranchEmpty(rounds, roundIndex - 1, feeder.positionIndex) : false;
+}
+
+function prunePlayableMatchesWithEmptySibling(rounds: BracketMatchDraft[][]): void {
+  for (let roundIndex = 0; roundIndex < rounds.length - 1; roundIndex++) {
+    const currentRound = rounds[roundIndex];
+    if (!currentRound) {
+      continue;
+    }
+
+    for (const match of currentRound) {
+      if (match.nextMatchId === null || match.winnerSlot !== null) {
+        continue;
+      }
+
+      if (match.slotAId === null || match.slotBId === null) {
+        continue;
+      }
+
+      const siblingPosition =
+        match.positionIndex % 2 === 0 ? match.positionIndex + 1 : match.positionIndex - 1;
+      if (isBranchEmpty(rounds, roundIndex, siblingPosition)) {
+        match.nextMatchId = null;
+      }
+    }
+  }
+}
+
+function isBranchEmpty(
+  rounds: BracketMatchDraft[][],
+  roundIndex: number,
+  positionIndex: number,
+): boolean {
+  const match = rounds[roundIndex]?.[positionIndex];
+  if (!match) {
+    return true;
+  }
+
+  if (match.slotAId !== null || match.slotBId !== null) {
+    return false;
+  }
+
+  if (roundIndex === 0) {
+    return true;
+  }
+
+  return (
+    isBranchEmpty(rounds, roundIndex - 1, positionIndex * 2) &&
+    isBranchEmpty(rounds, roundIndex - 1, positionIndex * 2 + 1)
+  );
 }
 
 export function defaultRatingForUser(rating: number | undefined): number {

--- a/apps/job-runner/src/tournaments/generate-bracket-lock.service.spec.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket-lock.service.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { GenerateBracketLockService } from "./generate-bracket-lock.service.js";
+
+describe("GenerateBracketLockService", () => {
+  it("builds a namespaced lock key per tournament", () => {
+    const service = new GenerateBracketLockService({
+      BULLMQ_PREFIX: "rps",
+      WORKER_ROLE: "bracket-generator",
+    } as never);
+
+    expect(service.lockKey("44444444-4444-4444-8444-444444444444")).toBe(
+      "rps:lock:generate-bracket:44444444-4444-4444-8444-444444444444",
+    );
+  });
+
+  it("acquires and releases the distributed lock", async () => {
+    const redis = {
+      set: jest.fn(async () => "OK"),
+      eval: jest.fn(async () => 1),
+      quit: jest.fn(async () => "OK"),
+    };
+    const service = new GenerateBracketLockService({
+      BULLMQ_PREFIX: "rps",
+      WORKER_ROLE: "bracket-generator",
+      REDIS_URL: "redis://localhost:6379",
+    } as never);
+    (service as never as { redis: typeof redis }).redis = redis;
+
+    const token = await service.acquire("tournament-id");
+    expect(token).toEqual(expect.stringMatching(/^bracket-generator:/));
+
+    await service.release("tournament-id", token ?? "missing-token");
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "rps:lock:generate-bracket:tournament-id",
+      token,
+      "EX",
+      600,
+      "NX",
+    );
+  });
+
+  it("returns null when the distributed lock is already held", async () => {
+    const redis = {
+      set: jest.fn(async () => null),
+    };
+    const service = new GenerateBracketLockService({
+      BULLMQ_PREFIX: "rps",
+      WORKER_ROLE: "bracket-generator",
+      REDIS_URL: "redis://localhost:6379",
+    } as never);
+    (service as never as { redis: typeof redis }).redis = redis;
+
+    await expect(service.acquire("tournament-id")).resolves.toBeNull();
+  });
+});

--- a/apps/job-runner/src/tournaments/generate-bracket-lock.service.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket-lock.service.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
+import { Redis } from "ioredis";
+import { JOB_RUNNER_CONFIG, type JobRunnerConfig } from "../config/env.js";
+
+const GENERATE_BRACKET_LOCK_TTL_SECONDS = 600;
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
+
+@Injectable()
+export class GenerateBracketLockService implements OnModuleInit, OnModuleDestroy {
+  private redis: Redis | null = null;
+
+  constructor(@Inject(JOB_RUNNER_CONFIG) private readonly config: JobRunnerConfig) {}
+
+  onModuleInit(): void {
+    if (process.env.SKIP_REDIS_CONNECT === "true") {
+      return;
+    }
+
+    this.redis = new Redis(this.config.REDIS_URL);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis?.quit();
+    this.redis = null;
+  }
+
+  lockKey(tournamentId: string): string {
+    return `${this.config.BULLMQ_PREFIX}:lock:generate-bracket:${tournamentId}`;
+  }
+
+  async acquire(tournamentId: string): Promise<string | null> {
+    const token = `${this.config.WORKER_ROLE}:${randomUUID()}`;
+    const result = await this.requireRedis().set(
+      this.lockKey(tournamentId),
+      token,
+      "EX",
+      GENERATE_BRACKET_LOCK_TTL_SECONDS,
+      "NX",
+    );
+
+    return result === "OK" ? token : null;
+  }
+
+  async release(tournamentId: string, token: string): Promise<void> {
+    await this.requireRedis().eval(RELEASE_LOCK_SCRIPT, 1, this.lockKey(tournamentId), token);
+  }
+
+  private requireRedis(): Redis {
+    if (!this.redis) {
+      throw new Error("Redis client is not connected");
+    }
+
+    return this.redis;
+  }
+}

--- a/apps/job-runner/src/tournaments/generate-bracket.processor.spec.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.processor.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { type Job, UnrecoverableError } from "bullmq";
+import { createGenerateBracketProcessor } from "./generate-bracket.processor.js";
+
+const validPayload = {
+  tournamentId: "44444444-4444-4444-8444-444444444444",
+};
+
+function createJob(overrides: Partial<Job> = {}): Job {
+  return {
+    name: "generate-bracket",
+    data: validPayload,
+    ...overrides,
+  } as Job;
+}
+
+describe("createGenerateBracketProcessor", () => {
+  it("processes valid generate-bracket jobs", async () => {
+    const generateBracket = {
+      processGenerateBracket: jest.fn(async () => "generated"),
+    };
+    const processor = createGenerateBracketProcessor({
+      generateBracket: generateBracket as never,
+    });
+
+    await processor(createJob());
+
+    expect(generateBracket.processGenerateBracket).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("rejects invalid payloads without retry", async () => {
+    const processor = createGenerateBracketProcessor({
+      generateBracket: { processGenerateBracket: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob({ data: { invalid: true } }))).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+
+  it("rejects unsupported job names without retry", async () => {
+    const processor = createGenerateBracketProcessor({
+      generateBracket: { processGenerateBracket: jest.fn() } as never,
+    });
+
+    await expect(processor(createJob({ name: "other-job" }))).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+
+  it("propagates service failures so BullMQ can retry", async () => {
+    const error = new Error("database unavailable");
+    const processor = createGenerateBracketProcessor({
+      generateBracket: {
+        processGenerateBracket: jest.fn(async () => {
+          throw error;
+        }),
+      } as never,
+    });
+
+    await expect(processor(createJob())).rejects.toBe(error);
+  });
+});

--- a/apps/job-runner/src/tournaments/generate-bracket.processor.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.processor.ts
@@ -1,0 +1,25 @@
+import { type Job, UnrecoverableError } from "bullmq";
+import type { WorkerProcessor } from "../workers/worker-processors.js";
+import type { GenerateBracketService } from "./generate-bracket.service.js";
+import { generateBracketPayloadSchema } from "./generate-bracket.types.js";
+
+export type GenerateBracketProcessorDependencies = {
+  generateBracket: GenerateBracketService;
+};
+
+export function createGenerateBracketProcessor(
+  deps: GenerateBracketProcessorDependencies,
+): WorkerProcessor {
+  return async (job: Job) => {
+    if (job.name !== "generate-bracket") {
+      throw new UnrecoverableError(`Unsupported job name on tournaments: ${job.name}`);
+    }
+
+    const parsed = generateBracketPayloadSchema.safeParse(job.data);
+    if (!parsed.success) {
+      throw new UnrecoverableError("Invalid generate-bracket job payload");
+    }
+
+    await deps.generateBracket.processGenerateBracket(parsed.data);
+  };
+}

--- a/apps/job-runner/src/tournaments/generate-bracket.service.spec.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.service.spec.ts
@@ -134,6 +134,55 @@ describe("GenerateBracketService", () => {
     expect(generateBracketLock.acquire).not.toHaveBeenCalled();
   });
 
+  it("re-enqueues tournament notifications when matches already exist", async () => {
+    const tournament = {
+      id: tournamentId,
+      name: "Spring Cup",
+      bracketSize: 4,
+      status: TournamentStatus.in_progress,
+      registrations: [
+        {
+          userId: userAId,
+          user: { id: userAId, displayName: "alice", email: "alice@test.com" },
+        },
+        {
+          userId: userBId,
+          user: { id: userBId, displayName: "bob", email: "bob@test.com" },
+        },
+      ],
+    };
+    const notificationsQueue = {
+      enqueueTournamentStartedMail: jest.fn(async () => undefined),
+    };
+    const prisma = {
+      tournament: {
+        findUnique: jest.fn(async () => tournament),
+      },
+      tournamentMatch: {
+        count: jest.fn(async () => 2),
+      },
+    };
+
+    const service = createService({
+      prisma,
+      generateBracketLock: { acquire: jest.fn(), release: jest.fn() },
+      notificationsQueue,
+    });
+
+    await expect(service.processGenerateBracket({ tournamentId })).resolves.toBe(
+      "already_generated",
+    );
+
+    expect(notificationsQueue.enqueueTournamentStartedMail).toHaveBeenCalledTimes(2);
+    expect(notificationsQueue.enqueueTournamentStartedMail).toHaveBeenCalledWith({
+      tournamentId,
+      userId: userAId,
+      to: "alice@test.com",
+      displayName: "alice",
+      tournamentName: "Spring Cup",
+    });
+  });
+
   it("is idempotent after acquiring the lock", async () => {
     const tournament = {
       id: tournamentId,
@@ -181,6 +230,7 @@ describe("GenerateBracketService", () => {
       "already_generated",
     );
     expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(generateBracketLock.release).toHaveBeenCalledWith(tournamentId, "token");
   });
 
   it("throws when the distributed lock cannot be acquired", async () => {

--- a/apps/job-runner/src/tournaments/generate-bracket.service.spec.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.service.spec.ts
@@ -1,0 +1,240 @@
+import { TournamentStatus, WinnerSlot } from "@chifoumi/db";
+import { describe, expect, it, jest } from "@jest/globals";
+import { UnrecoverableError } from "bullmq";
+import { GenerateBracketService } from "./generate-bracket.service.js";
+
+const tournamentId = "44444444-4444-4444-8444-444444444444";
+const userAId = "11111111-1111-4111-8111-111111111111";
+const userBId = "22222222-2222-4222-8222-222222222222";
+const userCId = "33333333-3333-4333-8333-333333333333";
+
+function createService(overrides: {
+  prisma?: Record<string, unknown>;
+  generateBracketLock?: Record<string, unknown>;
+  notificationsQueue?: Record<string, unknown>;
+}) {
+  return new GenerateBracketService(
+    overrides.prisma as never,
+    overrides.generateBracketLock as never,
+    overrides.notificationsQueue as never,
+  );
+}
+
+describe("GenerateBracketService", () => {
+  it("seeds registrations, creates linked matches and notifies players", async () => {
+    const tournament = {
+      id: tournamentId,
+      name: "Spring Cup",
+      bracketSize: 4,
+      status: TournamentStatus.in_progress,
+      registrations: [
+        {
+          userId: userAId,
+          user: { id: userAId, displayName: "alice", email: "alice@test.com" },
+        },
+        {
+          userId: userBId,
+          user: { id: userBId, displayName: "bob", email: "bob@test.com" },
+        },
+        {
+          userId: userCId,
+          user: { id: userCId, displayName: "carol", email: "carol@test.com" },
+        },
+      ],
+    };
+
+    const createMany = jest.fn(async () => ({ count: 3 }));
+    const registrationUpdate = jest.fn(async () => ({}));
+    const prisma = {
+      tournament: {
+        findUnique: jest.fn(async () => tournament),
+      },
+      tournamentMatch: {
+        count: jest.fn(async () => 0),
+      },
+      eloRating: {
+        findMany: jest.fn(async () => [
+          { userId: userAId, rating: 1600 },
+          { userId: userBId, rating: 1500 },
+          { userId: userCId, rating: 1400 },
+        ]),
+      },
+      $transaction: jest.fn(async (callback: (tx: never) => Promise<void>) =>
+        callback({
+          tournamentRegistration: { update: registrationUpdate },
+          tournamentMatch: { createMany },
+        } as never),
+      ),
+    };
+    const generateBracketLock = {
+      acquire: jest.fn(async () => "token"),
+      release: jest.fn(async () => undefined),
+    };
+    const notificationsQueue = {
+      enqueueTournamentStartedMail: jest.fn(async () => undefined),
+    };
+
+    const service = createService({ prisma, generateBracketLock, notificationsQueue });
+    const result = await service.processGenerateBracket({ tournamentId });
+
+    expect(result).toBe("generated");
+    expect(registrationUpdate).toHaveBeenCalledTimes(3);
+    expect(createMany).toHaveBeenCalledTimes(1);
+
+    const payload = (
+      createMany.mock.calls[0] as unknown as [
+        {
+          data: Array<{
+            round: number;
+            slotAId: string | null;
+            slotBId: string | null;
+            winnerSlot: WinnerSlot | null;
+            nextMatchId: string | null;
+          }>;
+        },
+      ]
+    )[0];
+    expect(payload.data).toHaveLength(3);
+    expect(payload.data.filter((match) => match.round === 1)).toHaveLength(2);
+    expect(payload.data.some((match) => match.winnerSlot === WinnerSlot.a)).toBe(true);
+    expect(payload.data.every((match) => match.round === 2 || match.nextMatchId !== null)).toBe(
+      true,
+    );
+    expect(notificationsQueue.enqueueTournamentStartedMail).toHaveBeenCalledTimes(3);
+    expect(generateBracketLock.release).toHaveBeenCalledWith(tournamentId, "token");
+  });
+
+  it("returns already_generated when tournament matches already exist", async () => {
+    const prisma = {
+      tournament: {
+        findUnique: jest.fn(async () => ({
+          id: tournamentId,
+          status: TournamentStatus.in_progress,
+          registrations: [],
+        })),
+      },
+      tournamentMatch: {
+        count: jest.fn(async () => 2),
+      },
+    };
+    const generateBracketLock = {
+      acquire: jest.fn(),
+      release: jest.fn(),
+    };
+
+    const service = createService({
+      prisma,
+      generateBracketLock,
+      notificationsQueue: { enqueueTournamentStartedMail: jest.fn() },
+    });
+
+    await expect(service.processGenerateBracket({ tournamentId })).resolves.toBe(
+      "already_generated",
+    );
+    expect(generateBracketLock.acquire).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent after acquiring the lock", async () => {
+    const tournament = {
+      id: tournamentId,
+      name: "Spring Cup",
+      bracketSize: 4,
+      status: TournamentStatus.in_progress,
+      registrations: [
+        {
+          userId: userAId,
+          user: { id: userAId, displayName: "alice", email: "alice@test.com" },
+        },
+        {
+          userId: userBId,
+          user: { id: userBId, displayName: "bob", email: "bob@test.com" },
+        },
+      ],
+    };
+    const prisma = {
+      tournament: {
+        findUnique: jest.fn(async () => tournament),
+      },
+      tournamentMatch: {
+        count: jest
+          .fn()
+          .mockResolvedValueOnce(0 as never)
+          .mockResolvedValueOnce(3 as never),
+      },
+      eloRating: {
+        findMany: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    };
+    const generateBracketLock = {
+      acquire: jest.fn(async () => "token"),
+      release: jest.fn(async () => undefined),
+    };
+
+    const service = createService({
+      prisma,
+      generateBracketLock,
+      notificationsQueue: { enqueueTournamentStartedMail: jest.fn() },
+    });
+
+    await expect(service.processGenerateBracket({ tournamentId })).resolves.toBe(
+      "already_generated",
+    );
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("throws when the distributed lock cannot be acquired", async () => {
+    const tournament = {
+      id: tournamentId,
+      status: TournamentStatus.in_progress,
+      registrations: [],
+    };
+    const prisma = {
+      tournament: {
+        findUnique: jest.fn(async () => tournament),
+      },
+      tournamentMatch: {
+        count: jest.fn(async () => 0),
+      },
+    };
+    const generateBracketLock = {
+      acquire: jest.fn(async () => null),
+      release: jest.fn(),
+    };
+
+    const service = createService({
+      prisma,
+      generateBracketLock,
+      notificationsQueue: { enqueueTournamentStartedMail: jest.fn() },
+    });
+
+    await expect(service.processGenerateBracket({ tournamentId })).rejects.toThrow(
+      "Generate-bracket lock not acquired",
+    );
+  });
+
+  it("rejects unsupported tournament statuses without retry", async () => {
+    const prisma = {
+      tournament: {
+        findUnique: jest.fn(async () => ({
+          id: tournamentId,
+          status: TournamentStatus.registration_open,
+          registrations: [],
+        })),
+      },
+      tournamentMatch: {
+        count: jest.fn(async () => 0),
+      },
+    };
+
+    const service = createService({
+      prisma,
+      generateBracketLock: { acquire: jest.fn(), release: jest.fn() },
+      notificationsQueue: { enqueueTournamentStartedMail: jest.fn() },
+    });
+
+    await expect(service.processGenerateBracket({ tournamentId })).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+});

--- a/apps/job-runner/src/tournaments/generate-bracket.service.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.service.ts
@@ -1,0 +1,150 @@
+import { generateFirstRound, type PlayerId, seedPlayers } from "@chifoumi/bracket";
+import { TournamentStatus } from "@chifoumi/db";
+import { Inject, Injectable } from "@nestjs/common";
+import { UnrecoverableError } from "bullmq";
+import { PrismaService } from "../prisma/prisma.service.js";
+import { NotificationsQueueService } from "../queues/notifications-queue.service.js";
+import { buildBracketStructure, defaultRatingForUser } from "./build-bracket-structure.js";
+import type { GenerateBracketPayload, GenerateBracketResult } from "./generate-bracket.types.js";
+import { GenerateBracketLockService } from "./generate-bracket-lock.service.js";
+
+@Injectable()
+export class GenerateBracketService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly generateBracketLock: GenerateBracketLockService,
+    @Inject(NotificationsQueueService)
+    private readonly notificationsQueue: NotificationsQueueService,
+  ) {}
+
+  async processGenerateBracket(payload: GenerateBracketPayload): Promise<GenerateBracketResult> {
+    const tournament = await this.prisma.tournament.findUnique({
+      where: { id: payload.tournamentId },
+      include: {
+        registrations: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                displayName: true,
+                email: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!tournament) {
+      throw new UnrecoverableError(`Tournament ${payload.tournamentId} not found`);
+    }
+
+    if (tournament.status !== TournamentStatus.in_progress) {
+      throw new UnrecoverableError(
+        `Tournament ${tournament.id} is not in progress (status=${tournament.status})`,
+      );
+    }
+
+    const existingMatches = await this.prisma.tournamentMatch.count({
+      where: { tournamentId: tournament.id },
+    });
+    if (existingMatches > 0) {
+      return "already_generated";
+    }
+
+    const lockToken = await this.generateBracketLock.acquire(tournament.id);
+    if (!lockToken) {
+      throw new Error(`Generate-bracket lock not acquired for ${tournament.id}`);
+    }
+
+    try {
+      const matchesAfterLock = await this.prisma.tournamentMatch.count({
+        where: { tournamentId: tournament.id },
+      });
+      if (matchesAfterLock > 0) {
+        return "already_generated";
+      }
+
+      if (tournament.registrations.length < 2) {
+        throw new UnrecoverableError(`Tournament ${tournament.id} has fewer than 2 registrations`);
+      }
+
+      if (tournament.registrations.length > tournament.bracketSize) {
+        throw new UnrecoverableError(
+          `${tournament.registrations.length} registrations exceed bracket size ${tournament.bracketSize}`,
+        );
+      }
+
+      const ratings = await this.prisma.eloRating.findMany({
+        where: {
+          userId: { in: tournament.registrations.map((registration) => registration.userId) },
+        },
+        select: { userId: true, rating: true },
+      });
+      const ratingByUserId = new Map(ratings.map((entry) => [entry.userId, entry.rating]));
+
+      const players = tournament.registrations.map((registration) => ({
+        id: registration.userId as PlayerId,
+        rating: defaultRatingForUser(ratingByUserId.get(registration.userId)),
+      }));
+      const seededPlayers = seedPlayers(players);
+      const firstRoundPairings = generateFirstRound(seededPlayers, tournament.bracketSize);
+      const built = buildBracketStructure(
+        seededPlayers,
+        tournament.bracketSize,
+        firstRoundPairings,
+      );
+
+      await this.prisma.$transaction(async (tx) => {
+        for (const seededPlayer of seededPlayers) {
+          await tx.tournamentRegistration.update({
+            where: {
+              tournamentId_userId: {
+                tournamentId: tournament.id,
+                userId: seededPlayer.id,
+              },
+            },
+            data: { seed: seededPlayer.seed },
+          });
+        }
+
+        await tx.tournamentMatch.createMany({
+          data: built.matches.map((match) => ({
+            id: match.id,
+            tournamentId: tournament.id,
+            round: match.round,
+            slotAId: match.slotAId,
+            slotBId: match.slotBId,
+            winnerSlot: match.winnerSlot,
+            nextMatchId: match.nextMatchId,
+          })),
+        });
+      });
+
+      await this.enqueueTournamentStartedNotifications(tournament.name, tournament.registrations);
+
+      return "generated";
+    } finally {
+      await this.generateBracketLock.release(tournament.id, lockToken);
+    }
+  }
+
+  private async enqueueTournamentStartedNotifications(
+    tournamentName: string,
+    registrations: Array<{
+      user: { email: string; displayName: string };
+    }>,
+  ): Promise<void> {
+    for (const registration of registrations) {
+      await this.notificationsQueue.enqueueTournamentStartedMail({
+        to: registration.user.email,
+        displayName: GenerateBracketService.sanitizeForTemplate(registration.user.displayName),
+        tournamentName,
+      });
+    }
+  }
+
+  private static sanitizeForTemplate(displayName: string): string {
+    return displayName.replace(/__[A-Z_]+__/g, "");
+  }
+}

--- a/apps/job-runner/src/tournaments/generate-bracket.service.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.service.ts
@@ -49,6 +49,11 @@ export class GenerateBracketService {
       where: { tournamentId: tournament.id },
     });
     if (existingMatches > 0) {
+      await this.enqueueTournamentStartedNotifications(
+        tournament.id,
+        tournament.name,
+        tournament.registrations,
+      );
       return "already_generated";
     }
 
@@ -62,6 +67,11 @@ export class GenerateBracketService {
         where: { tournamentId: tournament.id },
       });
       if (matchesAfterLock > 0) {
+        await this.enqueueTournamentStartedNotifications(
+          tournament.id,
+          tournament.name,
+          tournament.registrations,
+        );
         return "already_generated";
       }
 
@@ -121,7 +131,11 @@ export class GenerateBracketService {
         });
       });
 
-      await this.enqueueTournamentStartedNotifications(tournament.name, tournament.registrations);
+      await this.enqueueTournamentStartedNotifications(
+        tournament.id,
+        tournament.name,
+        tournament.registrations,
+      );
 
       return "generated";
     } finally {
@@ -130,13 +144,17 @@ export class GenerateBracketService {
   }
 
   private async enqueueTournamentStartedNotifications(
+    tournamentId: string,
     tournamentName: string,
     registrations: Array<{
+      userId: string;
       user: { email: string; displayName: string };
     }>,
   ): Promise<void> {
     for (const registration of registrations) {
       await this.notificationsQueue.enqueueTournamentStartedMail({
+        tournamentId,
+        userId: registration.userId,
         to: registration.user.email,
         displayName: GenerateBracketService.sanitizeForTemplate(registration.user.displayName),
         tournamentName,

--- a/apps/job-runner/src/tournaments/generate-bracket.types.ts
+++ b/apps/job-runner/src/tournaments/generate-bracket.types.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const generateBracketPayloadSchema = z.object({
+  tournamentId: z.string().uuid(),
+});
+
+export type GenerateBracketPayload = z.infer<typeof generateBracketPayloadSchema>;
+
+export type GenerateBracketResult = "generated" | "already_generated" | "noop";

--- a/apps/job-runner/src/workers/worker-factory.spec.ts
+++ b/apps/job-runner/src/workers/worker-factory.spec.ts
@@ -56,6 +56,12 @@ function createMailService(): { send: () => Promise<void> } {
   };
 }
 
+function createGenerateBracket(): { processGenerateBracket: () => Promise<"generated"> } {
+  return {
+    processGenerateBracket: jest.fn(async (): Promise<"generated"> => "generated"),
+  };
+}
+
 describe("WorkerFactory", () => {
   beforeEach(() => {
     workerCtor.mockReset();
@@ -75,6 +81,7 @@ describe("WorkerFactory", () => {
       createMatchPersistence() as never,
       createRedisInvalidation() as never,
       createSeasonReset() as never,
+      createGenerateBracket() as never,
       createMailService() as never,
       logger,
     );
@@ -120,6 +127,7 @@ describe("WorkerFactory", () => {
       createMatchPersistence() as never,
       createRedisInvalidation() as never,
       createSeasonReset() as never,
+      createGenerateBracket() as never,
       createMailService() as never,
       { log: jest.fn(), error: jest.fn() } as unknown as Logger,
     );
@@ -164,6 +172,7 @@ describe("WorkerFactory", () => {
       createMatchPersistence() as never,
       createRedisInvalidation() as never,
       createSeasonReset() as never,
+      createGenerateBracket() as never,
       createMailService() as never,
       logger,
     );

--- a/apps/job-runner/src/workers/worker-factory.ts
+++ b/apps/job-runner/src/workers/worker-factory.ts
@@ -7,6 +7,7 @@ import { MailService } from "../notifications/mail.service.js";
 import { MatchPersistenceService } from "../persistence/match-persistence.service.js";
 import { RedisInvalidationService } from "../redis/redis-invalidation.service.js";
 import { SeasonResetService } from "../seasons/season-reset.service.js";
+import { GenerateBracketService } from "../tournaments/generate-bracket.service.js";
 import { getProcessorForQueue } from "./worker-processors.js";
 
 export type ManagedWorker = {
@@ -22,6 +23,7 @@ export class WorkerFactory {
     private readonly matchPersistence: MatchPersistenceService,
     private readonly redisInvalidation: RedisInvalidationService,
     private readonly seasonReset: SeasonResetService,
+    private readonly generateBracket: GenerateBracketService,
     private readonly mailService: MailService,
     private readonly logger: Logger,
   ) {}
@@ -41,6 +43,7 @@ export class WorkerFactory {
       matchPersistence: this.matchPersistence,
       redisInvalidation: this.redisInvalidation,
       seasonReset: this.seasonReset,
+      generateBracket: this.generateBracket,
       mailService: this.mailService,
     });
 

--- a/apps/job-runner/src/workers/worker-processors.ts
+++ b/apps/job-runner/src/workers/worker-processors.ts
@@ -10,23 +10,17 @@ import {
   createSeasonResetProcessor,
   type SeasonResetProcessorDependencies,
 } from "../seasons/season-reset.processor.js";
+import {
+  createGenerateBracketProcessor,
+  type GenerateBracketProcessorDependencies,
+} from "../tournaments/generate-bracket.processor.js";
 
 export type WorkerProcessor = (job: Job) => Promise<void>;
 export type ProcessorDependencies = MatchEventsProcessorDependencies &
-  SeasonResetProcessorDependencies & {
+  SeasonResetProcessorDependencies &
+  GenerateBracketProcessorDependencies & {
     mailService: MailService;
   };
-
-const STUB_PROCESSORS: Record<
-  Exclude<WorkerQueueName, "match-events" | "notifications" | "seasons">,
-  WorkerProcessor
-> = {
-  tournaments: async (job) => {
-    if (job.name !== "generate-bracket") {
-      throw new Error(`Unsupported job name on tournaments: ${job.name}`);
-    }
-  },
-};
 
 export function getProcessorForQueue(
   queue: WorkerQueueName,
@@ -44,5 +38,9 @@ export function getProcessorForQueue(
     return createSeasonResetProcessor(deps);
   }
 
-  return STUB_PROCESSORS[queue];
+  if (queue === "tournaments") {
+    return createGenerateBracketProcessor(deps);
+  }
+
+  throw new Error(`Unsupported worker queue: ${queue satisfies never}`);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
 
   apps/job-runner:
     dependencies:
+      '@chifoumi/bracket':
+        specifier: workspace:*
+        version: link:../../packages/bracket
       '@chifoumi/db':
         specifier: workspace:*
         version: link:../../packages/db


### PR DESCRIPTION
## Summary

- Replace the `tournaments` queue stub with a real `generate-bracket` processor (US-070 / Closes #126)
- Seed registered players by ELO via `@chifoumi/bracket`, persist seeds on `tournament_registrations`, and create the full single-elimination tree (`tournament_matches` with `nextMatchId` chaining)
- Handle byes by marking round-1 winners and pre-filling the next-round slot; guard concurrency with a Redis lock and skip regeneration when matches already exist
- Notify all registered players via the `tournament-started` mail template (directed match start deferred until US-069 lands on `develop`)

## Test plan

- [x] `pnpm --filter @chifoumi/job-runner test` (seeding, round 1, byes, idempotence, lock)
- [x] `pnpm biome check apps/job-runner`
- [x] `pnpm --filter @chifoumi/job-runner typecheck`
- [ ] Manual: `PATCH /admin/tournaments/:id/start` with 2+ players → bracket persisted, tour 1 playable
- [ ] Manual: re-run job → no duplicate matches (idempotent)

## DoD checklist

- [x] Tests added and passing
- [x] Biome + typecheck green
- [x] Idempotent bracket generation
- [x] Redis distributed lock
- [ ] Directed match gRPC trigger (blocked on US-069 merge)