### PR TITLE
fix(job-runner): wire seasons queue consumer and fix TOCTOU in season reset

### DIFF
--- a/apps/job-runner/src/seasons/season-reset.service.ts
+++ b/apps/job-runner/src/seasons/season-reset.service.ts
@@ -95,18 +95,22 @@ export class SeasonResetService {
   private async archiveStandingsAndSoftReset(season: Season): Promise<void> {
     const leagues = await this.prisma.league.findMany({ orderBy: { tier: "asc" } });
     type LeagueRow = (typeof leagues)[number];
-    const ratings = await this.prisma.eloRating.findMany({
-      orderBy: [{ rating: "desc" }, { gamesPlayed: "desc" }],
-      include: {
-        user: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
 
     await this.prisma.$transaction(async (tx) => {
+      // Read ratings inside the transaction so a concurrent match-ended that
+      // updates an eloRating row cannot slip between the read and the write
+      // (TOCTOU). The transaction snapshot guarantees a consistent view.
+      const ratings = await tx.eloRating.findMany({
+        orderBy: [{ rating: "desc" }, { gamesPlayed: "desc" }],
+        include: {
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+
       if (ratings.length > 0) {
         await tx.seasonStanding.createMany({
           data: ratings.map((entry, index) => {
@@ -187,6 +191,10 @@ export class SeasonResetService {
           season.startedAt,
         );
 
+        // Enqueue then mark: at-least-once delivery. A crash between the two
+        // steps re-sends the mail on retry, which is acceptable for reward
+        // notifications. rewardsDistributed acts as an idempotency guard on
+        // the next run so the mail is not sent a third time.
         await this.notificationsQueue.enqueueSeasonRewardMail({
           to: standing.user.email,
           displayName: SeasonResetService.sanitizeForTemplate(standing.user.displayName),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -216,7 +216,7 @@ services:
       NODE_ENV: production
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: ${REDIS_URL}
-      WORKER_QUEUES: notifications,tournaments
+      WORKER_QUEUES: notifications,seasons,tournaments
       WORKER_CONCURRENCY: ${MISC_WORKER_CONCURRENCY:-4}
       WORKER_ROLE: notifier
       JOB_RUNNER_METRICS_PORT: 3002

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,7 @@ services:
     environment:
       DATABASE_URL: postgresql://app:chifoumi_dev@postgres:5432/chifoumi
       REDIS_URL: redis://redis:6379
-      WORKER_QUEUES: notifications,tournaments
+      WORKER_QUEUES: notifications,seasons,tournaments
       WORKER_CONCURRENCY: 4
       WORKER_ROLE: notifier
       JOB_RUNNER_METRICS_PORT: 3002


### PR DESCRIPTION
## Résumé

Corrige le ticket #159 (P0) — la chaîne saisonnière complète (US-061) ne s'exécutait dans aucune config déployée.

- **Queue `seasons` non consommée** : `WORKER_QUEUES` de `job-runner-misc` ne listait que `notifications,tournaments`. Le cron enfilait les jobs `season-reset` dans `seasons` mais aucune instance ne les consommait. Ajout de `seasons` dans les deux compose (dev + prod).
- **TOCTOU dans `archiveStandingsAndSoftReset`** : le `findMany` des ratings était effectué *avant* la `$transaction`. Un `match-ended` concurrent pouvait mettre à jour un `eloRating` entre la lecture et l'écriture, causant un soft-reset sur une valeur périmée et un `elo_history` incohérent. Le `findMany` est maintenant *à l'intérieur* de la transaction.
- **Livraison at-least-once documentée** : l'enqueue du mail suivi du flag `rewardsDistributed` est non atomique ; un crash entre les deux renvoie le mail au rejeu. Ce comportement est acceptable et désormais commenté.
- **Bonus** : `pnpm install` a été nécessaire pour lier `@chifoumi/bracket` dans le store pnpm (dépendance déclarée mais jamais installée — causait des erreurs typecheck pré-existantes dans les tests de tournoi).

## Fichiers modifiés

| Fichier | Changement |
|---|---|
| `docker-compose.yml:219` | `notifications,tournaments` → `notifications,seasons,tournaments` |
| `docker-compose.prod.yml:219` | idem |
| `apps/job-runner/src/seasons/season-reset.service.ts` | `findMany` déplacé dans `$transaction` + commentaire at-least-once |

## Checklist DoD

- [x] Typecheck vert (le hook pre-commit passe)
- [x] `pnpm biome check` vert
- [x] Aucune régression introduite
- [x] Closes #159