### PR TITLE
fix(api): security hardening — Helmet, JWT global guard, redact newPassword/token

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "argon2": "0.41.1",
+    "helmet": "^8.1.0",
     "bullmq": "^5.49.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { APP_GUARD } from "@nestjs/core";
 import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
 import { LoggerModule } from "nestjs-pino";
 import { AuthModule } from "./auth/auth.module.js";
+import { JwtAuthGuard } from "./auth/guards/jwt-auth.guard.js";
 import { AppConfigModule } from "./config/config.module.js";
 import { GrpcModule } from "./grpc/grpc.module.js";
 import { HealthModule } from "./health/health.module.js";
@@ -22,7 +23,13 @@ import { UsersModule } from "./users/users.module.js";
   imports: [
     LoggerModule.forRoot({
       pinoHttp: {
-        redact: ["req.headers.authorization", "req.body.password", "req.body.refreshToken"],
+        redact: [
+          "req.headers.authorization",
+          "req.body.password",
+          "req.body.newPassword",
+          "req.body.refreshToken",
+          "req.body.token",
+        ],
       },
     }),
     ThrottlerModule.forRoot([
@@ -57,6 +64,10 @@ import { UsersModule } from "./users/users.module.js";
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
     },
   ],
 })

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,21 @@
+import "reflect-metadata";
+import { AuthController } from "./auth.controller.js";
+import { IS_PUBLIC_KEY } from "./decorators/public.decorator.js";
+
+describe("AuthController route metadata", () => {
+  it.each([
+    "register",
+    "login",
+    "refresh",
+    "forgotPassword",
+    "resetPassword",
+  ] as const)("marks %s as public for the global JWT guard", (handlerName) => {
+    const handler = AuthController.prototype[handlerName];
+
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, handler)).toBe(true);
+  });
+
+  it("keeps logout protected by the global JWT guard", () => {
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, AuthController.prototype.logout)).toBeUndefined();
+  });
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import { Throttle } from "@nestjs/throttler";
 import { SWAGGER_BEARER_AUTH } from "../swagger.js";
 import type { SafeUser } from "../users/users.service.js";
 import { AuthService } from "./auth.service.js";
+import { Public } from "./decorators/public.decorator.js";
 import { AuthResponseDto } from "./dto/auth-response.dto.js";
 import { ForgotPasswordDto } from "./dto/forgot-password.dto.js";
 import { LoginDto } from "./dto/login.dto.js";
@@ -51,6 +52,7 @@ export class AuthController {
   constructor(@Inject(AuthService) private readonly authService: AuthService) {}
 
   @Post("register")
+  @Public()
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: "Register a new player account",
@@ -94,6 +96,7 @@ export class AuthController {
   }
 
   @Post("login")
+  @Public()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Login with email and password",
@@ -134,6 +137,7 @@ export class AuthController {
   }
 
   @Post("refresh")
+  @Public()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: "Rotate refresh token and issue a new access token",
@@ -201,6 +205,7 @@ export class AuthController {
   }
 
   @Post("forgot-password")
+  @Public()
   @HttpCode(HttpStatus.OK)
   // Override the shared "auth" throttler with a stricter limit for this route
   // only (the throttler key is per-handler), instead of a global throttler that
@@ -236,6 +241,7 @@ export class AuthController {
   }
 
   @Post("reset-password")
+  @Public()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     summary: "Reset the account password using a reset token",

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,5 +1,6 @@
 import { createConnection } from "node:net";
 import { Controller, Get, HttpStatus, Res } from "@nestjs/common";
+import { Public } from "../auth/decorators/public.decorator.js";
 
 const DEFAULT_GRPC_PORT = 50051;
 
@@ -14,6 +15,7 @@ function isGrpcPortListening(port: number): Promise<boolean> {
   });
 }
 
+@Public()
 @Controller("health")
 export class HealthController {
   @Get()

--- a/apps/api/src/jwks/jwks.controller.ts
+++ b/apps/api/src/jwks/jwks.controller.ts
@@ -1,7 +1,9 @@
 import { createPublicKey } from "node:crypto";
 import { Controller, Get, Inject } from "@nestjs/common";
+import { Public } from "../auth/decorators/public.decorator.js";
 import { JWT_CONFIG, type JwtConfig } from "../config/jwt.config.js";
 
+@Public()
 @Controller(".well-known")
 export class JwksController {
   constructor(@Inject(JWT_CONFIG) private readonly jwtConfig: JwtConfig) {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,6 +6,7 @@ import { AUTH_PROTO_PACKAGE, AUTH_PROTO_PATH } from "@chifoumi/proto";
 import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { type MicroserviceOptions, Transport } from "@nestjs/microservices";
+import helmet from "helmet";
 import { Logger } from "nestjs-pino";
 import { AppModule } from "./app.module.js";
 import { resolveCorsOrigins } from "./cors.js";
@@ -38,6 +39,7 @@ async function bootstrap() {
       transform: true,
     }),
   );
+  app.use(helmet());
   app.enableCors({
     origin: resolveCorsOrigins(),
   });

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Header, Inject } from "@nestjs/common";
 import { SkipThrottle } from "@nestjs/throttler";
+import { Public } from "../auth/decorators/public.decorator.js";
 import { HttpMetricsMiddleware } from "./http-metrics.middleware.js";
 
+@Public()
 @SkipThrottle({ auth: true, audit: true })
 @Controller("metrics")
 export class MetricsController {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
+      helmet:
+        specifier: ^8.1.0
+        version: 8.2.0
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
@@ -2905,6 +2908,10 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.2.0:
+    resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
+    engines: {node: '>=18.0.0'}
 
   hono@4.12.19:
     resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
@@ -6930,6 +6937,8 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.2.0: {}
 
   hono@4.12.19: {}
 


### PR DESCRIPTION
## Résumé

Corrige les items critiques du ticket #161 (P1 — sécurité).

### Ce qui est fait

| Item | Fix |
|---|---|
| **Helmet absent** | `app.use(helmet())` ajouté au bootstrap (`main.ts`) — headers CSP, HSTS, X-Frame-Options, X-Content-Type-Options activés |
| **Pas de guard JWT global** | `JwtAuthGuard` enregistré comme second `APP_GUARD` dans `AppModule` — secure-by-default : toute route nécessite un JWT valide sauf `@Public()` |
| **`@Public()` manquant** | Ajouté sur `HealthController`, `JwksController`, `MetricsController` (routes infra qui doivent rester ouvertes) |
| **Pino `redact` incomplet** | `req.body.newPassword` et `req.body.token` ajoutés — le token de reset-password ne fuite plus dans les logs |
| **`helmet` absent de package.json** | Dépendance ajoutée (`^8.1.0`) et installée |

### Items non traités (suivi dans #161)

- **Throttler Redis partagé** : requiert `@nestjs-throttler-storage-redis` (nouveau package à valider par le référent technique) — la limite effective reste 5×nb_replicas en mémoire distribuée
- **Sweep WS révoqués** : la borne réelle est max 30 s (cache `AuthTokenCacheService` TTL) — implémentation d'un sweep périodique laissée en follow-up game-service

## Checklist DoD

- [x] Typecheck vert
- [x] Biome vert (hook pre-commit)
- [x] Helmet activé (CLAUDE.md §5 / spec §7)
- [x] Secure-by-default : oubli de `@UseGuards` ne laisse plus de route ouverte
- [x] Aucun secret loggué sur le flux reset-password
- [x] Closes #161