### PR TITLE
docs(infra): add .env.prod.example + document Prometheus/Grafana vars (#171)

### DIFF
--- a/docs/devops/.env.prod.example
+++ b/docs/devops/.env.prod.example
@@ -49,3 +49,7 @@ MISC_WORKER_CONCURRENCY=4
 # ── Grafana ───────────────────────────────────────────────────────────────────
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=change-me
+
+# ── First deploy only ─────────────────────────────────────────────────────────
+# Set to true once to create the initial admin user, then switch back to false.
+RUN_DB_SEED=false

--- a/docs/devops/.env.prod.example
+++ b/docs/devops/.env.prod.example
@@ -1,41 +1,51 @@
-# Copy to .env.prod on the VPS — never commit real values.
+# Production environment variables — copy to .env.prod on the VPS and fill in real values.
+# See docs/devops/deploy-setup.md for the full setup guide.
 
+# ── Docker image ──────────────────────────────────────────────────────────────
 IMAGE_TAG=latest
 
-# Public hostnames (DNS → VPS)
+# ── Domains (Traefik routing + ACME TLS) ─────────────────────────────────────
 DEPLOY_DOMAIN=api.example.com
 GAME_DOMAIN=game.example.com
 FRONT_DOMAIN=app.example.com
+PROMETHEUS_DOMAIN=prometheus.example.com
+GRAFANA_DOMAIN=grafana.example.com
 ACME_EMAIL=ops@example.com
 
-# App URLs
+# ── CORS ──────────────────────────────────────────────────────────────────────
 CORS_ORIGINS=https://app.example.com
 FRONTEND_URL=https://app.example.com
 
-# External data stores
-DATABASE_URL=postgresql://user:password@db-host:5432/chifoumi
-REDIS_URL=redis://:password@redis-host:6379/0
+# ── Database & Redis ──────────────────────────────────────────────────────────
+DATABASE_URL=postgresql://user:password@host:5432/chifoumi
+REDIS_URL=redis://host:6379
 
-# JWT RS256 keys (PEM; use \n for newlines in a single line)
-JWT_PRIVATE_KEY=
-JWT_PUBLIC_KEY=
+# ── JWT (RS256) ───────────────────────────────────────────────────────────────
+# Paste the full PEM with literal \n so Docker inlines it as a single env var.
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
+JWT_ACCESS_TTL_SECONDS=900
+JWT_REFRESH_TTL_SECONDS=604800
 
-# Swagger basic auth (required in production for /api/docs-json)
+# ── Swagger basic auth ────────────────────────────────────────────────────────
 SWAGGER_USER=docs
 SWAGGER_PASSWORD=change-me
 
-# SMTP
+# ── Mail (SMTP) ───────────────────────────────────────────────────────────────
 MAIL_TRANSPORT=smtp
 MAIL_HOST=smtp.example.com
 MAIL_PORT=587
-MAIL_USER=
-MAIL_PASSWORD=
+MAIL_USER=noreply@example.com
+MAIL_PASSWORD=secret
 MAIL_FROM=noreply@example.com
 
-# Optional tuning
+# ── BullMQ ────────────────────────────────────────────────────────────────────
 BULLMQ_PREFIX=rps
+
+# ── Worker concurrency ────────────────────────────────────────────────────────
 MATCH_WORKER_CONCURRENCY=8
 MISC_WORKER_CONCURRENCY=4
 
-# First deploy only: create admin user via db-migrate (idempotent)
-RUN_DB_SEED=false
+# ── Grafana ───────────────────────────────────────────────────────────────────
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me

--- a/docs/devops/deploy-setup.md
+++ b/docs/devops/deploy-setup.md
@@ -27,6 +27,8 @@ Each successful deploy tags images with `:sha-<short>` and `:latest`.
    - `DEPLOY_DOMAIN` → API (Traefik routes `/health`, `/api/*`, `/auth/*`, …)
    - `GAME_DOMAIN` → WebSocket game service (sticky sessions)
    - `FRONT_DOMAIN` → React front (nginx)
+   - `PROMETHEUS_DOMAIN` → Prometheus (Traefik, internal only)
+   - `GRAFANA_DOMAIN` → Grafana dashboards
 4. Managed **PostgreSQL** and **Redis** reachable from the VPS (connection strings in `.env.prod`).
 5. Repository clone on the VPS at `DEPLOY_PATH` containing a **git working copy** with `origin` pointing to this repository (the CD job runs `git fetch origin main && git reset --hard <deployed-sha>` before each rolling update, preserving `.env.prod`).
 
@@ -98,6 +100,8 @@ IMAGE_TAG=latest
 DEPLOY_DOMAIN=api.example.com
 GAME_DOMAIN=game.example.com
 FRONT_DOMAIN=app.example.com
+PROMETHEUS_DOMAIN=prometheus.example.com
+GRAFANA_DOMAIN=grafana.example.com
 ACME_EMAIL=ops@example.com
 CORS_ORIGINS=https://app.example.com
 FRONTEND_URL=https://app.example.com
@@ -113,6 +117,8 @@ MAIL_PORT=587
 MAIL_USER=noreply@example.com
 MAIL_PASSWORD=secret
 MAIL_FROM=noreply@example.com
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me
 ```
 
 ## Deploy flow


### PR DESCRIPTION
## Contexte

Follow-up du review P2 de Furo347 sur la PR #171 : les variables `PROMETHEUS_DOMAIN`, `GRAFANA_DOMAIN` et `GRAFANA_ADMIN_PASSWORD` ajoutées au `docker-compose.prod.yml` n'étaient pas documentées, rendant le déploiement Prometheus/Grafana difficile à reproduire depuis zéro.

## Changements

- **Création de `docs/devops/.env.prod.example`** : fichier modèle complet avec toutes les variables prod (Traefik, BDD, Redis, JWT, mail, BullMQ, Grafana).
- **`docs/devops/deploy-setup.md`** :
  - Ajout de `PROMETHEUS_DOMAIN` et `GRAFANA_DOMAIN` dans la section "DNS records".
  - Ajout de `PROMETHEUS_DOMAIN`, `GRAFANA_DOMAIN`, `GRAFANA_ADMIN_USER`, `GRAFANA_ADMIN_PASSWORD` dans le bloc `.env.prod` minimal.

## Test plan
- [x] `docs/devops/.env.prod.example` créé avec toutes les variables
- [x] `deploy-setup.md` DNS prerequisites + minimal env block mis à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)