### PR TITLE
docs: restore French accents in README and architecture doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [![PR workflow (develop)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml/badge.svg?branch=develop)](https://github.com/Team-3-Ynov/Chifoumi/actions/workflows/pr.yml?query=branch%3Adevelop)
 
-Plateforme web competitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties temps reel et services decoupes en monorepo.
+Plateforme web compétitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties temps réel et services découpés en monorepo.
 
 ## Sommaire
 
-- [Pre-requis](#pre-requis)
-- [Demarrage rapide](#demarrage-rapide)
+- [Pré-requis](#pré-requis)
+- [Démarrage rapide](#démarrage-rapide)
 - [Devcontainer](#devcontainer)
 - [Stack multi-replicas (US-030)](#stack-multi-replicas-us-030)
-- [Demo multi-instances (US-032)](#demo-multi-instances-us-032)
+- [Démo multi-instances (US-032)](#démo-multi-instances-us-032)
 - [Tech stack](#tech-stack)
 - [Architecture](#architecture)
 - [Commandes utiles](#commandes-utiles)
@@ -18,14 +18,14 @@ Plateforme web competitive Pierre-Feuille-Ciseaux avec matchmaking ELO, parties 
 - [Contributing](#contributing)
 - [Documentation](#documentation)
 
-## Pre-requis
+## Pré-requis
 
 - Node.js `>=20.19.0`
 - pnpm `9.15.9` via Corepack ou `npx pnpm@9.15.9`
 - Docker Desktop ou Docker Engine avec Compose
 - Git
 
-## Demarrage rapide
+## Démarrage rapide
 
 ```bash
 pnpm install
@@ -38,7 +38,7 @@ pnpm dev
 
 ## Premier lancement
 
-Au premier demarrage (base Postgres vide), appliquer les migrations puis le seed :
+Au premier démarrage (base Postgres vide), appliquer les migrations puis le seed :
 
 ```bash
 docker compose up -d postgres
@@ -46,42 +46,42 @@ pnpm --filter @chifoumi/db migrate:deploy
 pnpm db:seed
 ```
 
-Le seed cree un compte admin par defaut :
+Le seed crée un compte admin par défaut :
 
 | Champ | Valeur dev |
 |---|---|
 | Email | `admin@chifoumi.local` |
 | Mot de passe | `admin-CHANGE-ME!` |
-| Role | `admin` |
+| Rôle | `admin` |
 | ELO initial | `1000` |
 
-**En production**, definir obligatoirement `ADMIN_DEFAULT_EMAIL` et `ADMIN_DEFAULT_PASSWORD` dans l'environnement — ne jamais conserver les valeurs par defaut.
+**En production**, définir obligatoirement `ADMIN_DEFAULT_EMAIL` et `ADMIN_DEFAULT_PASSWORD` dans l'environnement — ne jamais conserver les valeurs par défaut.
 
-Le seed est idempotent : relance sur une base deja initialisee, il ne duplique rien. En stack Docker scale, le job one-shot `db-migrate` execute `migrate deploy` puis `db:seed` avant le demarrage des replicas API (skip si l'admin existe deja).
+Le seed est idempotent : relancé sur une base déjà initialisée, il ne duplique rien. En stack Docker scale, le job one-shot `db-migrate` exécute `migrate deploy` puis `db:seed` avant le démarrage des replicas API (skip si l'admin existe déjà).
 
-Services lances par `pnpm dev` :
+Services lancés par `pnpm dev` :
 
-| Service | URL locale | Role |
+| Service | URL locale | Rôle |
 |---|---:|---|
 | Front | `http://localhost:5173` | Interface React/Vite |
 | API | `http://localhost:3000/health` | API HTTP NestJS |
-| Game service | `http://localhost:3001/health` | Service temps reel Socket.io |
+| Game service | `http://localhost:3001/health` | Service temps réel Socket.io |
 | Job runner | terminal uniquement | Workers et traitements asynchrones |
 
-Si le schema Postgres evolue, relancer une base vide avec `docker compose down -v`, puis `docker compose up -d`.
+Si le schéma Postgres évolue, relancer une base vide avec `docker compose down -v`, puis `docker compose up -d`.
 
 ## Devcontainer
 
-Le devcontainer lance un workspace Node + pnpm avec Postgres, Redis et MailHog. Le dossier local du repo doit rester nomme `Chifoumi`, car le workspace est monte dans le conteneur sous `/workspaces/Chifoumi`.
+Le devcontainer lance un workspace Node + pnpm avec Postgres, Redis et MailHog. Le dossier local du repo doit rester nommé `Chifoumi`, car le workspace est monté dans le conteneur sous `/workspaces/Chifoumi`.
 
-Au premier demarrage, `.devcontainer/post-create.sh` :
+Au premier démarrage, `.devcontainer/post-create.sh` :
 
 - copie `.env.example` vers `.env` avec les URLs internes Docker ;
-- genere les cles JWT de developpement dans `infra/keys/` si elles n'existent pas ;
+- génère les clés JWT de développement dans `infra/keys/` si elles n'existent pas ;
 - configure le store pnpm persistant dans `pnpm-store` ;
-- installe les dependances et genere le client Prisma.
+- installe les dépendances et génère le client Prisma.
 
-Apres ouverture dans VS Code ou Cursor, lancer les migrations puis les apps :
+Après ouverture dans VS Code ou Cursor, lancer les migrations puis les apps :
 
 ```bash
 pnpm --filter @chifoumi/db migrate:deploy
@@ -90,11 +90,11 @@ pnpm dev
 
 ## Stack multi-replicas (US-030)
 
-Stack containerisee complete avec Traefik, 2 replicas API, 2 replicas Game Service et observabilite.
+Stack containerisée complète avec Traefik, 2 replicas API, 2 replicas Game Service et observabilité.
 
-### Pre-requis supplementaires
+### Pré-requis supplémentaires
 
-Generer les cles JWT de dev (une seule fois) :
+Générer les clés JWT de dev (une seule fois) :
 
 ```bash
 mkdir -p infra/keys
@@ -102,7 +102,7 @@ openssl genrsa -out infra/keys/jwt-private.pem 2048
 openssl rsa -in infra/keys/jwt-private.pem -pubout -out infra/keys/jwt-public.pem
 ```
 
-Ajouter les entrees suivantes au fichier hosts local (`C:\Windows\System32\drivers\etc\hosts` ou `/etc/hosts`) :
+Ajouter les entrées suivantes au fichier hosts local (`C:\Windows\System32\drivers\etc\hosts` ou `/etc/hosts`) :
 
 ```text
 127.0.0.1 api.localhost front.localhost game.localhost traefik.localhost grafana.localhost prometheus.localhost
@@ -114,7 +114,7 @@ Ajouter les entrees suivantes au fichier hosts local (`C:\Windows\System32\drive
 docker compose -f docker-compose.yml -f docker-compose.scale.yml up -d --build
 ```
 
-Services demarres : `postgres` x1, `redis` x1, `db-migrate` (one-shot), `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
+Services démarrés : `postgres` x1, `redis` x1, `db-migrate` (one-shot), `api-1` + `api-2`, `game-1` + `game-2`, `job-runner-match` x1, `job-runner-misc` x1, `front` x1, `traefik` x1, `mailhog` x1, `prometheus` x1, `grafana` x1.
 
 | Service | URL via Traefik | Port direct |
 |---|---:|---|
@@ -126,9 +126,9 @@ Services demarres : `postgres` x1, `redis` x1, `db-migrate` (one-shot), `api-1` 
 | Prometheus | `http://prometheus.localhost` | `http://localhost:9090` |
 | MailHog | — | `http://localhost:8025` |
 
-Verifier le round-robin API : `curl http://api.localhost/health` plusieurs fois et comparer le champ `instance` (`api-1` / `api-2`) dans les logs ou la reponse JSON.
+Vérifier le round-robin API : `curl http://api.localhost/health` plusieurs fois et comparer le champ `instance` (`api-1` / `api-2`) dans les logs ou la réponse JSON.
 
-Demo de resilience : arreter une instance API puis verifier que `/health` repond toujours :
+Démo de résilience : arrêter une instance API puis vérifier que `/health` répond toujours :
 
 ```bash
 docker stop chifoumi-api-1
@@ -136,15 +136,15 @@ curl http://api.localhost/health
 docker start chifoumi-api-1
 ```
 
-Arreter la stack :
+Arrêter la stack :
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.scale.yml down
 ```
 
-## Demo multi-instances (US-032)
+## Démo multi-instances (US-032)
 
-Procedure de soutenance (~5 min) : deux joueurs sur des replicas Game Service differents, crash d'instance, Grafana live.
+Procédure de soutenance (~5 min) : deux joueurs sur des replicas Game Service différents, crash d'instance, Grafana live.
 
 ```bash
 # Linux / macOS / Git Bash
@@ -154,7 +154,7 @@ bash scripts/demo/run-demo.sh
 .\scripts\demo\run-demo.ps1
 ```
 
-Guide detaille avec captures : [`docs/demo/multi-instances.md`](docs/demo/multi-instances.md).
+Guide détaillé avec captures : [`docs/demo/multi-instances.md`](docs/demo/multi-instances.md).
 
 ## Tech stack
 
@@ -165,19 +165,19 @@ Guide detaille avec captures : [`docs/demo/multi-instances.md`](docs/demo/multi-
 | Front | React, Vite |
 | BDD | PostgreSQL 16, Prisma |
 | Cache / queues | Redis, BullMQ |
-| Temps reel | Socket.io |
-| Qualite | Biome, TypeScript, lefthook |
+| Temps réel | Socket.io |
+| Qualité | Biome, TypeScript, lefthook |
 | CI | GitHub Actions |
 
-Biome remplace ESLint + Prettier pour ce projet, choix valide et documente dans [`packages/biome/README.md`](packages/biome/README.md).
+Biome remplace ESLint + Prettier pour ce projet, choix validé et documenté dans [`packages/biome/README.md`](packages/biome/README.md).
 
 ## Architecture
 
-La vue d'architecture versionnee est disponible dans [`docs/architecture.md`](docs/architecture.md).
+La vue d'architecture versionnée est disponible dans [`docs/architecture.md`](docs/architecture.md).
 
-Elle couvre les replicas Front/API/Game Service/Job Runner, les dependances PostgreSQL/Redis/Prometheus/Grafana et les protocoles REST, WS Socket.io, gRPC, BullMQ et Prisma. Elle contient aussi les sequences de match complet et d'authentification utiles pour la soutenance.
+Elle couvre les replicas Front/API/Game Service/Job Runner, les dépendances PostgreSQL/Redis/Prometheus/Grafana et les protocoles REST, WS Socket.io, gRPC, BullMQ et Prisma. Elle contient aussi les séquences de match complet et d'authentification utiles pour la soutenance.
 
-La vision fonctionnelle complete reste dans [`docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md`](docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md). Les plans d'implementation sont dans [`docs/superpowers/plans/`](docs/superpowers/plans/).
+La vision fonctionnelle complète reste dans [`docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md`](docs/superpowers/specs/2026-04-28-rps-ranked-platform-design.md). Les plans d'implémentation sont dans [`docs/superpowers/plans/`](docs/superpowers/plans/).
 
 ## Commandes utiles
 
@@ -203,7 +203,7 @@ pnpm --filter @chifoumi/front dev
 
 ### Couverture de tests (US-044)
 
-La CI echoue si la couverture descend sous les seuils definis par package :
+La CI échoue si la couverture descend sous les seuils définis par package :
 
 | Package | Runner | Seuils (`lines` / `branches` / `functions`) |
 |---|---|---|
@@ -211,19 +211,19 @@ La CI echoue si la couverture descend sous les seuils definis par package :
 | `packages/elo` | Jest | 95 % / 95 % / 100 % |
 | `apps/front` | Vitest | 60 % / 50 % / — |
 
-Commande locale equivalente a la CI :
+Commande locale équivalente à la CI :
 
 ```bash
 pnpm -r run --if-present test --coverage
 ```
 
-Les rapports `lcov.info` / `coverage/` sont uploades en artefact GitHub Actions (`coverage-reports`) a chaque PR.
+Les rapports `lcov.info` / `coverage/` sont uploadés en artefact GitHub Actions (`coverage-reports`) à chaque PR.
 
 #### Ajouter une exclusion explicite
 
-Preferer exclure un fichier ou dossier entier plutot que baisser un seuil global.
+Préférer exclure un fichier ou dossier entier plutôt que baisser un seuil global.
 
-**Back (Jest)** — editer `coveragePathIgnorePatterns` dans le `jest.config.cjs` du package concerne, avec un commentaire inline expliquant pourquoi (DTO, bootstrap, infra, e2e-only…) :
+**Back (Jest)** — éditer `coveragePathIgnorePatterns` dans le `jest.config.cjs` du package concerné, avec un commentaire inline expliquant pourquoi (DTO, bootstrap, infra, e2e-only…) :
 
 ```js
 coveragePathIgnorePatterns: [
@@ -232,26 +232,26 @@ coveragePathIgnorePatterns: [
 ],
 ```
 
-**Front (Vitest)** — ajouter un glob commente dans `apps/front/vitest.config.ts` → `test.coverage.exclude`.
+**Front (Vitest)** — ajouter un glob commenté dans `apps/front/vitest.config.ts` → `test.coverage.exclude`.
 
-**Packages purement fonctionnels (`packages/elo`)** — viser 95 %+ ; n'exclure que les barrels (`index.ts`) ou le code genere.
+**Packages purement fonctionnels (`packages/elo`)** — viser 95 %+ ; n'exclure que les barrels (`index.ts`) ou le code généré.
 
-### Job-runner (deploiement)
+### Job-runner (déploiement)
 
-Le job-runner persiste les matchs termines et envoie les notifications. Il utilise la **meme base PostgreSQL que l'API** via Prisma.
+Le job-runner persiste les matchs terminés et envoie les notifications. Il utilise la **même base PostgreSQL que l'API** via Prisma.
 
-| Variable | Role |
+| Variable | Rôle |
 |---|---|
 | `DATABASE_URL` | Connexion PostgreSQL (obligatoire) — persistance des matchs, rounds, ELO et historique |
 | `REDIS_URL` | Redis pour BullMQ et publication `leaderboard:invalidate` |
-| `WORKER_QUEUES` | Queues a ecouter, ex. `match-events,notifications` |
-| `WORKER_CONCURRENCY` | Nombre de jobs traites en parallele par worker |
-| `WORKER_ROLE` | Role logique du processus (`match-processor`, `notifier`, etc.) |
-| `BULLMQ_PREFIX` | Prefixe des queues BullMQ (isole les environnements) |
+| `WORKER_QUEUES` | Queues à écouter, ex. `match-events,notifications` |
+| `WORKER_CONCURRENCY` | Nombre de jobs traités en parallèle par worker |
+| `WORKER_ROLE` | Rôle logique du processus (`match-processor`, `notifier`, etc.) |
+| `BULLMQ_PREFIX` | Préfixe des queues BullMQ (isole les environnements) |
 
-En local, copier `.env.example` vers `.env` : `DATABASE_URL` est partagee entre l'API et le job-runner. En production, pointer `DATABASE_URL` vers la base applicative et `REDIS_URL` vers le cluster Redis partage avec l'API et le game-service.
+En local, copier `.env.example` vers `.env` : `DATABASE_URL` est partagée entre l'API et le job-runner. En production, pointer `DATABASE_URL` vers la base applicative et `REDIS_URL` vers le cluster Redis partagé avec l'API et le game-service.
 
-Tests d'integration du worker match-events (Postgres + Redis requis) :
+Tests d'intégration du worker match-events (Postgres + Redis requis) :
 
 ```bash
 docker compose up -d
@@ -268,20 +268,20 @@ pnpm --filter @chifoumi/job-runner test:integration
 | Game service health | `http://localhost:3001/health` | disponible |
 | Swagger | `http://localhost:3000/api/docs` | disponible |
 | OpenAPI JSON | `http://localhost:3000/api/docs-json` | disponible |
-| MailHog | `http://localhost:8025` | disponible apres `docker compose up -d` |
+| MailHog | `http://localhost:8025` | disponible après `docker compose up -d` |
 | Grafana | `http://localhost:3002` | disponible avec `docker-compose.scale.yml` |
 
-En production, la documentation Swagger est protegee par Basic Auth via `SWAGGER_USER` et `SWAGGER_PASSWORD`.
-Sans ces deux variables en production, les routes `/api/docs` et `/api/docs-json` ne sont pas exposees.
+En production, la documentation Swagger est protégée par Basic Auth via `SWAGGER_USER` et `SWAGGER_PASSWORD`.
+Sans ces deux variables en production, les routes `/api/docs` et `/api/docs-json` ne sont pas exposées.
 
 ## Contributing
 
-Le workflow Git, les conventions de commit et les regles de review sont dans [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Le workflow Git, les conventions de commit et les règles de review sont dans [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-Resume :
+Résumé :
 
-- partir de `develop` a jour ;
-- creer une branche `feature/*`, `fix/*`, `docs/*` ou `chore/*` ;
+- partir de `develop` à jour ;
+- créer une branche `feature/*`, `fix/*`, `docs/*` ou `chore/*` ;
 - utiliser des commits Conventional Commits ;
 - ouvrir une PR vers `develop` ;
 - attendre une review avant merge.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Chifoumi Ranked
 
-Ce document donne une vue versionnee des composants deployes, des flux reseau et des traitements asynchrones utiles pour la soutenance.
+Ce document donne une vue versionnée des composants déployés, des flux réseau et des traitements asynchrones utiles pour la soutenance.
 
 ## Vue d'ensemble
 
@@ -154,29 +154,29 @@ sequenceDiagram
 
 ## Table des services
 
-| Service | Role | Port local | URL scale | Dependances |
+| Service | Rôle | Port local | URL scale | Dépendances |
 |---|---|---:|---|---|
 | Front | Interface React/Vite servie en HTTP | `5173` en dev, `80` en conteneur | `http://front.localhost` | API REST, Game WS |
-| API `api-1` | API REST NestJS, Swagger, metrics, gRPC auth interne | `3000:3000`, gRPC `50051` interne | `http://api.localhost/health` | PostgreSQL, Redis, BullMQ, cles JWT |
-| API `api-2` | Replica API REST pour round-robin | `3002:3000`, gRPC `50051` interne | `http://api.localhost/health` | PostgreSQL, Redis, BullMQ, cles JWT |
-| Game Service `game-service-1` | Socket.io `/game`, matchmaking, sessions BO3 en compose de base | `3001:3001` | Non route par Traefik | Redis, API gRPC `api-1:50051`, BullMQ |
-| Game Service `game-service-2` | Replica temps reel en compose de base | `3003:3001` | Non route par Traefik | Redis, API gRPC `api-2:50051`, BullMQ |
-| Game Service `game-1` | Replica temps reel avec sticky routing Traefik | Pas de port direct en scale | `ws://game.localhost/game` | Redis, API gRPC, BullMQ |
-| Game Service `game-2` | Replica temps reel avec sticky routing Traefik | Pas de port direct en scale | `ws://game.localhost/game` | Redis, API gRPC, BullMQ |
-| Job Runner `match-events` | Persistance des matchs termines, recalcul ELO, invalidation leaderboard | metrics `3002` interne | Non expose | Redis BullMQ, PostgreSQL |
-| Job Runner `notifications` / `tournaments` | Emails, notifications et jobs planifies | metrics `3002` interne | Non expose | Redis BullMQ, PostgreSQL, MailHog |
-| PostgreSQL | Stockage users, refresh tokens, matchs, rounds, ELO | `5432` | Non expose via Traefik | Volume `pg_data` |
-| Redis | Cache, blacklist JWT, matchmaking, pub/sub, BullMQ | `6379` | Non expose via Traefik | Volume `redis_data` |
+| API `api-1` | API REST NestJS, Swagger, metrics, gRPC auth interne | `3000:3000`, gRPC `50051` interne | `http://api.localhost/health` | PostgreSQL, Redis, BullMQ, clés JWT |
+| API `api-2` | Replica API REST pour round-robin | `3002:3000`, gRPC `50051` interne | `http://api.localhost/health` | PostgreSQL, Redis, BullMQ, clés JWT |
+| Game Service `game-service-1` | Socket.io `/game`, matchmaking, sessions BO3 en compose de base | `3001:3001` | Non routé par Traefik | Redis, API gRPC `api-1:50051`, BullMQ |
+| Game Service `game-service-2` | Replica temps réel en compose de base | `3003:3001` | Non routé par Traefik | Redis, API gRPC `api-2:50051`, BullMQ |
+| Game Service `game-1` | Replica temps réel avec sticky routing Traefik | Pas de port direct en scale | `ws://game.localhost/game` | Redis, API gRPC, BullMQ |
+| Game Service `game-2` | Replica temps réel avec sticky routing Traefik | Pas de port direct en scale | `ws://game.localhost/game` | Redis, API gRPC, BullMQ |
+| Job Runner `match-events` | Persistance des matchs terminés, recalcul ELO, invalidation leaderboard | metrics `3002` interne | Non exposé | Redis BullMQ, PostgreSQL |
+| Job Runner `notifications` / `tournaments` | Emails, notifications et jobs planifiés | metrics `3002` interne | Non exposé | Redis BullMQ, PostgreSQL, MailHog |
+| PostgreSQL | Stockage users, refresh tokens, matchs, rounds, ELO | `5432` | Non exposé via Traefik | Volume `pg_data` |
+| Redis | Cache, blacklist JWT, matchmaking, pub/sub, BullMQ | `6379` | Non exposé via Traefik | Volume `redis_data` |
 | Prometheus | Scraping des endpoints `/metrics` | `9090` | `http://prometheus.localhost` | API, Game Service, Job Runner |
-| Grafana | Dashboards observabilite pre-provisionnes | `3002:3000` en scale | `http://grafana.localhost` | Prometheus |
-| MailHog | SMTP et UI mail de developpement | `1025`, `8025` | Non expose via Traefik | Job Runner, API notifications |
+| Grafana | Dashboards observabilité pré-provisionnés | `3002:3000` en scale | `http://grafana.localhost` | Prometheus |
+| MailHog | SMTP et UI mail de développement | `1025`, `8025` | Non exposé via Traefik | Job Runner, API notifications |
 
 ## Notes de lecture
 
 - La stack scale passe par Traefik pour `front.localhost`, `api.localhost`, `game.localhost`, `prometheus.localhost` et `grafana.localhost`.
-- L'override de demo `docker-compose.demo.yml` expose seulement `game-1` et `game-2` sur `3101:3001` et `3102:3001` pour forcer un joueur sur chaque replica.
-- Le Game Service ne lit pas directement la base applicative pour l'authentification en temps reel : il delegue la verification JWT a l'API via gRPC.
-- Le protocole WebSocket public de jeu utilise l'evenement `play`; les champs commit/reveal appartiennent a l'etat interne des phases avancees.
-- Redis porte a la fois les files BullMQ, la file de matchmaking, les sessions de match, le pub/sub inter-instances et la blacklist des JWT deconnectes.
-- La table detaillee des cles Redis est disponible dans [docs/architecture/redis-keys.md](architecture/redis-keys.md).
-- Les jobs `match-events` terminent le flux metier apres `matchEnded` : persistance, calcul ELO et invalidation du cache leaderboard.
+- L'override de démo `docker-compose.demo.yml` expose seulement `game-1` et `game-2` sur `3101:3001` et `3102:3001` pour forcer un joueur sur chaque replica.
+- Le Game Service ne lit pas directement la base applicative pour l'authentification en temps réel : il délègue la vérification JWT à l'API via gRPC.
+- Le protocole WebSocket public de jeu utilise l'événement `play`; les champs commit/reveal appartiennent à l'état interne des phases avancées.
+- Redis porte à la fois les files BullMQ, la file de matchmaking, les sessions de match, le pub/sub inter-instances et la blacklist des JWT déconnectés.
+- La table détaillée des clés Redis est disponible dans [docs/architecture/redis-keys.md](architecture/redis-keys.md).
+- Les jobs `match-events` terminent le flux métier après `matchEnded` : persistance, calcul ELO et invalidation du cache leaderboard.


### PR DESCRIPTION
## Quoi

Corrige les accents français manquants dans la documentation :

- `README.md` — texte ré-accentué + ancres du sommaire ajustées sur les titres accentués (navigation préservée).
- `docs/architecture.md` — intro, table des services et notes de lecture.

## Pourquoi

Passe de propreté avant rendu : les deux fichiers étaient écrits sans accents, ce qui nuisait à la lisibilité d'un rendu FR.

## Hors périmètre

Aucune modification de code ni de diagramme Mermaid (labels techniques inchangés). Aucun impact fonctionnel.
